### PR TITLE
Updated kit-sdk dependency to latest release version

### DIFF
--- a/extern/nvidia/deps/kit-sdk.packman.xml
+++ b/extern/nvidia/deps/kit-sdk.packman.xml
@@ -1,5 +1,5 @@
 <project toolsVersion="5.6">
   <dependency name="kit_sdk" linkPath="../_build/target-deps/kit-sdk/">
-    <package name="kit-sdk" version="104.2+release.213.e103f25e.tc.${platform}.release"/>
+    <package name="kit-sdk" version="104.2+release.295.529af2e4.tc.${platform}.release"/>
   </dependency>
 </project>


### PR DESCRIPTION
Updates our kit-sdk dependency to `104.2+release.295.529af2e4.tc.${platform}.release`.