### PR TITLE
Fixed a crash when removing the last available token for a tileset

### DIFF
--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -277,6 +277,12 @@ void OmniTileset::addImageryIon(const pxr::SdfPath& imageryPath) {
     const OmniImagery imagery(imageryPath);
     const auto imageryIonAssetId = imagery.getIonAssetId();
     const auto imageryIonAccessToken = imagery.getIonAccessToken();
+
+    if (!imageryIonAccessToken.has_value()) {
+        // If we don't have an access token available there's no point in adding the imagery.
+        return;
+    }
+
     const auto imageryName = imagery.getName();
 
     const auto tilesetPath = getPath();


### PR DESCRIPTION
Resolves #226.

We are crashing when the user removes the last available token if a tileset and imagery are loaded. This is due to us having some unchecked access to an optional value in `OmniTileset::addImageryIon`. I added a check to bail out early from this function since without a token there is no reason to do any of the other work that frame.