### PR TITLE
Fixing some missed schema function call changes

### DIFF
--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -152,9 +152,9 @@ std::optional<CesiumIonClient::Token> OmniTileset::getDefaultToken() {
 
     pxr::CesiumData cesiumData(cesiumDataPrim);
     std::string projectDefaultToken;
-    cesiumData.GetDefaultProjectTokenAttr().Get(&projectDefaultToken);
+    cesiumData.GetCesiumDefaultProjectTokenAttr().Get(&projectDefaultToken);
     std::string projectDefaultTokenId;
-    cesiumData.GetDefaultProjectTokenIdAttr().Get(&projectDefaultTokenId);
+    cesiumData.GetCesiumDefaultProjectTokenIdAttr().Get(&projectDefaultTokenId);
 
     return CesiumIonClient::Token{projectDefaultTokenId, "", projectDefaultToken};
 }


### PR DESCRIPTION
Apparently I missed some function call changes. Not sure why it built with these wrong function calls nor why no errors occurred during run, but this fixes it.