### PR TITLE
Added word_wrap to the Asset Details header

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
@@ -97,8 +97,18 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
             if self._should_be_visible():
                 with ui.VStack(spacing=20):
                     with ui.VStack(spacing=5):
-                        ui.Label(self._name, style=CesiumOmniverseUiStyles.asset_detail_name_label, height=0)
-                        ui.Label(f"(ID: {self._id})", style=CesiumOmniverseUiStyles.asset_detail_id_label, height=0)
+                        ui.Label(
+                            self._name,
+                            style=CesiumOmniverseUiStyles.asset_detail_name_label,
+                            height=0,
+                            word_wrap=True,
+                        )
+                        ui.Label(
+                            f"(ID: {self._id})",
+                            style=CesiumOmniverseUiStyles.asset_detail_id_label,
+                            height=0,
+                            word_wrap=True,
+                        )
                     with ui.HStack(spacing=0, height=0):
                         ui.Spacer(height=0)
                         if self._asset_type == "3DTILES" or self._asset_type == "TERRAIN":


### PR DESCRIPTION
Resolves #223.

We were missing `word_wrap` on the label for the Asset Details panel header. This was causing long asset names to expand beyond the max size of the window.