### PR TITLE
Use same kit version as create 2022.3.3

### DIFF
--- a/extern/nvidia/deps/kit-sdk.packman.xml
+++ b/extern/nvidia/deps/kit-sdk.packman.xml
@@ -1,5 +1,5 @@
 <project toolsVersion="5.6">
   <dependency name="kit_sdk" linkPath="../_build/target-deps/kit-sdk/">
-    <package name="kit-sdk" version="104.2+release.295.529af2e4.tc.${platform}.release"/>
+    <package name="kit-sdk" version="104.2+release.275.6d591d71.tc.${platform}.release"/>
   </dependency>
 </project>


### PR DESCRIPTION
Our build uses a slightly ahead version of Kit SDK. I changed it back to `275.6d591d71` which is what Create 2022.3.3 uses. Generally we should be in lockstep with the official releases, I must have accidentally overlooked this.


![image](https://user-images.githubusercontent.com/915398/228896844-bcdf540c-df35-4ee9-a3e6-84e48e2c02c4.png)
