### PR TITLE
Fix adding imagery to existing tileset

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
@@ -89,7 +89,7 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
             all_tilesets = self._cesium_omniverse_interface.get_all_tileset_ids_and_paths()
 
             if len(all_tilesets) > 0:
-                tileset_id = all_tilesets[0]
+                tileset_id = all_tilesets[0][0]
             else:
                 self._add_overlay_with_tileset()
                 return


### PR DESCRIPTION
Adding imagery to an existing tileset was failing. See the video below for reproducing the bug.

https://user-images.githubusercontent.com/915398/221707236-31db739f-3de9-47c8-93f7-1fa31f35f985.mp4
