### PR TITLE
Temporary fix for Kit 104.1 texture issues.

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/window.py
@@ -84,6 +84,9 @@ class CesiumOmniverseWindow(ui.Window):
 
             app = omni_app.get_app()
             omni_settings.get_settings().set("/rtx/hydra/TBNFrameMode", 1)
+            # Disabling Texture Streaming is a workaround for issues with Kit 104.1. We should remove this as soon as
+            #   the issue is fixed.
+            omni_settings.get_settings().set("/rtx-transient/resourcemanager/enableTextureStreaming", False)
             self._subscription_handle = app.get_update_event_stream().create_subscription_to_pop(
                 on_update_frame, name="cesium_update_frame"
             )


### PR DESCRIPTION
Nvidia folks suggested we disable texture streaming for the time being. This is not a permanent fix, so I am not closing the issue, but it at least allows us to continue using Kit 104.1.