### PR TITLE
Update README for Code 2022.3.0

### DIFF
--- a/cesium-kit-exts/README.md
+++ b/cesium-kit-exts/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Install Nvidia Omniverse: https://www.nvidia.com/en-us/omniverse/download/
-- Install Omniverse Create 2022.3.0 (or later)
+- Install Omniverse Code 2022.3.0 (or later)
 - Go to the [`cesium-omniverse`](../cesium-omniverse/) directory and build the C++ project
 
     ```sh
@@ -19,7 +19,7 @@
     cmake --install build --component kit
     ```
 
-- Launch Omniverse Create. Add `exts` to the extension search paths so it can find our extensions. Then look for "cesium.omniverse" in the extension manager and enable it. Click the auto-load checkbox to load our extension on startup.
+- Launch Omniverse Code. Add `exts` to the extension search paths so it can find our extensions. Then look for "cesium.omniverse" in the extension manager and enable it. Click the auto-load checkbox to load our extension on startup.
   Extension Search Paths | Enable Extension
   --|--
   ![Extension Search Paths](./images/extension-search-paths.png)|![Enable Extension](./images/enable-extension.png)
@@ -34,11 +34,11 @@
 - Run `link_app`. This will create a folder called `app` that is a symlink to the Omniverse Code installation folder. This allows VS Code Python IntelliSense to find the Omniverse Python libraries and select the same Python interpreter as Omniverse Code.
     ```sh
     # Windows
-    link_app.bat --app create
+    link_app.bat --app code
     ```
     ```sh
     # Linux
-    link_app.sh --app create
+    link_app.sh --app code
     ```
 - Open the VS Code workspace for your OS and install the recommended extensions. Make sure to open the workspace instead of opening the `cesium-kit-exts` folder directly, otherwise IntelliSense my not work properly.
   - [cesium-omniverse-linux.code-workspace](./.vscode/cesium-omniverse-linux.code-workspace)


### PR DESCRIPTION
Now that Code 2022.3.0 is out and uses Kit 104 we can recommend using Code again in the instructions.

Related to https://github.com/CesiumGS/cesium-omniverse/pull/56