### PR TITLE
Update to cesium-native v0.23.0

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -24,6 +24,7 @@ add_external_project(
         tinyxml2
         uriparser
         webpdecoder
+        turbojpeg
     OPTIONS
         CESIUM_TESTS_ENABLED=OFF
         CESIUM_COVERAGE_ENABLED=OFF

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,6 +52,7 @@ setup_lib(
         tinyxml2
         uriparser
         webpdecoder
+        turbojpeg
         cpr::cpr
         stb::stb
         ZLIB::ZLIB


### PR DESCRIPTION
 Some of the highlights from the v0.23.0 release:

> * Switched to `libjpeg-turbo` instead of `stb` for faster jpeg decoding.
> * Changed how `TilesetOptions::forbidHoles` works so that it loads much more quickly, while still guaranteeing there are no holes in the tileset.
> * Fixed a bug that caused the main thread to sometimes load low-priority tiles before high-priority ones. This could result in much longer waits than necessary for a tileset's appropriate level-of-detail to be shown.