### PR TITLE
Switched from UsdPreviewSurface to OmniPBR to improve performance

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -81,7 +81,6 @@ class CesiumOmniverseWindow(ui.Window):
 
             app = omni_app.get_app()
             omni_settings.get_settings().set("/rtx/hydra/TBNFrameMode", 1)
-            omni_settings.get_settings().set("/rtx/materialDb/syncLoads", True)
             self._subscription_handle = app.get_update_event_stream().create_subscription_to_pop(
                 on_update_frame, name="cesium_update_frame"
             )

--- a/src/core/src/GltfToUSD.cpp
+++ b/src/core/src/GltfToUSD.cpp
@@ -375,7 +375,7 @@ pxr::UsdShadeMaterial convertMaterialToUSD(
                                          const pxr::SdfAssetPath& texturePath, const size_t texcoord) {
         const pxr::UsdShadeShader& stReader = stReaders[texcoord];
         pxr::UsdShadeShader diffuseTextureSampler =
-            pxr::UsdShadeShader::Define(stage, materialPath.AppendChild(pxr::TfToken("DiffuseTexture")));
+            pxr::UsdShadeShader::Define(stage, materialPath.AppendChild(pxr::TfToken("OmniPBR")));
         diffuseTextureSampler.CreateIdAttr(pxr::VtValue(pxr::_tokens->UsdUVTexture));
         diffuseTextureSampler.CreateInput(pxr::_tokens->file, pxr::SdfValueTypeNames->Asset).Set(texturePath);
         diffuseTextureSampler.CreateInput(pxr::_tokens->st, pxr::SdfValueTypeNames->Float2)


### PR DESCRIPTION
We have been using `UsdPreviewSurface` as our shader for the tilesets but this switches to using the `OmniPBR` shader. This is a more performant shader using MDL but it comes at the cost of being Omniverse specific. It's a better stop gap while we create our own MDL shaders.