### PR TITLE
Fixed browser not reopening and opening on windows during sign-in

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -49,6 +49,9 @@ class CesiumOmniverseMainWindow(ui.Window):
         for subscription in self._subscriptions:
             subscription.unsubscribe()
 
+        if self._sign_in_widget:
+            self._sign_in_widget.destroy()
+
         super().destroy()
 
     def _setup_subscriptions(self):

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -51,6 +51,7 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def("is_loading_asset_list", &CesiumIonSession::isLoadingAssetList)
         .def("is_token_list_loaded", &CesiumIonSession::isTokenListLoaded)
         .def("is_loading_token_list", &CesiumIonSession::isLoadingTokenList)
+        .def("get_authorize_url", &CesiumIonSession::getAuthorizeUrl)
         .def("get_connection", &CesiumIonSession::getConnection)
         .def("get_profile", &CesiumIonSession::getProfile)
         .def("get_assets", &CesiumIonSession::getAssets)

--- a/src/core/src/CesiumIonSession.cpp
+++ b/src/core/src/CesiumIonSession.cpp
@@ -50,14 +50,8 @@ void CesiumIonSession::connect() {
         "/cesium-for-omniverse/oauth2/callback",
         {"assets:list", "assets:read", "profile:read", "tokens:read", "tokens:write", "geocode"},
         [this](const std::string& url) {
+            // NOTE: We open the browser in the Python code. Check in the sign in widget's on_update_frame function.
             this->_authorizeUrl = url;
-
-            std::string command(browserCommandBase);
-            command.append(" \"");
-            command.append(url);
-            command.append("\"");
-
-            [[maybe_unused]] const auto status = system(command.c_str());
         })
         .thenInMainThread([this](CesiumIonClient::Connection&& connection) {
             this->_isConnecting = false;


### PR DESCRIPTION
Fixes #130.

The biggest change here is I moved the code to open the browser out of the C++ layer and into the Python layer. Omniverse's only reliable method for opening a web browser is through the `webbrowser` package in Python, so we're gonna just go that route rather than try to engineer something ourselves.

Secondarily I fixed some issues where I had missed implementing the authorization URL in the Sign-In Widget. This is now all implemented properly.