### PR TITLE
Pass stage_id instead of stage

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -97,11 +97,11 @@ class CesiumOmniverseWindow(ui.Window):
             # Cape Canaveral
             CesiumOmniverse.setGeoreferenceOrigin(-80.53, 28.46, -30.0)
 
-            stage = omni.usd.get_context().get_stage()
+            stage_id = omni.usd.get_context().get_stage_id()
 
             self._tilesets.append(
                 CesiumOmniverse.addTilesetIon(
-                    stage,
+                    stage_id,
                     1387142,
                     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMjRhYzI0Yi1kNWEwLTQ4ZWYtYjdmZC1hY2JmYWIzYmFiMGUiLCJpZCI6NDQsImlhdCI6MTY2NzQ4OTg0N30.du0tvWptgLWsvM1Gnbv3Zw_pDAOILg1Wr6s2sgK-qlM",
                 )
@@ -113,10 +113,10 @@ class CesiumOmniverseWindow(ui.Window):
             # Cesium HQ
             CesiumOmniverse.setGeoreferenceOrigin(-75.1564977, 39.9501464, 150.0)
 
-            stage = omni.usd.get_context().get_stage()
+            stage_id = omni.usd.get_context().get_stage_id()
 
             tileset_id = CesiumOmniverse.addTilesetIon(
-                stage,
+                stage_id,
                 1,
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMjRhYzI0Yi1kNWEwLTQ4ZWYtYjdmZC1hY2JmYWIzYmFiMGUiLCJpZCI6NDQsImlhdCI6MTY2NzQ4OTg0N30.du0tvWptgLWsvM1Gnbv3Zw_pDAOILg1Wr6s2sgK-qlM",
             )
@@ -136,10 +136,10 @@ class CesiumOmniverseWindow(ui.Window):
             # Cesium HQ
             CesiumOmniverse.setGeoreferenceOrigin(-75.1564977, 39.9501464, 150.0)
 
-            stage = omni.usd.get_context().get_stage()
+            stage_id = omni.usd.get_context().get_stage_id()
 
             tileset_id = CesiumOmniverse.addTilesetIon(
-                stage,
+                stage_id,
                 1,
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMjRhYzI0Yi1kNWEwLTQ4ZWYtYjdmZC1hY2JmYWIzYmFiMGUiLCJpZCI6NDQsImlhdCI6MTY2NzQ4OTg0N30.du0tvWptgLWsvM1Gnbv3Zw_pDAOILg1Wr6s2sgK-qlM",
             )

--- a/include/cesium/omniverse/CesiumOmniverse.h
+++ b/include/cesium/omniverse/CesiumOmniverse.h
@@ -3,7 +3,6 @@
 #include "CesiumOmniverseAbi.h"
 
 #include <pxr/pxr.h>
-#include <pxr/usd/usd/common.h>
 
 #include <cstdint>
 
@@ -30,23 +29,23 @@ finalize() CESIUM_OMNI_NOEXCEPT;
 /**
  * @brief Adds a tileset from url.
  *
- * @param stage The USD stage
+ * @param stage The USD stage id
  * @param url The tileset url
  * @returns The tileset id. Returns -1 on error.
  */
 CESIUM_OMNI_EXPORT_C_FUNCTION(int)
-addTilesetUrl(const pxr::UsdStageRefPtr* stage, const char* url) CESIUM_OMNI_NOEXCEPT;
+addTilesetUrl(long stageId, const char* url) CESIUM_OMNI_NOEXCEPT;
 
 /**
  * @brief Adds a tileset from ion.
  *
- * @param stage The USD stage
+ * @param stage The USD stage id
  * @param ionId The ion asset id
  * @param ionToken The ion access token
  * @returns The tileset id. Returns -1 on error.
  */
 CESIUM_OMNI_EXPORT_C_FUNCTION(int)
-addTilesetIon(const pxr::UsdStageRefPtr* stage, int64_t ionId, const char* ionToken) CESIUM_OMNI_NOEXCEPT;
+addTilesetIon(long stageId, int64_t ionId, const char* ionToken) CESIUM_OMNI_NOEXCEPT;
 
 /**
  * @brief Removes a tileset from the scene.

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -4,7 +4,6 @@
 
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/vec4d.h>
-#include <pxr/usd/usd/stage.h>
 #include <pybind11/pybind11.h>
 
 namespace pybind11 {
@@ -12,7 +11,6 @@ namespace detail {
 
 PYBOOST11_TYPE_CASTER(pxr::GfVec4d, _("Vec4d"));
 PYBOOST11_TYPE_CASTER(pxr::GfMatrix4d, _("Matrix4d"));
-PYBOOST11_TYPE_CASTER(pxr::UsdStageRefPtr, _("StageRefPtr"));
 
 } // end namespace detail
 } // end namespace pybind11
@@ -24,14 +22,9 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
 
     m.def("initialize", &initialize);
     m.def("finalize", &finalize);
-    m.def("addTilesetUrl", [](const pxr::UsdStageRefPtr& stage, const char* url) -> int {
-        return addTilesetUrl(&stage, url);
-    });
-    m.def("addTilesetIon", [](const pxr::UsdStageRefPtr& stage, int64_t ionId, const char* ionToken) -> int {
-        return addTilesetIon(&stage, ionId, ionToken);
-    });
+    m.def("addTilesetUrl", &addTilesetUrl);
+    m.def("addTilesetIon", &addTilesetIon);
     m.def("removeTileset", &removeTileset);
-
     m.def("addIonRasterOverlay", &addIonRasterOverlay);
 
     m.def(

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -2,6 +2,9 @@
 
 #include "cesium/omniverse/OmniTileset.h"
 
+#include <pxr/usd/usd/stageCache.h>
+#include <pxr/usd/usdUtils/stageCache.h>
+
 #include <unordered_map>
 
 namespace Cesium {
@@ -19,15 +22,17 @@ void finalize() noexcept {
     OmniTileset::shutdown();
 }
 
-int addTilesetUrl(const pxr::UsdStageRefPtr* stage, const char* url) noexcept {
+int addTilesetUrl(long stageId, const char* url) noexcept {
     const int tilesetId = currentId++;
-    tilesets.insert({tilesetId, std::make_unique<OmniTileset>(*stage, url)});
+    const auto& stage = pxr::UsdUtilsStageCache::Get().Find(pxr::UsdStageCache::Id::FromLongInt(stageId));
+    tilesets.insert({tilesetId, std::make_unique<OmniTileset>(stage, url)});
     return tilesetId;
 }
 
-int addTilesetIon(const pxr::UsdStageRefPtr* stage, int64_t ionId, const char* ionToken) noexcept {
+int addTilesetIon(long stageId, int64_t ionId, const char* ionToken) noexcept {
     const int tilesetId = currentId++;
-    tilesets.insert({tilesetId, std::make_unique<OmniTileset>(*stage, ionId, ionToken)});
+    const auto& stage = pxr::UsdUtilsStageCache::Get().Find(pxr::UsdStageCache::Id::FromLongInt(stageId));
+    tilesets.insert({tilesetId, std::make_unique<OmniTileset>(stage, ionId, ionToken)});
     return tilesetId;
 }
 


### PR DESCRIPTION
Prerequisite for #75 

This makes the C interface and python bindings simpler. Also, this will allow us to use the same interface for USD and USDRT.

Once in the C++ code USD and USDRT have different ways to get the stage from the stage id. This will be handled in #75 

* USD: `pxr::UsdUtilsStageCache::Get().Find(pxr::UsdStageCache::Id::FromLongInt(stageId));` ([link](https://github.com/NVIDIA-Omniverse/kit-extension-template-cpp/blob/2d11f7d70549ad387734dcea5a9123cb500d7f49/source/extensions/omni.example.cpp.usd/plugins/omni.example.cpp.usd/ExampleUsdExtension.cpp#L185))
* USDRT: `usdrt::UsdStage::Attach(stageId)` ([link](http://omniverse-docs.s3-website-us-east-1.amazonaws.com/usdrt/5.0.0/docs/scenegraph_use.html))