### PR TITLE
Pull kit-sdk and don't hardcode library versions

### DIFF
--- a/extern/nvidia/deps/kit-sdk.packman.xml
+++ b/extern/nvidia/deps/kit-sdk.packman.xml
@@ -1,0 +1,5 @@
+<project toolsVersion="5.6">
+  <dependency name="kit_sdk" linkPath="../_build/target-deps/kit-sdk/">
+    <package name="kit-sdk" version="104.1+release.387.3b4671f3.tc.${platform}.release"/>
+  </dependency>
+</project>

--- a/extern/nvidia/deps/target-deps.packman.xml
+++ b/extern/nvidia/deps/target-deps.packman.xml
@@ -1,26 +1,20 @@
 <project toolsVersion="5.6">
-  <dependency name="python" linkPath="../_build/target-deps/python">
-    <package name="python" version="3.7.13+nv1-${platform}"/>
-  </dependency>
-  <dependency name="nv_usd_py37_release" linkPath="../_build/target-deps/usd/release">
-    <package name="nv-usd" version="20.08.nv.1.2.2496.ecf7aef9-win64_py37_release-main" platforms="windows-x86_64"/>
-    <package name="nv-usd" version="20.08.nv.1.2.2496.ecf7aef9-linux64_py37-centos_release-main" platforms="linux-x86_64"/>
-  </dependency>
-  <dependency name="nv_usd_py37_debug" linkPath="../_build/target-deps/usd/debug">
-    <package name="nv-usd" version="20.08.nv.1.2.2496.ecf7aef9-win64_py37_debug-main" platforms="windows-x86_64"/>
-    <package name="nv-usd" version="20.08.nv.1.2.2496.ecf7aef9-linux64_py37-centos_debug-main" platforms="linux-x86_64"/>
-  </dependency>
-  <dependency name="usdrt" linkPath="../_build/target-deps/usdrt">
-    <package name="usdrt" version="4.0.6+support_104_deploy.816.93ec0708.tc.${platform}" />
-  </dependency>
-  <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins">
-    <package name="carb_sdk+plugins.${platform}" version="129.1+release129.tc6901.7e9b5eab" />
-  </dependency>
-  <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11">
-    <package name="pybind11" version="2.3.dev1-349dd2e6" />
-  </dependency>
-  <dependency name="cuda" linkPath="../_build/target-deps/cuda/cuda">
-    <package name="cuda" version="11.3.0_465.89-46d75baa-windows-x86_64" platforms="windows-x86_64"/>
-    <package name="cuda" version="11.3.0_465.19.02-8923463f-linux-x86_64" platforms="linux-x86_64"/>
-  </dependency>
+  <!-- Import dependencies from Kit SDK to ensure we're using the same versions. -->
+  <import path="../_build/target-deps/kit-sdk/dev/all-deps.packman.xml">
+    <filter include="python"/>
+    <filter include="nv_usd_py37_release"/>
+    <filter include="nv_usd_py37_debug"/>
+    <filter include="usdrt"/>
+    <filter include="carb_sdk_plugins"/>
+    <filter include="pybind11"/>
+    <filter include="cuda"/>
+  </import>
+  <!-- Override the link paths to point to the correct locations. -->
+  <dependency name="python" linkPath="../_build/target-deps/python"/>
+  <dependency name="nv_usd_py37_release" linkPath="../_build/target-deps/usd/release"/>
+  <dependency name="nv_usd_py37_debug" linkPath="../_build/target-deps/usd/debug"/>
+  <dependency name="usdrt" linkPath="../_build/target-deps/usdrt"/>
+  <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins"/>
+  <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11"/>
+  <dependency name="cuda" linkPath="../_build/target-deps/cuda/cuda"/>
 </project>

--- a/extern/nvidia/tools/repoman/build.py
+++ b/extern/nvidia/tools/repoman/build.py
@@ -10,23 +10,25 @@ def run_command():
 
     # Fetch the asset dependencies
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--platform-target',
-                        dest='platform_target', required=False)
+    parser.add_argument("-p", "--platform-target", dest="platform_target", required=False)
     options, _ = parser.parse_known_args()
 
     # Checking if platform was passed
     # We cannot use argparse's default, as we also need to set up the command line argument
     # if it wasn't supplied. It is possible to also check for the host platform, if we want to
     # make different default behavior when building on windows.
-    if not repoman.api.has_options_arg(options, 'platform_target'):
-        options.platform_target = 'linux-x86_64'
+    if not repoman.api.has_options_arg(options, "platform_target"):
+        options.platform_target = "linux-x86_64"
 
-    deps_target = [repo_folders["target_deps_xml"]]
-    repo_root = repo_folders["root"]
+    deps_folder = repo_folders["deps_xml_folder"]
+    deps_targets = [
+        "kit-sdk.packman.xml",
+        "target-deps.packman.xml",
+    ]
 
     # Dependencies will be fetched from the "deps" folder files
-    for deps_target in deps_target:
-        packmanapi.pull(os.path.join(repo_root, deps_target), platform=options.platform_target)
+    for deps_target in deps_targets:
+        packmanapi.pull(os.path.join(deps_folder, deps_target), platform=options.platform_target)
 
 
 if __name__ == "__main__" or __name__ == "__mp_main__":


### PR DESCRIPTION
Add kit-sdk as a dependency. There are some omniverse specific things we need to do like being able to communicate with the application and using the new `DynamicTextureProvider`.

Now that we're pulling kit-sdk we no longer hardcode specific library versions. Instead we can use the versions that kit-sdk is using like what [kit-extension-template-cpp](https://github.com/NVIDIA-Omniverse/kit-extension-template-cpp/blob/main/deps/kit-sdk-deps.packman.xml) does.