### PR TITLE
Fixing the styles for small DPI devices

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -127,7 +127,7 @@ class CesiumOmniverseMainWindow(ui.Window):
     def _build_fn(self):
         """Builds all UI components."""
 
-        with ui.VStack(spacing=20):
+        with ui.VStack(spacing=0):
             button_style = CesiumOmniverseUiStyles.top_bar_button_style
 
             with ui.HStack(height=ui.Length(80, ui.UnitType.PIXEL)):

--- a/exts/cesium.omniverse/cesium/omniverse/ui/quick_add_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/quick_add_widget.py
@@ -128,14 +128,14 @@ class CesiumOmniverseQuickAddWidget(ui.Frame):
     def _build_ui(self):
         with self:
             with ui.VStack(spacing=10):
-                with ui.VStack(spacing=10):
+                with ui.VStack(spacing=5):
                     ui.Label("Quick Add Basic Assets", style=CesiumOmniverseUiStyles.quick_add_section_label,
                              height=LABEL_HEIGHT)
                     ui.Button("Blank 3D Tiles Tileset", style=CesiumOmniverseUiStyles.quick_add_button,
                               clicked_fn=self._add_blank_button_clicked, height=BUTTON_HEIGHT)
                 self._ion_quick_add_frame = ui.Frame(visible=False, height=0)
                 with self._ion_quick_add_frame:
-                    with ui.VStack(spacing=10):
+                    with ui.VStack(spacing=5):
                         ui.Label("Quick Add Cesium ion Assets", style=CesiumOmniverseUiStyles.quick_add_section_label,
                                  height=LABEL_HEIGHT)
                         ui.Button("Cesium World Terrain + Bing Maps Aerial imagery",

--- a/exts/cesium.omniverse/cesium/omniverse/ui/sign_in_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/sign_in_widget.py
@@ -55,8 +55,9 @@ class CesiumOmniverseSignInWidget(ui.Frame):
     def _build_ui(self):
         with self:
             with ui.VStack(alignment=ui.Alignment.CENTER_TOP, spacing=ui.Length(20, ui.UnitType.PIXEL)):
+                ui.Spacer(height=0)
                 ui.Image(f"{self._images_path}/placeholder_logo.png", alignment=ui.Alignment.CENTER,
-                         fill_policy=ui.FillPolicy.PRESERVE_ASPECT_FIT, height=ui.Length(25, ui.UnitType.PERCENT))
+                         fill_policy=ui.FillPolicy.PRESERVE_ASPECT_FIT, height=140)
                 with ui.HStack(height=0):
                     ui.Spacer()
                     ui.Label(

--- a/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
@@ -3,11 +3,12 @@ from omni.ui import Alignment, color as cl, Direction
 
 class CesiumOmniverseUiStyles:
     intro_label_style = {
-        "font_size": 18,
+        "font_size": 16,
     }
 
     quick_add_section_label = {
         "font_size": 20,
+        "margin": 5,
     }
 
     quick_add_button = {


### PR DESCRIPTION
I have a HiDPI monitor at home, and I didn't realize how big things were looking on smaller monitors. I've fixed a lot of things here, including:

* The logo bug.
* Layout of the main window.
* Tightened up the blue buttons.
* Tightened up the quick add buttons to make everything else fit better.
* Decreased font sizes across the board. Going forward, 16 px is our "standard" font size, and we can step up and down by 2 px increments.