### PR TITLE
Fix Linux

### DIFF
--- a/cesium-omniverse/CMakeLists.txt
+++ b/cesium-omniverse/CMakeLists.txt
@@ -39,14 +39,16 @@ find_package(
 set(USE_NVIDIA_RELEASE_LIBRARIES TRUE)
 
 if(MSVC)
-    if (${USE_NVIDIA_RELEASE_LIBRARIES})
+    if(${USE_NVIDIA_RELEASE_LIBRARIES})
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
         set(MSVC_RUNTIME_FLAG_DEBUG "/MD")
         set(MSVC_RUNTIME_FLAG_RELEASE "/MD")
 
         # Disable run-time error checks. Otherwise boost will error with the message "Using the /RTC option without specifying a debug runtime will lead to linker errors"
-        STRING (REGEX REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-        STRING (REGEX REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        # cmake-format: off
+        STRING(REGEX REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+        STRING(REGEX REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        # cmake-format: on
     else()
         set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
         set(MSVC_RUNTIME_FLAG_DEBUG "/MDd")
@@ -271,17 +273,31 @@ if(CESIUM_OMNI_ENABLE_COVERAGE)
         set(CESIUM_OMNI_LINKER_FLAGS_DEBUG ${CESIUM_OMNI_LINKER_FLAGS_DEBUG} --coverage)
     endif()
 
+    # COVERAGE_SOURCE_DIRECTORIES must be passed exactly like this
+    # If you:
+    # - Don't escape the semicolon list delimiters
+    # - Don't use the VERBATIM option with add_custom_target
+    # Then CMake will swap your semicolons with whitespaces, ruining
+    # the list when it's forwarded to the generate-coverage script and
+    # causing only the first directory in your list to actually be used
+    # for filters.
+
+    # cmake-format: off
+    list(JOIN COVERAGE_SOURCE_DIRECTORIES "\;" COVERAGE_SOURCE_DIRECTORIES_FORMATTED)
+    # cmake-format: on
+
     # We always define the `generate-coverage` target, even if it would fail at runtime
     # due to missing tools / incompatible compilers.
     add_custom_target(
         generate-coverage
         COMMAND
             ${CMAKE_COMMAND} -DCMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}
-            -DCMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION} -DPROJECT_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
-            -DPROJECT_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}"
-            -DPROJECT_SOURCE_DIRECTORIES=${COVERAGE_SOURCE_DIRECTORIES}
-            -DOUTPUT_DIRECTORY="${PROJECT_BINARY_DIR}/coverage/" -P "${PROJECT_SOURCE_DIR}/cmake/GenerateCoverage.cmake"
-        DEPENDS $<TARGET_FILE:tests>)
+            -DCMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION} -DPROJECT_ROOT_DIRECTORY=${PROJECT_SOURCE_DIR}
+            -DPROJECT_BUILD_DIRECTORY=${PROJECT_BINARY_DIR}
+            -DPROJECT_SOURCE_DIRECTORIES=${COVERAGE_SOURCE_DIRECTORIES_FORMATTED}
+            -DOUTPUT_DIRECTORY=${PROJECT_BINARY_DIR}/coverage -P ${PROJECT_SOURCE_DIR}/cmake/GenerateCoverage.cmake
+        DEPENDS $<TARGET_FILE:tests>
+        VERBATIM)
 endif()
 
 # System preprocessor definitions
@@ -322,7 +338,7 @@ set(CESIUM_OMNI_CXX_DEFINES
 set(CESIUM_OMNI_CXX_DEFINES ${CESIUM_OMNI_CXX_DEFINES} BOOST_ALL_DYN_LINK)
 
 # TBB is a dependency of USD
-if (NOT ${USE_NVIDIA_RELEASE_LIBRARIES})
+if(NOT ${USE_NVIDIA_RELEASE_LIBRARIES})
     set(CESIUM_OMNI_CXX_DEFINES_DEBUG ${CESIUM_OMNI_CXX_DEFINES_DEBUG} TBB_USE_DEBUG)
 endif()
 

--- a/cesium-omniverse/cmake/GenerateCoverage.cmake
+++ b/cesium-omniverse/cmake/GenerateCoverage.cmake
@@ -85,12 +85,7 @@ else()
     message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}, cannot generate coverage.")
 endif()
 
