### PR TITLE
Pin conan to 1.58.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,14 +67,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.CONAN_USER_HOME }}/.conan
-          key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v1
+          key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v2
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt update
           sudo apt install -y doxygen clang-tidy-14 gcovr
-          sudo pip3 install conan
+          sudo pip3 install conan==1.58.0
 
       # Could not figure out how to add Chocolatey libraries to the PATH automatically with refreshenv, so
       # hardcoding their locations instead. Followed these instructions for adding to the PATH on PowerShell:
@@ -83,7 +83,7 @@ jobs:
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
         run: |
-          choco install -y conan
+          choco install -y conan --version 1.58.0
           echo "C:/Program Files/conan/conan" >> $env:GITHUB_PATH
 
       # Note: CMAKE_BUILD_TYPE is only used by Linux. It is ignored for Windows.

--- a/docs/building/building.md
+++ b/docs/building/building.md
@@ -47,7 +47,7 @@ See [Linux](#linux) or [Windows](#windows) for step-by-step installation instruc
   ```
 - Install Conan with pip because Conan is not in Ubuntu's package manager
   ```sh
-  sudo pip3 install conan
+  sudo pip3 install conan==1.58.0
   ```
 - Install `cmake-format`
   ```sh
@@ -105,8 +105,10 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
   ```sh
   pip3 install colorama
   ```
-- Install Conan: https://conan.io/downloads.html
-  - Use defaults
+- Install Conan
+  ```sh
+  pip3 install conan==1.58.0
+  ```
 - Install Doxygen: https://www.doxygen.nl/download.html
   - After installation, add the install location to your `PATH`. Open PowerShell as administrator and enter:
     ```sh
@@ -130,10 +132,13 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
 
 - Install [Chocolatey](https://docs.chocolatey.org/en-us/choco/setup) and then install dependencies
   ```sh
-  choco install -y visualstudio2022professional visualstudio2022-workload-nativedesktop python cmake ninja git conan doxygen.install vswhere --installargs 'ADD_CMAKE_TO_PATH=System'
+  choco install -y visualstudio2022professional visualstudio2022-workload-nativedesktop python cmake ninja git doxygen.install vswhere --installargs 'ADD_CMAKE_TO_PATH=System'
   ```
   ```sh
   choco install -y llvm --version=14.0.6
+  ```
+  ```sh
+  choco install -y conan --version 1.58.0
   ```
   > **Note:** If you see a warning like `Chocolatey detected you are not running from an elevated command shell`, reopen Command Prompt as administrator
 - Create a symbolic link called `python3.exe` that points to the actual `python` (version 3.x) executable. This is necessary for some of the scripts to run correctly when `#!/usr/bin/env python3` is at the top of the file.


### PR DESCRIPTION
Conan 2.0.0 was just released and it doesn't work out of the box with our build system. It could be a simple fix, but no time to investigate right now. Pinning to 1.58.0 for now.

Here's the log from https://github.com/CesiumGS/cesium-omniverse/actions/runs/4236435146/jobs/7378449197:

```
-- Downloading conan.cmake from https://github.com/conan-io/cmake-conan
usage: conan config [-h] [-v [V]] [--logger] {home,install,list} ...
conan config: error: argument subcommand: invalid choice: 'init' (choose from 'home', 'install', 'list')
ERROR: Exiting with code: 2
CMake Error at cmake/ConfigureConan.cmake:82 (file):
  file failed to open for reading (No such file or directory):

    /home/runner/.conan2/conan.conf
Call Stack (most recent call first):
  cmake/AddConanDependencies.cmake:[21](https://github.com/CesiumGS/cesium-omniverse/actions/runs/4236435146/jobs/7378449197#step:10:22) (configure_conan)
  CMakeLists.txt:167 (include)
```