### PR TITLE
Import header only libraries properly

### DIFF
--- a/cesium-omniverse/cmake/Macros.cmake
+++ b/cesium-omniverse/cmake/Macros.cmake
@@ -268,7 +268,7 @@ $<$<CONFIG:MinSizeRel>:${CMAKE_MINSIZEREL_POSTFIX}>")
 
     if(NOT DEFINED _LIBRARIES)
         # Header only
-        add_library(${_PROJECT_NAME} INTERFACE)
+        add_library(${_PROJECT_NAME} INTERFACE IMPORTED GLOBAL)
         target_include_directories(${_PROJECT_NAME} INTERFACE "${PROJECT_INCLUDE_DIR}")
     else()
         foreach(lib IN LISTS _LIBRARIES)


### PR DESCRIPTION
Ensures that header only libraries are included as `-isystem` instead of `-I` so that warnings don't propagate to our code.

I noticed this mistake in a different project and wanted to bring the change into here. This doesn't actually affect `cesium-omniverse` since we don't have any header only libraries in the `extern` directory yet.