### PR TITLE
Setting normal generation to use CPU on update frame

### DIFF
--- a/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -5,6 +5,7 @@ from pxr import Gf, Sdf
 import omni.usd
 from omni.kit.viewport.utility import get_active_viewport_camera_path, get_active_viewport
 import omni.kit.app as omni_app
+import carb.settings as omni_settings
 
 
 class CesiumOmniverseWindow(ui.Window):
@@ -60,6 +61,7 @@ class CesiumOmniverseWindow(ui.Window):
 
         def create_update_frame():
             app = omni_app.get_app()
+            omni_settings.get_settings().set("/rtx/hydra/TBNFrameMode", 1)
             self._subscription_handle = app.get_update_event_stream().create_subscription_to_pop(
                 on_update_frame, name="cesium_update_frame"
             )


### PR DESCRIPTION
Solves #20. Mostly. There is still some minor artifacting but it is significantly reduced and I suspect with textures it will not be noticeable.

Flips the `/rtx/hydra/TBNFrameMode` setting to use the CPU. This setting is referred to in the CODE interface as "Tangent and Normal Map Generation" in the "Geometry" tab of the "Renderer" settings.

See the issue for more details about my process for figuring out which setting to flip.