### PR TITLE
Fixed docking Cesium window on launch

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/utils.py
+++ b/exts/cesium.omniverse/cesium/omniverse/utils.py
@@ -1,0 +1,6 @@
+import omni.kit
+
+
+async def wait_n_frames(n: int):
+    for i in range(0, n):
+        await omni.kit.app.get_app().next_update_async()


### PR DESCRIPTION
Resolves #99 

This fixes docking the Cesium window on initial launch.

I've also added a file for storing python utility functions, including a utility function to wait `n` frames where `n` is the number of frames to wait.