### PR TITLE
Fix blue flashing when tilesets load

### DIFF
--- a/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/cesium-kit-exts/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -81,6 +81,7 @@ class CesiumOmniverseWindow(ui.Window):
         def create_update_frame():
             app = omni_app.get_app()
             omni_settings.get_settings().set("/rtx/hydra/TBNFrameMode", 1)
+            omni_settings.get_settings().set("/rtx/materialDb/syncLoads", True)
             self._subscription_handle = app.get_update_event_stream().create_subscription_to_pop(
                 on_update_frame, name="cesium_update_frame"
             )

--- a/cesium-omniverse/ThirdParty.json
+++ b/cesium-omniverse/ThirdParty.json
@@ -28,7 +28,7 @@
         "license": [
             "OpenSSL"
         ],
-        "version": "1.1.1q",
+        "version": "1.1.1s",
         "url": "https://github.com/openssl/openssl"
     },
     {


### PR DESCRIPTION
Resolves #16 

Thanks to help from the Nvidia folks, we finally have a solution for stopping the blue flash. By setting the `/rtx/materialDb/syncLoads` setting to `True` we can disable the flash by preventing Omniverse from rendering the material until everything is fully loaded.


https://user-images.githubusercontent.com/284269/202293370-1b519498-e26c-46ff-8cba-d543d28fa0ff.mp4

