### PR TITLE
Run VS Code build in developer command prompt

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,9 +32,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat configure ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py configure ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py configure ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Build (advanced)",
@@ -42,9 +45,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py build ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Build (verbose)",
@@ -52,9 +58,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build ${input:build-type} ${input:compiler} --verbose --no-parallel"
             },
-            "command": "python3 scripts/vscode_build.py build ${input:build-type} ${input:compiler} --verbose --no-parallel"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build ${input:build-type} ${input:compiler} --verbose --no-parallel"
+            }
         },
         {
             "label": "Build (debug)",
@@ -62,9 +71,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build Debug default"
             },
-            "command": "python3 scripts/vscode_build.py build Debug default",
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build Debug default",
+            }
         },
         {
             "label": "Build (release)",
@@ -72,9 +84,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build Release default"
             },
-            "command": "python3 scripts/vscode_build.py build Release default"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build Release default"
+            }
         },
         {
             "label": "Build Only (debug)",
@@ -82,9 +97,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build Debug default --build-only"
             },
-            "command": "python3 scripts/vscode_build.py build Debug default --build-only",
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build Debug default --build-only"
+            }
         },
         {
             "label": "Build Only (release)",
@@ -92,9 +110,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat build Release default --build-only"
             },
-            "command": "python3 scripts/vscode_build.py build Release default --build-only"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py build Release default --build-only"
+            }
         },
         {
             "label": "Clean",
@@ -102,9 +123,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat clean ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py clean ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py clean ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Test",
@@ -112,9 +136,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat test ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py test ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py test ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Coverage",
@@ -122,9 +149,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat coverage Debug ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py coverage Debug ${input:compiler}",
+            "linux": {
+                "command": "python3 scripts/vscode_build.py coverage Debug ${input:compiler}",
+            }
         },
         {
             "label": "Documentation",
@@ -132,19 +162,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat documentation ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py documentation ${input:build-type} ${input:compiler}"
-        },
-        {
-            "label": "Install",
-            "type": "shell",
-            "group": "build",
-            "problemMatcher": "$gcc",
-            "windows": {
-                "problemMatcher": "$msCompile"
-            },
-            "command": "python3 scripts/vscode_build.py install ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py documentation ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Format",
@@ -152,9 +175,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat format ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py format ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py format ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Lint",
@@ -162,9 +188,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat lint ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py lint ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py lint ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Lint Fix",
@@ -172,9 +201,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat lint-fix ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py lint-fix ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py lint-fix ${input:build-type} ${input:compiler}"
+            }
         },
         {
             "label": "Dependency Graph",
@@ -182,9 +214,12 @@
             "group": "build",
             "problemMatcher": "$gcc",
             "windows": {
-                "problemMatcher": "$msCompile"
+                "problemMatcher": "$msCompile",
+                "command": "scripts/vscode_build_launcher.bat dependency-graph ${input:build-type} ${input:compiler}"
             },
-            "command": "python3 scripts/vscode_build.py dependency-graph ${input:build-type} ${input:compiler}"
+            "linux": {
+                "command": "python3 scripts/vscode_build.py dependency-graph ${input:build-type} ${input:compiler}"
+            }
         }
     ]
 }

--- a/docs/building/building.md
+++ b/docs/building/building.md
@@ -130,7 +130,7 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
 
 - Install [Chocolatey](https://docs.chocolatey.org/en-us/choco/setup) and then install dependencies
   ```sh
-  choco install -y visualstudio2022professional visualstudio2022-workload-nativedesktop python cmake ninja git conan doxygen.install --installargs 'ADD_CMAKE_TO_PATH=System'
+  choco install -y visualstudio2022professional visualstudio2022-workload-nativedesktop python cmake ninja git conan doxygen.install vswhere --installargs 'ADD_CMAKE_TO_PATH=System'
   ```
   ```sh
   choco install -y llvm --version=14.0.6
@@ -544,7 +544,6 @@ Each workspace contains recommended extensions and settings for VSCode developme
 - Test - runs unit tests
 - Coverage - generates a coverage report and opens a web browser showing the results
 - Documentation - generates documentation and opens a web browser showing the results
-- Install - installs the project to the default system location
 - Format - formats the code with clang-format
 - Lint - runs clang-tidy
 - Lint Fix - runs clang-tidy and fixes issues

--- a/scripts/vscode_build_launcher.bat
+++ b/scripts/vscode_build_launcher.bat
@@ -1,0 +1,38 @@
+:: Initialize the MSVC C++ development environment before running the python script
+:: This ensures that environment variables are populated and CMake can find cl.exe when using the Ninja generator
+@echo off
+
+:: Check if vswhere is in the path already (e.g. if installed with chocolatey)
+where /q vswhere
+
+if %ERRORLEVEL% equ 0 (
+    :: Found vswhere, now get the full path
+    for /f "delims=" %%i in ('where vswhere') do set vswhere_path="%%i"
+) else (
+    :: Otherwise look for vswhere in the Visual Studio Installer directory
+    set vswhere_path="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+)
+
+if not exist %vswhere_path% (
+    echo Could not find vswhere.exe
+    exit /b 1
+)
+
+echo vswhere.exe path: %vswhere_path%
+
+:: Find vsdevcmd.bat in the latest Visual Studio installation
+:: See https://github.com/microsoft/vswhere/wiki/Find-VC
+for /f "usebackq tokens=*" %%i in (`%vswhere_path% -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set vsdevcmd_path="%%i\Common7\Tools\vsdevcmd.bat"
+
+if not exist %vsdevcmd_path% (
+    echo "Could not find vsdevcmd.bat"
+    exit /b 1
+)
+
+echo vsdevcmd.bat path: %vsdevcmd_path%
+
+:: Call vsdevcmd.bat. This will start the developer command prompt and populate MSVC environment variables.
+call %vsdevcmd_path% -arch=x64 -host_arch=x64
+
+:: Now run our python script
+python3 %~dp0\vscode_build.py %*


### PR DESCRIPTION
Follow up to https://github.com/CesiumGS/cesium-omniverse/pull/90

In order to use Ninja you need to be in `x64 Native Tools Command Prompt for VS 2022`. This is fine if you're doing everything on the command line, but if you're building the project through VS Code which `Ctrl + Shift + B` or `launch.json` then Ninja won't be able to find `cl.exe`.

This PR fixes this by calling `vscode_build_launcher.bat` in `tasks.json` which will locate the Visual Studio installation with [vswhere](https://github.com/microsoft/vswhere), call `vsdevcmd.bat` to populate the needed environment variables, and then run `vscode_build.py`.

This was my first time writing a non-trivial batch script, and I am not a fan 😓 