### PR TITLE
Disable Fabric geometry streaming in testing app

### DIFF
--- a/apps/cesium.omniverse.app.kit
+++ b/apps/cesium.omniverse.app.kit
@@ -14,6 +14,7 @@ app = true
 app.asyncRendering = false
 app.useFabricSceneDelegate = true
 app.usdrt.scene_delegate.enableProxyCubes = false
+app.usdrt.scene_delegate.geometryStreaming.enabled = false
 
 [settings.app.exts]
 folders.'++' = ["${app}/../exts"] # Make extensions from this repo available.


### PR DESCRIPTION
Related to https://github.com/CesiumGS/cesium-omniverse/issues/214

Disable Fabric geometry streaming our testing application `cesium.omniverse.app.kit`. We do something similar in the Fabric modal: https://github.com/CesiumGS/cesium-omniverse/pull/220/files#diff-0d2e2fd1d2454d0e5e0ec998f53283845c71b35af89dc95c3f4d8dbbf49eb740R21