### PR TITLE
Fixed the segfault when create tileset is called twice

### DIFF
--- a/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -7,9 +7,12 @@ from omni.kit.viewport.utility import get_active_viewport_camera_path, get_activ
 import omni.kit.app as omni_app
 import omni.kit.commands as omni_commands
 import carb.settings as omni_settings
+from carb.events._events import ISubscription
 
 
 class CesiumOmniverseWindow(ui.Window):
+    _subscription_handle: ISubscription = None
+
     def __init__(self, title: str, **kwargs):
         super().__init__(title, **kwargs)
 
@@ -89,6 +92,9 @@ class CesiumOmniverseWindow(ui.Window):
             self._subscription_handle = None
 
         def create_tileset():
+            if self._subscription_handle is not None:
+                self._subscription_handle = None
+
             stage = omni.usd.get_context().get_stage()
             self._tilesets.append(
                 CesiumOmniverse.addTilesetIon(

--- a/cesium-omniverse/src/core/src/RenderResourcesPreparer.cpp
+++ b/cesium-omniverse/src/core/src/RenderResourcesPreparer.cpp
@@ -20,7 +20,14 @@ static std::atomic<std::uint64_t> tileID;
 RenderResourcesPreparer::RenderResourcesPreparer(const pxr::UsdStageRefPtr& stage_, const pxr::SdfPath& tilesetPath_)
     : stage{stage_}
     , tilesetPath{tilesetPath_} {
-    auto xform = pxr::UsdGeomXform::Define(stage, tilesetPath_);
+    auto xform = pxr::UsdGeomXform::Get(stage, tilesetPath_);
+    if (xform) {
+        auto prim = xform.GetPrim();
+        stage->RemovePrim(prim.GetPath());
+    }
+
+    xform = pxr::UsdGeomXform::Define(stage, tilesetPath_);
+
     const glm::dmat4& z_to_y = CesiumGeometry::AxisTransforms::Z_UP_TO_Y_UP;
     pxr::GfMatrix4d currentTransform{
         z_to_y[0][0],


### PR DESCRIPTION
If the user clicks the "Create Tileset" button twice, a segmentation fault occurs. This is due to us trying to create another Xform prim with the same SdfPath. This PR fixes that by removing the existing prim from the stage before adding a new one.

Note: There may be a better way to do this where we reuse the existing Xform and just clear it, but for now this is a sufficient solution and does what is on the label for the button.