### PR TITLE
Generate flat normals by default + option for smooth normals

### DIFF
--- a/exts/cesium.omniverse/schemas/cesium_schemas.usda
+++ b/exts/cesium.omniverse/schemas/cesium_schemas.usda
@@ -192,6 +192,14 @@ class "CesiumTilesetSchemaAPI" (
         displayName = "Suspend Update"
         doc = "Pauses level-of-detail and culling updates of this tileset."
     )
+
+    bool cesium:smoothNormals = false (
+        customData = {
+            string apiName = "smoothNormals"
+        }
+        displayName = "Smooth Normals"
+        doc = "Generate smooth normals instead of flat normals when normals are missing."
+    )
 }
 
 class CesiumImageryPrim "CesiumImageryPrim" (

--- a/src/core/include/cesium/omniverse/FabricStageUtil.h
+++ b/src/core/include/cesium/omniverse/FabricStageUtil.h
@@ -27,7 +27,8 @@ AddTileResults addTile(
     int64_t tileId,
     const glm::dmat4& ecefToUsdTransform,
     const glm::dmat4& tileTransform,
-    const CesiumGltf::Model& model);
+    const CesiumGltf::Model& model,
+    bool smoothNormals);
 
 AddTileResults addTileWithImagery(
     int64_t tilesetId,
@@ -35,6 +36,7 @@ AddTileResults addTileWithImagery(
     const glm::dmat4& ecefToUsdTransform,
     const glm::dmat4& tileTransform,
     const CesiumGltf::Model& model,
+    bool smoothNormals,
     const CesiumGltf::ImageCesium& image,
     const std::string& imageryName,
     const CesiumGeometry::Rectangle& imageryRectangle,

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -29,7 +29,8 @@ pxr::VtArray<pxr::GfVec3f> getPrimitiveNormals(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     const pxr::VtArray<pxr::GfVec3f>& positions,
-    const pxr::VtArray<int>& indices);
+    const pxr::VtArray<int>& indices,
+    bool smoothNormals);
 
 pxr::VtArray<pxr::GfVec2f>
 getPrimitiveUVs(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -46,6 +46,7 @@ class OmniTileset {
     bool getEnforceCulledScreenSpaceError() const;
     float getCulledScreenSpaceError() const;
     bool getSuspendUpdate() const;
+    bool getSmoothNormals() const;
 
     int64_t getTilesetId() const;
 

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -274,7 +274,8 @@ void Context::processPropertyChanged(const ChangedPrim& changedPrim) {
                 name == pxr::CesiumTokens->cesiumEnableFrustumCulling ||
                 name == pxr::CesiumTokens->cesiumEnableFogCulling ||
                 name == pxr::CesiumTokens->cesiumEnforceCulledScreenSpaceError ||
-                name == pxr::CesiumTokens->cesiumCulledScreenSpaceError) {
+                name == pxr::CesiumTokens->cesiumCulledScreenSpaceError ||
+                name == pxr::CesiumTokens->cesiumSmoothNormals) {
                 tilesetsToReload.emplace(tileset.value());
             }
             // clang-format on

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -50,7 +50,12 @@ FabricPrepareRenderResources::prepareInLoadThread(
                 Context::instance().getGeoreferenceOrigin(), _tileset.getPath());
 
             const auto addTileResults = FabricStageUtil::addTile(
-                _tileset.getTilesetId(), Context::instance().getNextTileId(), ecefToUsdTransform, transform, *pModel);
+                _tileset.getTilesetId(),
+                Context::instance().getNextTileId(),
+                ecefToUsdTransform,
+                transform,
+                *pModel,
+                _tileset.getSmoothNormals());
 
             return asyncSystem.createResolvedFuture(Cesium3DTilesSelection::TileLoadResultAndRenderResources{
                 std::move(tileLoadResult),
@@ -166,6 +171,7 @@ void FabricPrepareRenderResources::attachRasterInMainThread(
         ecefToUsdTransform,
         pTileRenderResources->tileTransform,
         tile.getContent().getRenderContent()->getModel(),
+        _tileset.getSmoothNormals(),
         rasterTile.getImage(),
         rasterTile.getOverlay().getName(),
         rasterTile.getRectangle(),

--- a/src/core/src/FabricStageUtil.cpp
+++ b/src/core/src/FabricStageUtil.cpp
@@ -739,21 +739,22 @@ void addPrimitive(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     const std::vector<pxr::SdfPath>& materialPaths,
-    uint64_t imageryUvSetIndex) {
+    uint64_t imageryUvSetIndex,
+    bool smoothNormals) {
 
     auto sip = UsdUtil::getFabricStageInProgress();
     const auto geomPathFabric = carb::flatcache::Path(carb::flatcache::asInt(geomPath));
 
     const auto positions = GltfUtil::getPrimitivePositions(model, primitive);
     const auto indices = GltfUtil::getPrimitiveIndices(model, primitive, positions);
-    const auto normals = GltfUtil::getPrimitiveNormals(model, primitive, positions, indices);
+    const auto normals = GltfUtil::getPrimitiveNormals(model, primitive, positions, indices, smoothNormals);
     const auto st0 = GltfUtil::getPrimitiveUVs(model, primitive, 0);
     const auto imagerySt = GltfUtil::getImageryUVs(model, primitive, imageryUvSetIndex);
     const auto localExtent = GltfUtil::getPrimitiveExtent(model, primitive);
     const auto faceVertexCounts = GltfUtil::getPrimitiveFaceVertexCounts(indices);
     const auto doubleSided = GltfUtil::getDoubleSided(model, primitive);
 
-    if (positions.empty() || indices.empty() || normals.empty() || !localExtent.has_value()) {
+    if (positions.empty() || indices.empty() || !localExtent.has_value()) {
         return;
     }
 
@@ -768,6 +769,7 @@ void addPrimitive(
     const auto hasPrimitiveSt = !st0.empty();
     const auto hasImagerySt = !imagerySt.empty();
     const auto hasSt = hasPrimitiveSt || hasImagerySt;
+    const auto hasNormals = !normals.empty();
 
     const auto localToEcefTransform = gltfToEcefTransform * nodeTransform;
     const auto localToUsdTransform = ecefToUsdTransform * localToEcefTransform;
@@ -786,7 +788,6 @@ void addPrimitive(
     attributes.addAttribute(FabricTypes::primvars, FabricTokens::primvars);
     attributes.addAttribute(FabricTypes::primvarInterpolations, FabricTokens::primvarInterpolations);
     attributes.addAttribute(FabricTypes::primvars_displayColor, FabricTokens::primvars_displayColor);
-    attributes.addAttribute(FabricTypes::primvars_normals, FabricTokens::primvars_normals);
     attributes.addAttribute(FabricTypes::Mesh, FabricTokens::Mesh);
     attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
     attributes.addAttribute(FabricTypes::_cesium_tileId, FabricTokens::_cesium_tileId);
@@ -805,12 +806,25 @@ void addPrimitive(
         attributes.addAttribute(FabricTypes::primvars_st, FabricTokens::primvars_st);
     }
 
+    if (hasNormals) {
+        attributes.addAttribute(FabricTypes::primvars_normals, FabricTokens::primvars_normals);
+    }
+
     attributes.createAttributes(geomPathFabric);
 
-    const size_t primvarsCount = hasSt ? 3 : 2;
-    const size_t primvarIndexDisplayColor = 0;
-    const size_t primvarIndexNormal = 1;
-    const size_t primvarIndexSt = 2;
+    size_t primvarsCount = 0;
+    size_t primvarIndexSt = 0;
+    size_t primvarIndexNormal = 0;
+
+    const size_t primvarIndexDisplayColor = primvarsCount++;
+
+    if (hasSt) {
+        primvarIndexSt = primvarsCount++;
+    }
+
+    if (hasNormals) {
+        primvarIndexNormal = primvarsCount++;
+    }
 
     sip.setArrayAttributeSize(geomPathFabric, FabricTokens::faceVertexCounts, faceVertexCounts.size());
     sip.setArrayAttributeSize(geomPathFabric, FabricTokens::faceVertexIndices, indices.size());
@@ -818,7 +832,6 @@ void addPrimitive(
     sip.setArrayAttributeSize(geomPathFabric, FabricTokens::primvars, primvarsCount);
     sip.setArrayAttributeSize(geomPathFabric, FabricTokens::primvarInterpolations, primvarsCount);
     sip.setArrayAttributeSize(geomPathFabric, FabricTokens::primvars_displayColor, 1);
-    sip.setArrayAttributeSize(geomPathFabric, FabricTokens::primvars_normals, normals.size());
 
     // clang-format off
     auto faceVertexCountsFabric = sip.getArrayAttributeWr<int>(geomPathFabric, FabricTokens::faceVertexCounts);
@@ -830,7 +843,6 @@ void addPrimitive(
     auto primvarsFabric = sip.getArrayAttributeWr<carb::flatcache::Token>(geomPathFabric, FabricTokens::primvars);
     auto primvarInterpolationsFabric = sip.getArrayAttributeWr<carb::flatcache::Token>(geomPathFabric, FabricTokens::primvarInterpolations);
     auto displayColorFabric = sip.getArrayAttributeWr<pxr::GfVec3f>(geomPathFabric, FabricTokens::primvars_displayColor);
-    auto normalsFabric = sip.getArrayAttributeWr<pxr::GfVec3f>(geomPathFabric, FabricTokens::primvars_normals);
     auto tilesetIdFabric = sip.getAttributeWr<int64_t>(geomPathFabric, FabricTokens::_cesium_tilesetId);
     auto tileIdFabric = sip.getAttributeWr<int64_t>(geomPathFabric, FabricTokens::_cesium_tileId);
     auto localToEcefTransformFabric = sip.getAttributeWr<pxr::GfMatrix4d>(geomPathFabric, FabricTokens::_cesium_localToEcefTransform);
@@ -844,13 +856,10 @@ void addPrimitive(
     std::copy(faceVertexCounts.begin(), faceVertexCounts.end(), faceVertexCountsFabric.begin());
     std::copy(indices.begin(), indices.end(), faceVertexIndicesFabric.begin());
     std::copy(positions.begin(), positions.end(), pointsFabric.begin());
-    std::copy(normals.begin(), normals.end(), normalsFabric.begin());
 
     *worldVisibilityFabric = false;
     primvarsFabric[primvarIndexDisplayColor] = FabricTokens::primvars_displayColor;
     primvarInterpolationsFabric[primvarIndexDisplayColor] = FabricTokens::constant;
-    primvarsFabric[primvarIndexNormal] = FabricTokens::primvars_normals;
-    primvarInterpolationsFabric[primvarIndexNormal] = FabricTokens::vertex;
     *tilesetIdFabric = tilesetId;
     *tileIdFabric = tileId;
     *worldPositionFabric = worldPosition;
@@ -881,6 +890,17 @@ void addPrimitive(
 
         primvarsFabric[primvarIndexSt] = FabricTokens::primvars_st;
         primvarInterpolationsFabric[primvarIndexSt] = FabricTokens::vertex;
+    }
+
+    if (hasNormals) {
+        sip.setArrayAttributeSize(geomPathFabric, FabricTokens::primvars_normals, normals.size());
+
+        auto normalsFabric = sip.getArrayAttributeWr<pxr::GfVec3f>(geomPathFabric, FabricTokens::primvars_normals);
+
+        std::copy(normals.begin(), normals.end(), normalsFabric.begin());
+
+        primvarsFabric[primvarIndexNormal] = FabricTokens::primvars_normals;
+        primvarInterpolationsFabric[primvarIndexNormal] = FabricTokens::vertex;
     }
 }
 
@@ -958,7 +978,8 @@ AddTileResults addTile(
     int64_t tileId,
     const glm::dmat4& ecefToUsdTransform,
     const glm::dmat4& tileTransform,
-    const CesiumGltf::Model& model) {
+    const CesiumGltf::Model& model,
+    bool smoothNormals) {
     auto gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyRtcCenter(model, tileTransform);
     gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyGltfUpAxisTransform(model, gltfToEcefTransform);
 
@@ -998,7 +1019,14 @@ AddTileResults addTile(
 
     model.forEachPrimitiveInScene(
         -1,
-        [tilesetId, tileId, &primitiveId, &ecefToUsdTransform, &gltfToEcefTransform, &materialPaths, &geomPaths](
+        [tilesetId,
+         tileId,
+         &primitiveId,
+         &ecefToUsdTransform,
+         &gltfToEcefTransform,
+         &materialPaths,
+         &geomPaths,
+         smoothNormals](
             const CesiumGltf::Model& gltf,
             [[maybe_unused]] const CesiumGltf::Node& node,
             [[maybe_unused]] const CesiumGltf::Mesh& mesh,
@@ -1015,7 +1043,8 @@ AddTileResults addTile(
                 gltf,
                 primitive,
                 materialPaths,
-                0);
+                0,
+                smoothNormals);
             geomPaths.emplace_back(std::move(geomPath));
         });
 
@@ -1030,6 +1059,7 @@ AddTileResults addTileWithImagery(
     const glm::dmat4& ecefToUsdTransform,
     const glm::dmat4& tileTransform,
     const CesiumGltf::Model& model,
+    bool smoothNormals,
     const CesiumGltf::ImageCesium& image,
     const std::string& imageryName,
     const CesiumGeometry::Rectangle& imageryRectangle,
@@ -1082,7 +1112,8 @@ AddTileResults addTileWithImagery(
          &gltfToEcefTransform,
          &materialPaths,
          &geomPaths,
-         imageryUvSetIndex](
+         imageryUvSetIndex,
+         smoothNormals](
             const CesiumGltf::Model& gltf,
             [[maybe_unused]] const CesiumGltf::Node& node,
             [[maybe_unused]] const CesiumGltf::Mesh& mesh,
@@ -1099,7 +1130,8 @@ AddTileResults addTileWithImagery(
                 gltf,
                 primitive,
                 materialPaths,
-                imageryUvSetIndex);
+                imageryUvSetIndex,
+                smoothNormals);
             geomPaths.emplace_back(std::move(geomPath));
         });
 

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -185,6 +185,15 @@ bool OmniTileset::getSuspendUpdate() const {
     return suspendUpdate;
 }
 
+bool OmniTileset::getSmoothNormals() const {
+    auto tileset = UsdUtil::getCesiumTileset(_tilesetPath);
+
+    bool smoothNormals;
+    tileset.GetSmoothNormalsAttr().Get<bool>(&smoothNormals);
+
+    return smoothNormals;
+}
+
 int64_t OmniTileset::getTilesetId() const {
     return _tilesetId;
 }

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -263,6 +263,7 @@ pxr::CesiumTilesetAPI defineCesiumTileset(const pxr::SdfPath& path) {
     tileset.CreateEnforceCulledScreenSpaceErrorAttr(pxr::VtValue(true));
     tileset.CreateCulledScreenSpaceErrorAttr(pxr::VtValue(64.0f));
     tileset.CreateSuspendUpdateAttr(pxr::VtValue(false));
+    tileset.CreateSmoothNormalsAttr(pxr::VtValue(false));
 
     return tileset;
 }

--- a/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
+++ b/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in
@@ -90,6 +90,10 @@ class "CesiumTilesetSchemaAPI" (
         displayName = "Preload Siblings"
         doc = "Whether to preload sibling tiles. Setting this to true causes tiles with the same parent as a rendered tile to be loaded, even if they are culled. Setting this to true may provide a better panning experience at the cost of loading more tiles."
     )
+    bool cesium:smoothNormals = 0 (
+        displayName = "Smooth Normals"
+        doc = "Generate smooth normals instead of flat normals when normals are missing."
+    )
     bool cesium:suspendUpdate = 0 (
         displayName = "Suspend Update"
         doc = "Pauses level-of-detail and culling updates of this tileset."

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.cpp
@@ -331,6 +331,23 @@ CesiumTilesetAPI::CreateSuspendUpdateAttr(VtValue const &defaultValue, bool writ
                        writeSparsely);
 }
 
+UsdAttribute
+CesiumTilesetAPI::GetSmoothNormalsAttr() const
+{
+    return GetPrim().GetAttribute(CesiumTokens->cesiumSmoothNormals);
+}
+
+UsdAttribute
+CesiumTilesetAPI::CreateSmoothNormalsAttr(VtValue const &defaultValue, bool writeSparsely) const
+{
+    return UsdSchemaBase::_CreateAttr(CesiumTokens->cesiumSmoothNormals,
+                       SdfValueTypeNames->Bool,
+                       /* custom = */ false,
+                       SdfVariabilityVarying,
+                       defaultValue,
+                       writeSparsely);
+}
+
 namespace {
 static inline TfTokenVector
 _ConcatenateAttributeNames(const TfTokenVector& left,const TfTokenVector& right)
@@ -363,6 +380,7 @@ CesiumTilesetAPI::GetSchemaAttributeNames(bool includeInherited)
         CesiumTokens->cesiumEnforceCulledScreenSpaceError,
         CesiumTokens->cesiumCulledScreenSpaceError,
         CesiumTokens->cesiumSuspendUpdate,
+        CesiumTokens->cesiumSmoothNormals,
     };
     static TfTokenVector allNames =
         _ConcatenateAttributeNames(

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tilesetAPI.h
@@ -499,6 +499,27 @@ public:
                                        bool writeSparsely = false) const;
 
 public:
+  // --------------------------------------------------------------------- //
+  // SMOOTHNORMALS
+  // --------------------------------------------------------------------- //
+  /// Generate smooth normals instead of flat normals when normals are missing.
+  ///
+  /// | ||
+  /// | -- | -- |
+  /// | Declaration | `bool cesium:smoothNormals = 0` |
+  /// | C++ Type | bool |
+  /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->Bool |
+  UsdAttribute GetSmoothNormalsAttr() const;
+
+  /// See GetSmoothNormalsAttr(), and also
+  /// \ref Usd_Create_Or_Get_Property for when to use Get vs Create.
+  /// If specified, author \p defaultValue as the attribute's default,
+  /// sparsely (when it makes sense to do so) if \p writeSparsely is \c true -
+  /// the default for \p writeSparsely is \c false.
+  UsdAttribute CreateSmoothNormalsAttr(VtValue const &defaultValue = VtValue(),
+                                       bool writeSparsely = false) const;
+
+public:
   // ===================================================================== //
   // Feel free to add custom code below this line, it will be preserved by
   // the code generator.

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.cpp
@@ -21,6 +21,7 @@ CesiumTokensType::CesiumTokensType() :
     cesiumPreloadSiblings("cesium:preloadSiblings", TfToken::Immortal),
     cesiumProjectDefaultIonAccessToken("cesium:projectDefaultIonAccessToken", TfToken::Immortal),
     cesiumProjectDefaultIonAccessTokenId("cesium:projectDefaultIonAccessTokenId", TfToken::Immortal),
+    cesiumSmoothNormals("cesium:smoothNormals", TfToken::Immortal),
     cesiumSuspendUpdate("cesium:suspendUpdate", TfToken::Immortal),
     cesiumUrl("cesium:url", TfToken::Immortal),
     allTokens({
@@ -42,6 +43,7 @@ CesiumTokensType::CesiumTokensType() :
         cesiumPreloadSiblings,
         cesiumProjectDefaultIonAccessToken,
         cesiumProjectDefaultIonAccessTokenId,
+        cesiumSmoothNormals,
         cesiumSuspendUpdate,
         cesiumUrl
     })

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/tokens.h
@@ -111,6 +111,10 @@ struct CesiumTokensType {
     /// 
     /// CesiumData
     const TfToken cesiumProjectDefaultIonAccessTokenId;
+    /// \brief "cesium:smoothNormals"
+    /// 
+    /// CesiumTilesetAPI
+    const TfToken cesiumSmoothNormals;
     /// \brief "cesium:suspendUpdate"
     /// 
     /// CesiumTilesetAPI

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTilesetAPI.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTilesetAPI.cpp
@@ -130,6 +130,13 @@ _CreateSuspendUpdateAttr(CesiumTilesetAPI &self,
     return self.CreateSuspendUpdateAttr(
         UsdPythonToSdfType(defaultVal, SdfValueTypeNames->Bool), writeSparsely);
 }
+        
+static UsdAttribute
+_CreateSmoothNormalsAttr(CesiumTilesetAPI &self,
+                                      object defaultVal, bool writeSparsely) {
+    return self.CreateSmoothNormalsAttr(
+        UsdPythonToSdfType(defaultVal, SdfValueTypeNames->Bool), writeSparsely);
+}
 
 static std::string
 _Repr(const CesiumTilesetAPI &self)
@@ -275,6 +282,13 @@ void wrapCesiumTilesetAPI()
              &This::GetSuspendUpdateAttr)
         .def("CreateSuspendUpdateAttr",
              &_CreateSuspendUpdateAttr,
+             (arg("defaultValue")=object(),
+              arg("writeSparsely")=false))
+        
+        .def("GetSmoothNormalsAttr",
+             &This::GetSmoothNormalsAttr)
+        .def("CreateSmoothNormalsAttr",
+             &_CreateSmoothNormalsAttr,
              (arg("defaultValue")=object(),
               arg("writeSparsely")=false))
 

--- a/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
+++ b/src/plugins/CesiumUsdSchemas/src/CesiumUsdSchemas/wrapTokens.cpp
@@ -59,6 +59,7 @@ void wrapCesiumTokens()
     _AddToken(cls, "cesiumPreloadSiblings", CesiumTokens->cesiumPreloadSiblings);
     _AddToken(cls, "cesiumProjectDefaultIonAccessToken", CesiumTokens->cesiumProjectDefaultIonAccessToken);
     _AddToken(cls, "cesiumProjectDefaultIonAccessTokenId", CesiumTokens->cesiumProjectDefaultIonAccessTokenId);
+    _AddToken(cls, "cesiumSmoothNormals", CesiumTokens->cesiumSmoothNormals);
     _AddToken(cls, "cesiumSuspendUpdate", CesiumTokens->cesiumSuspendUpdate);
     _AddToken(cls, "cesiumUrl", CesiumTokens->cesiumUrl);
 }


### PR DESCRIPTION
If a glTF doesn't have normals we now generate flat normals by default. Or more accurately, Omniverse will generate flat normals if none are provided. Previously we would generate smooth normals which wasn't compliant with the glTF spec.

In case anyone wants to generate smooth normals, e.g. for photogrammetry tilesets, there is now a tileset option to do so.

Flat|Smooth
--|--
![flat](https://user-images.githubusercontent.com/915398/223876392-1084984a-8638-447a-be2b-568e7dccd53f.png)|![smooth](https://user-images.githubusercontent.com/915398/223876394-adcd1244-49fd-4ef2-acb5-c4c15ac59687.png)
