### PR TITLE
Prefixed our schema attributes and added Georeference attribute

### DIFF
--- a/exts/cesium.omniverse/schemas/cesium_schemas.usda
+++ b/exts/cesium.omniverse/schemas/cesium_schemas.usda
@@ -24,12 +24,19 @@ class "CesiumData" (
         string className = "Data"
     }
 ) {
-    string defaultProjectTokenId = "" (
+    string cesium:defaultProjectTokenId = "" (
+        displayName = "Default Project ion Token ID"
         doc = "A string representing the token ID for accessing Cesium ion tilesets."
     )
 
-    string defaultProjectToken = "" (
+    string cesium:defaultProjectToken = "" (
+        displayName = "Default Project ion Token"
         doc = "A string representing a token for accessing Cesium ion tilesets."
+    )
+
+    double3 cesium:georeferenceOrigin = (0, 0, 0) (
+        displayName = "Georeference Origin Point"
+        doc = "Specifies a Georeference origin point for Cesium in Longitude, Latitude, and Height"
     )
 }
 
@@ -40,10 +47,10 @@ class "TilesetAPI" (
         string className = "TilesetAPI"
     }
 ) {
-    string assetId = "" (
+    string cesium:assetId = "" (
         doc = "A string representing a Cesium ion asset ID."
     )
-    string assetUrl = "" (
+    string cesium:assetUrl = "" (
         doc = "A string representing an asset URL."
     )
 }

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -173,12 +173,12 @@ void OmniTileset::addCesiumDataIfNotExists(const CesiumIonClient::Token& token) 
     }
 
     pxr::CesiumData cesiumData(cesiumDataPrim);
-    auto projectDefaultToken = cesiumData.GetDefaultProjectTokenAttr();
-    auto projectDefaultTokenId = cesiumData.GetDefaultProjectTokenIdAttr();
+    auto projectDefaultToken = cesiumData.GetCesiumDefaultProjectTokenAttr();
+    auto projectDefaultTokenId = cesiumData.GetCesiumDefaultProjectTokenIdAttr();
 
     if (!projectDefaultToken.IsValid()) {
-        projectDefaultToken = cesiumData.CreateDefaultProjectTokenAttr(pxr::VtValue(""));
-        projectDefaultTokenId = cesiumData.CreateDefaultProjectTokenIdAttr(pxr::VtValue(""));
+        projectDefaultToken = cesiumData.CreateCesiumDefaultProjectTokenAttr(pxr::VtValue(""));
+        projectDefaultTokenId = cesiumData.CreateCesiumDefaultProjectTokenIdAttr(pxr::VtValue(""));
     }
 
     if (!token.token.empty()) {

--- a/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
+++ b/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
@@ -12,11 +12,17 @@ class "CesiumData" (
     doc = "Stores stage level data for Cesium for Omniverse/USD."
 )
 {
-    string defaultProjectToken = "" (
+    string cesium:defaultProjectToken = "" (
+        displayName = "Default Project ion Token"
         doc = "A string representing a token for accessing Cesium ion tilesets."
     )
-    string defaultProjectTokenId = "" (
+    string cesium:defaultProjectTokenId = "" (
+        displayName = "Default Project ion Token ID"
         doc = "A string representing the token ID for accessing Cesium ion tilesets."
+    )
+    double3 cesium:georeferenceOrigin = (0, 0, 0) (
+        displayName = "Georeference Origin Point"
+        doc = "Specifies a Georeference origin point for Cesium in Longitude, Latitude, and Height"
     )
 }
 
@@ -24,10 +30,10 @@ class "TilesetAPI" (
     doc = "Adds Cesium specific data to a prim for representing a tileset."
 )
 {
-    string assetId = "" (
+    string cesium:assetId = "" (
         doc = "A string representing a Cesium ion asset ID."
     )
-    string assetUrl = "" (
+    string cesium:assetUrl = "" (
         doc = "A string representing an asset URL."
     )
 }

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.cpp
@@ -61,15 +61,15 @@ CesiumData::_GetTfType() const
 }
 
 UsdAttribute
-CesiumData::GetDefaultProjectTokenIdAttr() const
+CesiumData::GetCesiumDefaultProjectTokenIdAttr() const
 {
-    return GetPrim().GetAttribute(CesiumTokens->defaultProjectTokenId);
+    return GetPrim().GetAttribute(CesiumTokens->cesiumDefaultProjectTokenId);
 }
 
 UsdAttribute
-CesiumData::CreateDefaultProjectTokenIdAttr(VtValue const &defaultValue, bool writeSparsely) const
+CesiumData::CreateCesiumDefaultProjectTokenIdAttr(VtValue const &defaultValue, bool writeSparsely) const
 {
-    return UsdSchemaBase::_CreateAttr(CesiumTokens->defaultProjectTokenId,
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumDefaultProjectTokenId,
                        SdfValueTypeNames->String,
                        /* custom = */ false,
                        SdfVariabilityVarying,
@@ -78,16 +78,33 @@ CesiumData::CreateDefaultProjectTokenIdAttr(VtValue const &defaultValue, bool wr
 }
 
 UsdAttribute
-CesiumData::GetDefaultProjectTokenAttr() const
+CesiumData::GetCesiumDefaultProjectTokenAttr() const
 {
-    return GetPrim().GetAttribute(CesiumTokens->defaultProjectToken);
+    return GetPrim().GetAttribute(CesiumTokens->cesiumDefaultProjectToken);
 }
 
 UsdAttribute
-CesiumData::CreateDefaultProjectTokenAttr(VtValue const &defaultValue, bool writeSparsely) const
+CesiumData::CreateCesiumDefaultProjectTokenAttr(VtValue const &defaultValue, bool writeSparsely) const
 {
-    return UsdSchemaBase::_CreateAttr(CesiumTokens->defaultProjectToken,
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumDefaultProjectToken,
                        SdfValueTypeNames->String,
+                       /* custom = */ false,
+                       SdfVariabilityVarying,
+                       defaultValue,
+                       writeSparsely);
+}
+
+UsdAttribute
+CesiumData::GetCesiumGeoreferenceOriginAttr() const
+{
+    return GetPrim().GetAttribute(CesiumTokens->cesiumGeoreferenceOrigin);
+}
+
+UsdAttribute
+CesiumData::CreateCesiumGeoreferenceOriginAttr(VtValue const &defaultValue, bool writeSparsely) const
+{
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumGeoreferenceOrigin,
+                       SdfValueTypeNames->Double3,
                        /* custom = */ false,
                        SdfVariabilityVarying,
                        defaultValue,
@@ -111,8 +128,9 @@ const TfTokenVector&
 CesiumData::GetSchemaAttributeNames(bool includeInherited)
 {
     static TfTokenVector localNames = {
-        CesiumTokens->defaultProjectTokenId,
-        CesiumTokens->defaultProjectToken,
+        CesiumTokens->cesiumDefaultProjectTokenId,
+        CesiumTokens->cesiumDefaultProjectToken,
+        CesiumTokens->cesiumGeoreferenceOrigin,
     };
     static TfTokenVector allNames =
         _ConcatenateAttributeNames(

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/data.h
@@ -96,43 +96,63 @@ private:
 
 public:
     // --------------------------------------------------------------------- //
-    // DEFAULTPROJECTTOKENID 
+    // CESIUMDEFAULTPROJECTTOKENID 
     // --------------------------------------------------------------------- //
     /// A string representing the token ID for accessing Cesium ion tilesets.
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `string defaultProjectTokenId = ""` |
+    /// | Declaration | `string cesium:defaultProjectTokenId = ""` |
     /// | C++ Type | std::string |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
-    UsdAttribute GetDefaultProjectTokenIdAttr() const;
+    UsdAttribute GetCesiumDefaultProjectTokenIdAttr() const;
 
-    /// See GetDefaultProjectTokenIdAttr(), and also 
+    /// See GetCesiumDefaultProjectTokenIdAttr(), and also 
     /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
     /// If specified, author \p defaultValue as the attribute's default,
     /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
     /// the default for \p writeSparsely is \c false.
-    UsdAttribute CreateDefaultProjectTokenIdAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+    UsdAttribute CreateCesiumDefaultProjectTokenIdAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
 
 public:
     // --------------------------------------------------------------------- //
-    // DEFAULTPROJECTTOKEN 
+    // CESIUMDEFAULTPROJECTTOKEN 
     // --------------------------------------------------------------------- //
     /// A string representing a token for accessing Cesium ion tilesets.
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `string defaultProjectToken = ""` |
+    /// | Declaration | `string cesium:defaultProjectToken = ""` |
     /// | C++ Type | std::string |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
-    UsdAttribute GetDefaultProjectTokenAttr() const;
+    UsdAttribute GetCesiumDefaultProjectTokenAttr() const;
 
-    /// See GetDefaultProjectTokenAttr(), and also 
+    /// See GetCesiumDefaultProjectTokenAttr(), and also 
     /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
     /// If specified, author \p defaultValue as the attribute's default,
     /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
     /// the default for \p writeSparsely is \c false.
-    UsdAttribute CreateDefaultProjectTokenAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+    UsdAttribute CreateCesiumDefaultProjectTokenAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+
+public:
+    // --------------------------------------------------------------------- //
+    // CESIUMGEOREFERENCEORIGIN 
+    // --------------------------------------------------------------------- //
+    /// Specifies a Georeference origin point for Cesium in Longitude, Latitude, and Height
+    ///
+    /// | ||
+    /// | -- | -- |
+    /// | Declaration | `double3 cesium:georeferenceOrigin = (0, 0, 0)` |
+    /// | C++ Type | GfVec3d |
+    /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->Double3 |
+    UsdAttribute GetCesiumGeoreferenceOriginAttr() const;
+
+    /// See GetCesiumGeoreferenceOriginAttr(), and also 
+    /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
+    /// If specified, author \p defaultValue as the attribute's default,
+    /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
+    /// the default for \p writeSparsely is \c false.
+    UsdAttribute CreateCesiumGeoreferenceOriginAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
 
 public:
     // ===================================================================== //

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.cpp
@@ -77,15 +77,15 @@ CesiumTilesetAPI::_GetTfType() const
 }
 
 UsdAttribute
-CesiumTilesetAPI::GetAssetIdAttr() const
+CesiumTilesetAPI::GetCesiumAssetIdAttr() const
 {
-    return GetPrim().GetAttribute(CesiumTokens->assetId);
+    return GetPrim().GetAttribute(CesiumTokens->cesiumAssetId);
 }
 
 UsdAttribute
-CesiumTilesetAPI::CreateAssetIdAttr(VtValue const &defaultValue, bool writeSparsely) const
+CesiumTilesetAPI::CreateCesiumAssetIdAttr(VtValue const &defaultValue, bool writeSparsely) const
 {
-    return UsdSchemaBase::_CreateAttr(CesiumTokens->assetId,
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumAssetId,
                        SdfValueTypeNames->String,
                        /* custom = */ false,
                        SdfVariabilityVarying,
@@ -94,15 +94,15 @@ CesiumTilesetAPI::CreateAssetIdAttr(VtValue const &defaultValue, bool writeSpars
 }
 
 UsdAttribute
-CesiumTilesetAPI::GetAssetUrlAttr() const
+CesiumTilesetAPI::GetCesiumAssetUrlAttr() const
 {
-    return GetPrim().GetAttribute(CesiumTokens->assetUrl);
+    return GetPrim().GetAttribute(CesiumTokens->cesiumAssetUrl);
 }
 
 UsdAttribute
-CesiumTilesetAPI::CreateAssetUrlAttr(VtValue const &defaultValue, bool writeSparsely) const
+CesiumTilesetAPI::CreateCesiumAssetUrlAttr(VtValue const &defaultValue, bool writeSparsely) const
 {
-    return UsdSchemaBase::_CreateAttr(CesiumTokens->assetUrl,
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumAssetUrl,
                        SdfValueTypeNames->String,
                        /* custom = */ false,
                        SdfVariabilityVarying,
@@ -127,8 +127,8 @@ const TfTokenVector&
 CesiumTilesetAPI::GetSchemaAttributeNames(bool includeInherited)
 {
     static TfTokenVector localNames = {
-        CesiumTokens->assetId,
-        CesiumTokens->assetUrl,
+        CesiumTokens->cesiumAssetId,
+        CesiumTokens->cesiumAssetUrl,
     };
     static TfTokenVector allNames =
         _ConcatenateAttributeNames(

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.h
@@ -113,43 +113,43 @@ private:
 
 public:
     // --------------------------------------------------------------------- //
-    // ASSETID 
+    // CESIUMASSETID 
     // --------------------------------------------------------------------- //
     /// A string representing a Cesium ion asset ID.
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `string assetId = ""` |
+    /// | Declaration | `string cesium:assetId = ""` |
     /// | C++ Type | std::string |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
-    UsdAttribute GetAssetIdAttr() const;
+    UsdAttribute GetCesiumAssetIdAttr() const;
 
-    /// See GetAssetIdAttr(), and also 
+    /// See GetCesiumAssetIdAttr(), and also 
     /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
     /// If specified, author \p defaultValue as the attribute's default,
     /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
     /// the default for \p writeSparsely is \c false.
-    UsdAttribute CreateAssetIdAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+    UsdAttribute CreateCesiumAssetIdAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
 
 public:
     // --------------------------------------------------------------------- //
-    // ASSETURL 
+    // CESIUMASSETURL 
     // --------------------------------------------------------------------- //
     /// A string representing an asset URL.
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `string assetUrl = ""` |
+    /// | Declaration | `string cesium:assetUrl = ""` |
     /// | C++ Type | std::string |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->String |
-    UsdAttribute GetAssetUrlAttr() const;
+    UsdAttribute GetCesiumAssetUrlAttr() const;
 
-    /// See GetAssetUrlAttr(), and also 
+    /// See GetCesiumAssetUrlAttr(), and also 
     /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
     /// If specified, author \p defaultValue as the attribute's default,
     /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
     /// the default for \p writeSparsely is \c false.
-    UsdAttribute CreateAssetUrlAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
+    UsdAttribute CreateCesiumAssetUrlAttr(VtValue const &defaultValue = VtValue(), bool writeSparsely=false) const;
 
 public:
     // ===================================================================== //

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
@@ -3,15 +3,17 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 CesiumTokensType::CesiumTokensType() :
-    assetId("assetId", TfToken::Immortal),
-    assetUrl("assetUrl", TfToken::Immortal),
-    defaultProjectToken("defaultProjectToken", TfToken::Immortal),
-    defaultProjectTokenId("defaultProjectTokenId", TfToken::Immortal),
+    cesiumAssetId("cesium:assetId", TfToken::Immortal),
+    cesiumAssetUrl("cesium:assetUrl", TfToken::Immortal),
+    cesiumDefaultProjectToken("cesium:defaultProjectToken", TfToken::Immortal),
+    cesiumDefaultProjectTokenId("cesium:defaultProjectTokenId", TfToken::Immortal),
+    cesiumGeoreferenceOrigin("cesium:georeferenceOrigin", TfToken::Immortal),
     allTokens({
-        assetId,
-        assetUrl,
-        defaultProjectToken,
-        defaultProjectTokenId
+        cesiumAssetId,
+        cesiumAssetUrl,
+        cesiumDefaultProjectToken,
+        cesiumDefaultProjectTokenId,
+        cesiumGeoreferenceOrigin
     })
 {
 }

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
@@ -35,26 +35,30 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Use CesiumTokens like so:
 ///
 /// \code
-///     gprim.GetMyTokenValuedAttr().Set(CesiumTokens->assetId);
+///     gprim.GetMyTokenValuedAttr().Set(CesiumTokens->cesiumAssetId);
 /// \endcode
 struct CesiumTokensType {
     CESIUM_API CesiumTokensType();
-    /// \brief "assetId"
+    /// \brief "cesium:assetId"
     /// 
     /// CesiumTilesetAPI
-    const TfToken assetId;
-    /// \brief "assetUrl"
+    const TfToken cesiumAssetId;
+    /// \brief "cesium:assetUrl"
     /// 
     /// CesiumTilesetAPI
-    const TfToken assetUrl;
-    /// \brief "defaultProjectToken"
+    const TfToken cesiumAssetUrl;
+    /// \brief "cesium:defaultProjectToken"
     /// 
     /// CesiumData
-    const TfToken defaultProjectToken;
-    /// \brief "defaultProjectTokenId"
+    const TfToken cesiumDefaultProjectToken;
+    /// \brief "cesium:defaultProjectTokenId"
     /// 
     /// CesiumData
-    const TfToken defaultProjectTokenId;
+    const TfToken cesiumDefaultProjectTokenId;
+    /// \brief "cesium:georeferenceOrigin"
+    /// 
+    /// CesiumData
+    const TfToken cesiumGeoreferenceOrigin;
     /// A vector of all of the tokens listed above.
     const std::vector<TfToken> allTokens;
 };

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapData.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapData.cpp
@@ -27,17 +27,24 @@ WRAP_CUSTOM;
 
         
 static UsdAttribute
-_CreateDefaultProjectTokenIdAttr(CesiumData &self,
+_CreateCesiumDefaultProjectTokenIdAttr(CesiumData &self,
                                       object defaultVal, bool writeSparsely) {
-    return self.CreateDefaultProjectTokenIdAttr(
+    return self.CreateCesiumDefaultProjectTokenIdAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
 }
         
 static UsdAttribute
-_CreateDefaultProjectTokenAttr(CesiumData &self,
+_CreateCesiumDefaultProjectTokenAttr(CesiumData &self,
                                       object defaultVal, bool writeSparsely) {
-    return self.CreateDefaultProjectTokenAttr(
+    return self.CreateCesiumDefaultProjectTokenAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
+}
+        
+static UsdAttribute
+_CreateCesiumGeoreferenceOriginAttr(CesiumData &self,
+                                      object defaultVal, bool writeSparsely) {
+    return self.CreateCesiumGeoreferenceOriginAttr(
+        UsdPythonToSdfType(defaultVal, SdfValueTypeNames->Double3), writeSparsely);
 }
 
 static std::string
@@ -79,17 +86,24 @@ void wrapCesiumData()
         .def(!self)
 
         
-        .def("GetDefaultProjectTokenIdAttr",
-             &This::GetDefaultProjectTokenIdAttr)
-        .def("CreateDefaultProjectTokenIdAttr",
-             &_CreateDefaultProjectTokenIdAttr,
+        .def("GetCesiumDefaultProjectTokenIdAttr",
+             &This::GetCesiumDefaultProjectTokenIdAttr)
+        .def("CreateCesiumDefaultProjectTokenIdAttr",
+             &_CreateCesiumDefaultProjectTokenIdAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
         
-        .def("GetDefaultProjectTokenAttr",
-             &This::GetDefaultProjectTokenAttr)
-        .def("CreateDefaultProjectTokenAttr",
-             &_CreateDefaultProjectTokenAttr,
+        .def("GetCesiumDefaultProjectTokenAttr",
+             &This::GetCesiumDefaultProjectTokenAttr)
+        .def("CreateCesiumDefaultProjectTokenAttr",
+             &_CreateCesiumDefaultProjectTokenAttr,
+             (arg("defaultValue")=object(),
+              arg("writeSparsely")=false))
+        
+        .def("GetCesiumGeoreferenceOriginAttr",
+             &This::GetCesiumGeoreferenceOriginAttr)
+        .def("CreateCesiumGeoreferenceOriginAttr",
+             &_CreateCesiumGeoreferenceOriginAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
 

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTilesetAPI.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTilesetAPI.cpp
@@ -27,16 +27,16 @@ WRAP_CUSTOM;
 
         
 static UsdAttribute
-_CreateAssetIdAttr(CesiumTilesetAPI &self,
+_CreateCesiumAssetIdAttr(CesiumTilesetAPI &self,
                                       object defaultVal, bool writeSparsely) {
-    return self.CreateAssetIdAttr(
+    return self.CreateCesiumAssetIdAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
 }
         
 static UsdAttribute
-_CreateAssetUrlAttr(CesiumTilesetAPI &self,
+_CreateCesiumAssetUrlAttr(CesiumTilesetAPI &self,
                                       object defaultVal, bool writeSparsely) {
-    return self.CreateAssetUrlAttr(
+    return self.CreateCesiumAssetUrlAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->String), writeSparsely);
 }
 
@@ -82,17 +82,17 @@ void wrapCesiumTilesetAPI()
         .def(!self)
 
         
-        .def("GetAssetIdAttr",
-             &This::GetAssetIdAttr)
-        .def("CreateAssetIdAttr",
-             &_CreateAssetIdAttr,
+        .def("GetCesiumAssetIdAttr",
+             &This::GetCesiumAssetIdAttr)
+        .def("CreateCesiumAssetIdAttr",
+             &_CreateCesiumAssetIdAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
         
-        .def("GetAssetUrlAttr",
-             &This::GetAssetUrlAttr)
-        .def("CreateAssetUrlAttr",
-             &_CreateAssetUrlAttr,
+        .def("GetCesiumAssetUrlAttr",
+             &This::GetCesiumAssetUrlAttr)
+        .def("CreateCesiumAssetUrlAttr",
+             &_CreateCesiumAssetUrlAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
 

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
@@ -41,8 +41,9 @@ void wrapCesiumTokens()
 {
     boost::python::class_<CesiumTokensType, boost::noncopyable>
         cls("Tokens", boost::python::no_init);
-    _AddToken(cls, "assetId", CesiumTokens->assetId);
-    _AddToken(cls, "assetUrl", CesiumTokens->assetUrl);
-    _AddToken(cls, "defaultProjectToken", CesiumTokens->defaultProjectToken);
-    _AddToken(cls, "defaultProjectTokenId", CesiumTokens->defaultProjectTokenId);
+    _AddToken(cls, "cesiumAssetId", CesiumTokens->cesiumAssetId);
+    _AddToken(cls, "cesiumAssetUrl", CesiumTokens->cesiumAssetUrl);
+    _AddToken(cls, "cesiumDefaultProjectToken", CesiumTokens->cesiumDefaultProjectToken);
+    _AddToken(cls, "cesiumDefaultProjectTokenId", CesiumTokens->cesiumDefaultProjectTokenId);
+    _AddToken(cls, "cesiumGeoreferenceOrigin", CesiumTokens->cesiumGeoreferenceOrigin);
 }


### PR DESCRIPTION
I noticed that all of the Omniverse USD schemas prefix their attributes with `omni`, so I figured we should also do so with `cesium`. I also added the Georeference attribute to the Cesium Prim schema.