### PR TITLE
Fix InMemoryAssetResolver

### DIFF
--- a/cesium-omniverse/src/plugins/InMemoryAssetResolver/CMakeLists.txt
+++ b/cesium-omniverse/src/plugins/InMemoryAssetResolver/CMakeLists.txt
@@ -2,6 +2,15 @@ include(Macros)
 
 glob_files(SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 
+set(IN_MEMORY_ASSET_RESOLVER_CXX_FLAGS ${CESIUM_OMNI_CXX_FLAGS})
+
+if(MSVC)
+    # Disable whole program optimization and unreferenced function removal
+    # Without these flags InMemoryAssetResolver won't work in Release mode
+    # Related issue: https://github.com/PixarAnimationStudios/USD/issues/1095
+    set(IN_MEMORY_ASSET_RESOLVER_CXX_FLAGS ${IN_MEMORY_ASSET_RESOLVER_CXX_FLAGS} /GL- /Zc:inline-)
+endif()
+
 set(IN_MEMORY_ASSET_RESOLVER_CXX_DEFINES ${CESIUM_OMNI_CXX_DEFINES} AR_EXPORTS)
 
 # cmake-format: off
@@ -22,7 +31,7 @@ setup_lib(
         tbb
         tf
     CXX_FLAGS
-        ${CESIUM_OMNI_CXX_FLAGS}
+        ${IN_MEMORY_ASSET_RESOLVER_CXX_FLAGS}
     CXX_FLAGS_DEBUG
         ${CESIUM_OMNI_CXX_FLAGS_DEBUG}
     CXX_DEFINES


### PR DESCRIPTION
MSVC whole program optimization seems to interfere with USD plugins. CMake sets `/GL` for the Release configuration so we need to explicitly disable that with `/GL-`. This fixes `InMemoryAssetResolver` and now textures are loading again!

https://github.com/PixarAnimationStudios/USD/issues/1095 is a related issue. Even though MSVC doesn't set `/Zc:inline` by default it's good to be safe and explicitly disable that as well with `/Zc:inline-`.

Note that you still need to set the path to `mem.cesium` and set the `PXR_PLUGINPATH_NAME` environment variable as described in [`main-old`](https://github.com/CesiumGS/cesium-omniverse/tree/main-old). Hopefully both these steps can be avoided in future PRs.