### PR TITLE
Fix some nomenclature with default project token storage

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
@@ -180,12 +180,12 @@ class CesiumOmniverseDebugWindow(ui.Window):
             stage_id = omni.usd.get_context().get_stage_id()
             stage = omni.usd.get_context().get_stage()
             cesium_prim = stage.GetPrimAtPath("/Cesium")
-            ion_token = cesium_prim.GetAttribute("ionToken").Get()
+            default_project_token = cesium_prim.GetAttribute("defaultProjectToken").Get()
 
             tileset_id = self._cesium_omniverse_interface.addTilesetIon(
                 stage_id,
                 1,
-                ion_token,
+                default_project_token,
             )
 
             self._tilesets.append(tileset_id)
@@ -194,7 +194,7 @@ class CesiumOmniverseDebugWindow(ui.Window):
                 tileset_id,
                 "Layer",
                 2,
-                ion_token,
+                default_project_token,
             )
 
         def add_bing_maps_terrain_using_stage_token():

--- a/exts/cesium.omniverse/schemas/cesium_schemas.usda
+++ b/exts/cesium.omniverse/schemas/cesium_schemas.usda
@@ -24,8 +24,12 @@ class "CesiumData" (
         string className = "Data"
     }
 ) {
-    string ionToken = "" (
-        doc = "A string representing an API token for Cesium ion."
+    string defaultProjectTokenId = "" (
+        doc = "A string representing the token ID for accessing Cesium ion tilesets."
+    )
+
+    string defaultProjectToken = "" (
+        doc = "A string representing a token for accessing Cesium ion tilesets."
     )
 }
 

--- a/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
+++ b/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
@@ -12,8 +12,11 @@ class "CesiumData" (
     doc = "Stores stage level data for Cesium for Omniverse/USD."
 )
 {
-    string ionToken = "" (
-        doc = "A string representing an API token for Cesium ion."
+    string defaultProjectToken = "" (
+        doc = "A string representing a token for accessing Cesium ion tilesets."
+    )
+    string defaultProjectTokenId = "" (
+        doc = "A string representing the token ID for accessing Cesium ion tilesets."
     )
 }
 

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.cpp
@@ -61,15 +61,32 @@ CesiumData::_GetTfType() const
 }
 
 UsdAttribute
-CesiumData::GetIonTokenAttr() const
+CesiumData::GetDefaultProjectTokenIdAttr() const
 {
-    return GetPrim().GetAttribute(CesiumTokens->ionToken);
+    return GetPrim().GetAttribute(CesiumTokens->defaultProjectTokenId);
 }
 
 UsdAttribute
-CesiumData::CreateIonTokenAttr(VtValue const &defaultValue, bool writeSparsely) const
+CesiumData::CreateDefaultProjectTokenIdAttr(VtValue const &defaultValue, bool writeSparsely) const
 {
-    return UsdSchemaBase::_CreateAttr(CesiumTokens->ionToken,
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->defaultProjectTokenId,
+                       SdfValueTypeNames->String,
+                       /* custom = */ false,
+                       SdfVariabilityVarying,
+                       defaultValue,
+                       writeSparsely);
+}
+
+UsdAttribute
+CesiumData::GetDefaultProjectTokenAttr() const
+{
+    return GetPrim().GetAttribute(CesiumTokens->defaultProjectToken);
+}
+
+UsdAttribute
+CesiumData::CreateDefaultProjectTokenAttr(VtValue const &defaultValue, bool writeSparsely) const
+{
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->defaultProjectToken,
                        SdfValueTypeNames->String,
                        /* custom = */ false,
                        SdfVariabilityVarying,
@@ -94,7 +111,8 @@ const TfTokenVector&
 CesiumData::GetSchemaAttributeNames(bool includeInherited)
 {
     static TfTokenVector localNames = {
-        CesiumTokens->ionToken,
+        CesiumTokens->defaultProjectTokenId,
+        CesiumTokens->defaultProjectToken,
     };
     static TfTokenVector allNames =
         _ConcatenateAttributeNames(

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.h
@@ -96,23 +96,43 @@ private:
 
 public:
     // --------------------------------------------------------------------- //
-    // IONTOKEN 
+    // DEFAULTPROJECTTOKENID 
     // --------------------------------------------------------------------- //
-    /// A string representing an API token for Cesium ion.
+    /// A string representing the token ID for accessing Cesium ion tilesets.
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `string ionToken = ""` |
+    /// | Declaration | `string defaultProjectTokenId = ""` |
     /// | C++ Type | std::string |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
-    UsdAttribute GetIonTokenAttr() const;
+    UsdAttribute GetDefaultProjectTokenIdAttr() const;
 
-    /// See GetIonTokenAttr(), and also 
+    /// See GetDefaultProjectTokenIdAttr(), and also 
     /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
     /// If specified, author \p defaultValue as the attribute's default,
     /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
     /// the default for \p writeSparsely is \c false.
-    UsdAttribute CreateIonTokenAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+    UsdAttribute CreateDefaultProjectTokenIdAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+
+public:
+    // --------------------------------------------------------------------- //
+    // DEFAULTPROJECTTOKEN 
+    // --------------------------------------------------------------------- //
+    /// A string representing a token for accessing Cesium ion tilesets.
+    ///
+    /// | ||
+    /// | -- | -- |
+    /// | Declaration | `string defaultProjectToken = ""` |
+    /// | C++ Type | std::string |
+    /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
+    UsdAttribute GetDefaultProjectTokenAttr() const;
+
+    /// See GetDefaultProjectTokenAttr(), and also 
+    /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
+    /// If specified, author \p defaultValue as the attribute's default,
+    /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
+    /// the default for \p writeSparsely is \c false.
+    UsdAttribute CreateDefaultProjectTokenAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
 
 public:
     // ===================================================================== //

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
@@ -5,11 +5,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 CesiumTokensType::CesiumTokensType() :
     assetId("assetId", TfToken::Immortal),
     assetUrl("assetUrl", TfToken::Immortal),
-    ionToken("ionToken", TfToken::Immortal),
+    defaultProjectToken("defaultProjectToken", TfToken::Immortal),
+    defaultProjectTokenId("defaultProjectTokenId", TfToken::Immortal),
     allTokens({
         assetId,
         assetUrl,
-        ionToken
+        defaultProjectToken,
+        defaultProjectTokenId
     })
 {
 }

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
@@ -47,10 +47,14 @@ struct CesiumTokensType {
     /// 
     /// CesiumTilesetAPI
     const TfToken assetUrl;
-    /// \brief "ionToken"
+    /// \brief "defaultProjectToken"
     /// 
     /// CesiumData
-    const TfToken ionToken;
+    const TfToken defaultProjectToken;
+    /// \brief "defaultProjectTokenId"
+    /// 
+    /// CesiumData
+    const TfToken defaultProjectTokenId;
     /// A vector of all of the tokens listed above.
     const std::vector<TfToken> allTokens;
 };

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapData.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapData.cpp
@@ -27,9 +27,16 @@ WRAP_CUSTOM;
 
         
 static UsdAttribute
-_CreateIonTokenAttr(CesiumData &self,
+_CreateDefaultProjectTokenIdAttr(CesiumData &self,
                                       object defaultVal, bool writeSparsely) {
-    return self.CreateIonTokenAttr(
+    return self.CreateDefaultProjectTokenIdAttr(
+        UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
+}
+        
+static UsdAttribute
+_CreateDefaultProjectTokenAttr(CesiumData &self,
+                                      object defaultVal, bool writeSparsely) {
+    return self.CreateDefaultProjectTokenAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
 }
 
@@ -72,10 +79,17 @@ void wrapCesiumData()
         .def(!self)
 
         
-        .def("GetIonTokenAttr",
-             &This::GetIonTokenAttr)
-        .def("CreateIonTokenAttr",
-             &_CreateIonTokenAttr,
+        .def("GetDefaultProjectTokenIdAttr",
+             &This::GetDefaultProjectTokenIdAttr)
+        .def("CreateDefaultProjectTokenIdAttr",
+             &_CreateDefaultProjectTokenIdAttr,
+             (arg("defaultValue")=object(),
+              arg("writeSparsely")=false))
+        
+        .def("GetDefaultProjectTokenAttr",
+             &This::GetDefaultProjectTokenAttr)
+        .def("CreateDefaultProjectTokenAttr",
+             &_CreateDefaultProjectTokenAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
 

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
@@ -43,5 +43,6 @@ void wrapCesiumTokens()
         cls("Tokens", boost::python::no_init);
     _AddToken(cls, "assetId", CesiumTokens->assetId);
     _AddToken(cls, "assetUrl", CesiumTokens->assetUrl);
-    _AddToken(cls, "ionToken", CesiumTokens->ionToken);
+    _AddToken(cls, "defaultProjectToken", CesiumTokens->defaultProjectToken);
+    _AddToken(cls, "defaultProjectTokenId", CesiumTokens->defaultProjectTokenId);
 }

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -34,10 +34,12 @@ class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
         const auto& stage = pxr::UsdUtilsStageCache::Get().Find(pxr::UsdStageCache::Id::FromLongInt(stageId));
         pxr::UsdPrim cesiumDataPrim = stage->DefinePrim(pxr::SdfPath("/Cesium"));
         pxr::CesiumData cesiumData(cesiumDataPrim);
-        auto ionTokenAttr = cesiumData.CreateIonTokenAttr(pxr::VtValue(""));
+        auto defaultTokenId = cesiumData.CreateDefaultProjectTokenIdAttr(pxr::VtValue(""));
+        auto defaultToken = cesiumData.CreateDefaultProjectTokenAttr(pxr::VtValue(""));
 
         if (strlen(ionToken) != 0) {
-            ionTokenAttr.Set(ionToken);
+            defaultTokenId.Set("");
+            defaultToken.Set(ionToken);
         }
     }
 


### PR DESCRIPTION
Updated the Cesium prim schema so we can store both the default project token in string form and the default project token ID in string form (for easy lookup). This mirrors what is stored in both Unreal and Unity.