### PR TITLE
Convert meters to centimeters

### DIFF
--- a/cesium-omniverse/src/core/src/Georeference.cpp
+++ b/cesium-omniverse/src/core/src/Georeference.cpp
@@ -2,6 +2,7 @@
 
 #include <CesiumGeometry/AxisTransforms.h>
 #include <CesiumGeospatial/Transforms.h>
+#include <glm/gtc/matrix_transform.hpp>
 
 namespace Cesium {
 Georeference& Georeference::instance() {
@@ -10,8 +11,9 @@ Georeference& Georeference::instance() {
 }
 
 void Georeference::setOrigin(const glm::dvec3& origin) {
-    relToAbsWorld =
-        CesiumGeospatial::Transforms::eastNorthUpToFixedFrame(origin) * CesiumGeometry::AxisTransforms::Y_UP_TO_Z_UP;
+    const auto centimeterToMeter = glm::scale(glm::dmat4(1.0), glm::dvec3(0.01));
+    relToAbsWorld = CesiumGeospatial::Transforms::eastNorthUpToFixedFrame(origin) *
+                    CesiumGeometry::AxisTransforms::Y_UP_TO_Z_UP * centimeterToMeter;
     absToRelWorld = glm::inverse(relToAbsWorld);
     originChangeEvent.invoke(relToAbsWorld, absToRelWorld);
 }

--- a/cesium-omniverse/src/core/src/OmniTileset.cpp
+++ b/cesium-omniverse/src/core/src/OmniTileset.cpp
@@ -67,6 +67,9 @@ void OmniTileset::updateFrame(
         glm::dvec3 cameraPosition{
             relToAbs * glm::dvec4(omniCameraPosition[0], omniCameraPosition[1], omniCameraPosition[2], 1.0)};
 
+        cameraUp = glm::normalize(cameraUp);
+        cameraFwd = glm::normalize(cameraFwd);
+
         double aspect = width / height;
         double verticalFov = 2.0 * glm::atan(1.0 / projMatrix[1][1]);
         double horizontalFov = 2.0 * glm::atan(glm::tan(verticalFov * 0.5) * aspect);


### PR DESCRIPTION
Part of https://github.com/CesiumGS/cesium-omniverse/issues/19

Convert tiles from meters to centimeters to match USD's default units.

As noted in https://github.com/CesiumGS/cesium-omniverse/issues/19, not all USD stages will be Y-up or centimeters so this is just a temporary fix for the default case.