### PR TITLE
Re-enable Compiler Warnings

### DIFF
--- a/cesium-omniverse/src/RenderResourcesPreparer.cpp
+++ b/cesium-omniverse/src/RenderResourcesPreparer.cpp
@@ -9,11 +9,6 @@
 
 #include <atomic>
 
-// TODO: Determine if this is actually needed for anything.
-// namespace pxr {
-// TF_DEFINE_PRIVATE_TOKENS(_tileTokens, (visibility)(invisible)(visible));
-// }
-
 namespace Cesium {
 static std::atomic<std::uint64_t> tileID;
 


### PR DESCRIPTION
Solves #24.

- [x] Reenable compiler warnings on Linux.
- [ ] Reenable compiler warnings on Windows.