-# Normalize paths so they don't end with a trailing slash.
-file(TO_CMAKE_PATH "${PROJECT_BUILD_DIRECTORY}" PROJECT_BUILD_DIRECTORY_NORMALIZED)
-file(TO_CMAKE_PATH "${PROJECT_ROOT_DIRECTORY}" PROJECT_ROOT_DIRECTORY_NORMALIZED)
-file(TO_CMAKE_PATH "${OUTPUT_DIRECTORY}" OUTPUT_DIRECTORY_NORMALIZED)
-
-file(GLOB_RECURSE GCDA_FILES "${PROJECT_BUILD_DIRECTORY_NORMALIZED}/*.gcda")
+file(GLOB_RECURSE GCDA_FILES "${PROJECT_BUILD_DIRECTORY}/*.gcda")
 list(LENGTH GCDA_FILES GCDA_FILES_LENGTH)
 
 if(GCDA_FILES_LENGTH GREATER 0)
@@ -101,12 +96,12 @@ if(GCDA_FILES_LENGTH GREATER 0)
     endforeach()
 endif()
 
-execute_process(COMMAND ctest WORKING_DIRECTORY "${PROJECT_BUILD_DIRECTORY_NORMALIZED}")
+execute_process(COMMAND ctest WORKING_DIRECTORY "${PROJECT_BUILD_DIRECTORY}")
 
-message("Removing and recreating ${PROJECT_BUILD_DIRECTORY_NORMALIZED}/coverage")
+message("Removing and recreating ${PROJECT_BUILD_DIRECTORY}/coverage")
 
-file(REMOVE_RECURSE "${OUTPUT_DIRECTORY_NORMALIZED}")
-file(MAKE_DIRECTORY "${OUTPUT_DIRECTORY_NORMALIZED}")
+file(REMOVE_RECURSE "${OUTPUT_DIRECTORY}")
+file(MAKE_DIRECTORY "${OUTPUT_DIRECTORY}")
 
 set(CMD
     ${GCOVR_EXECUTABLE}
@@ -114,10 +109,12 @@ set(CMD
     --delete # delete GCDA files after processing
     --txt # print text output
     --html-details # generate HTML report with annotated source code
-    ${OUTPUT_DIRECTORY_NORMALIZED}/index.html
-    --filter
-    ${PROJECT_SOURCE_DIRECTORIES})
+    "${OUTPUT_DIRECTORY}/index.html")
+
+foreach(DIR IN LISTS PROJECT_SOURCE_DIRECTORIES)
+    set(CMD ${CMD} "--filter=${DIR}")
+endforeach()
 
 message("Generating HTML coverage with command: ${CMD}")
 
-execute_process(COMMAND ${CMD} WORKING_DIRECTORY "${PROJECT_ROOT_DIRECTORY_NORMALIZED}")
+execute_process(COMMAND ${CMD} WORKING_DIRECTORY "${PROJECT_ROOT_DIRECTORY}")

--- a/cesium-omniverse/cmake/Macros.cmake
+++ b/cesium-omniverse/cmake/Macros.cmake
@@ -40,6 +40,10 @@ function(setup_lib)
     # Note that third party libraries in the public API will need to be installed.
     target_link_libraries(${_TARGET_NAME} PUBLIC ${_LIBRARIES})
 
