### PR TITLE
Fix python bindings extension

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -32,6 +32,14 @@
         "url": "https://github.com/openssl/openssl"
     },
     {
+        "name": "pybind11",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "version": "2.10.0",
+        "url": "https://github.com/pybind/pybind11"
+    },
+    {
         "name": "stb",
         "license": [
             "Unlicense",

--- a/cmake/AddConanDependencies.cmake
+++ b/cmake/AddConanDependencies.cmake
@@ -10,6 +10,7 @@ configure_conan(
     REQUIRES
         cpr/1.9.0
         doctest/2.4.9
+        pybind11/2.10.0
         stb/cci.20210910
         zlib/1.2.13
 )

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 
 # cmake-format: off
 setup_python_module(
+    PYTHON_DIR
+        # Use the same Python version as Omniverse (Python 3.7)
+        "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/python"
     TARGET_NAME
         CesiumOmniversePythonBindings
     SOURCES


### PR DESCRIPTION
I accidentally introduced a bug in https://github.com/CesiumGS/cesium-omniverse/pull/79. For some reason I thought `${PYTHON_MODULE_PREFIX}` and `${PYTHON_MODULE_EXTENSION}` were defined by CMake's FindPython but they're actually defined by pybind11. So on a fresh build the python bindings file would be missing its extension `.cp37-win_amd64.pyd`.

I added pybind11 back to the list of conan dependencies but we only use it for its cmake helper functions / targets. The actual version that's included / linked in our code is the pybind11 from packman.