### PR TITLE
Fix transforming the tileset

### DIFF
--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -17,7 +17,6 @@
 
 namespace Cesium3DTilesSelection {
 class CreditSystem;
-class ViewState;
 } // namespace Cesium3DTilesSelection
 
 namespace CesiumGeospatial {
@@ -151,8 +150,6 @@ class Context {
     std::filesystem::path _certificatePath;
 
     bool _debugDisableMaterials{false};
-
-    std::vector<Cesium3DTilesSelection::ViewState> _viewStates;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -52,11 +52,11 @@ class OmniTileset {
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);
-    void onUpdateFrame(const std::vector<Cesium3DTilesSelection::ViewState>& viewStates);
+    void onUpdateFrame(const glm::dmat4& viewMatrix, const glm::dmat4& projMatrix, double width, double height);
 
   private:
     void updateTransform();
-    void updateView(const std::vector<Cesium3DTilesSelection::ViewState>& viewStates);
+    void updateView(const glm::dmat4& viewMatrix, const glm::dmat4& projMatrix, double width, double height);
 
     std::unique_ptr<Cesium3DTilesSelection::Tileset> _tileset;
     std::shared_ptr<FabricPrepareRenderResources> _renderResourcesPreparer;
@@ -65,5 +65,6 @@ class OmniTileset {
     pxr::SdfPath _tilesetPath;
     int64_t _tilesetId;
     glm::dmat4 _ecefToUsdTransform;
+    std::vector<Cesium3DTilesSelection::ViewState> _viewStates;
 };
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Cesium3DTilesSelection/ViewState.h>
 #include <CesiumUsdSchemas/data.h>
 #include <CesiumUsdSchemas/imagery.h>
 #include <CesiumUsdSchemas/tilesetAPI.h>
@@ -42,6 +43,14 @@ std::string getSafeName(const std::string& name);
 glm::dmat4 computeUsdToEcefTransform(const CesiumGeospatial::Cartographic& origin);
 glm::dmat4 computeEcefToUsdTransform(const CesiumGeospatial::Cartographic& origin);
 glm::dmat4 computeEcefToUsdTransformForPrim(const CesiumGeospatial::Cartographic& origin, const pxr::SdfPath& primPath);
+glm::dmat4 computeUsdToEcefTransformForPrim(const CesiumGeospatial::Cartographic& origin, const pxr::SdfPath& primPath);
+Cesium3DTilesSelection::ViewState computeViewState(
+    const CesiumGeospatial::Cartographic& origin,
+    const pxr::SdfPath& primPath,
+    const glm::dmat4& viewMatrix,
+    const glm::dmat4& projMatrix,
+    double width,
+    double height);
 pxr::GfRange3d computeWorldExtent(const pxr::GfRange3d& localExtent, const glm::dmat4& localToUsdTransform);
 
 pxr::CesiumData defineCesiumData(const pxr::SdfPath& path);


### PR DESCRIPTION
Fixes #166 

In the issue I had it backwards - instead of setting the transform in Cesium Native we can compute a unique view state per tileset like how cesium-unity does it.

Non-uniform scale is somewhat broken, and will trigger an assertion in our code is any components are zero. I think we can fix that later.

https://user-images.githubusercontent.com/915398/224388330-cf4216ea-f633-4307-a85f-2b9d237fc305.mp4