+    if(CESIUM_OMNI_ENABLE_COVERAGE AND NOT WIN32)
+        target_link_libraries(${_TARGET_NAME} PUBLIC gcov)
+    endif()
+
     if(WIN32 AND ${TYPE} STREQUAL "SHARED")
         add_custom_command(
             TARGET ${_TARGET_NAME}
@@ -74,6 +78,10 @@ function(setup_python_module)
     target_compile_definitions(${_TARGET_NAME} PRIVATE ${_CXX_DEFINES} "$<$<CONFIG:DEBUG>:${_CXX_DEFINES_DEBUG}>")
 
     target_link_libraries(${_TARGET_NAME} PRIVATE ${_LIBRARIES})
+
+    if(CESIUM_OMNI_ENABLE_COVERAGE AND NOT WIN32)
+        target_link_libraries(${_TARGET_NAME} PRIVATE gcov)
+    endif()
 
     # Pybind11 module name needs to match the file name so remove any prefix / suffix
     set_target_properties(${_TARGET_NAME} PROPERTIES DEBUG_POSTFIX "")

--- a/cesium-omniverse/extern/CMakeLists.txt
+++ b/cesium-omniverse/extern/CMakeLists.txt
@@ -7,8 +7,8 @@ add_external_project(
     LIBRARIES
         Cesium3DTilesSelection
         CesiumAsync
-        CesiumGeometry
         CesiumGeospatial
+        CesiumGeometry
         CesiumGltf
         CesiumGltfReader
         CesiumJsonReader

--- a/cesium-omniverse/src/core/CMakeLists.txt
+++ b/cesium-omniverse/src/core/CMakeLists.txt
@@ -34,8 +34,8 @@ setup_lib(
         InMemoryAssetResolver
         Cesium3DTilesSelection
         CesiumAsync
-        CesiumGeometry
         CesiumGeospatial
+        CesiumGeometry
         CesiumGltf
         CesiumGltfReader
         CesiumJsonReader

--- a/cesium-omniverse/tests/CesiumOmniverseTest.cpp
+++ b/cesium-omniverse/tests/CesiumOmniverseTest.cpp
@@ -1,4 +1,3 @@
-
 #include <doctest/doctest.h>
 
 TEST_SUITE("Test") {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/32

Fixes coverage by linking `gcov` directly. Previously we would see linker errors like:

```
[ 90%] Building CXX object tests/CMakeFiles/tests.dir/CesiumOmniverseTest.cpp.o
[ 95%] Linking CXX executable ../bin/tests
/usr/bin/ld: ../bin/tests: hidden symbol `__gcov_init' in /usr/lib/gcc/x86_64-linux-gnu/9/libgcov.a(_gcov.o) is referenced by DSO
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
gmake[3]: *** [tests/CMakeFiles/tests.dir/build.make:158: bin/tests] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:625: tests/CMakeFiles/tests.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:445: CMakeFiles/generate-coverage.dir/rule] Error 2
gmake: *** [Makefile:284: generate-coverage] Error 2
 *  Terminal will be reused by tasks, press any key to close it. 
```

There were also some mistakes in `GenerateCoverage.cmake` that were causing coverage results to be empty. The filter paths weren't being passed to `GenerateCoverage.cmake` correctly and weren't being passed to `gcovr` correctly either.

#

Fixes https://github.com/CesiumGS/cesium-omniverse/issues/33

I tested both `BUILD_SHARED_LIBS=ON` and `BUILD_SHARED_LIBS=OFF`. If you set `BUILD_SHARED_LIBS=OFF` you also have to remove `CesiumOmniverse` from `extension.toml` because the .so won't exist. But otherwise things seem to work.

```toml
# [[native.library]]
# path = "bin/${lib_prefix}CesiumOmniverse${lib_ext}"
```

![image](https://user-images.githubusercontent.com/915398/202914968-764da950-4c08-4a0f-8809-2736df5fc2b6.png)

I'm not sure why I'm not seeing https://github.com/CesiumGS/cesium-omniverse/issues/34. I'm going to keep that open until I have a chance to test on another system.