### PR TITLE
Statistics widget

### DIFF
--- a/apps/cesium.omniverse.app.kit
+++ b/apps/cesium.omniverse.app.kit
@@ -9,6 +9,8 @@ app = true
 "cesium.omniverse" = {}
 #"omni.example.ui" = {}
 #"omni.kit.documentation.ui.style" = {}
+#"omni.kit.debug.vscode" = {}
+#"omni.kit.debug.python" = {}
 
 [settings]
 app.window.title = "Cesium for Omniverse Test App"

--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -483,6 +483,11 @@ Each workspace contains recommended extensions and settings for VSCode developme
       "args": [
         "${workspaceFolder}/apps/cesium.omniverse.app.kit"
       ],
+      "env": {
+        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
+        "ASAN_OPTIONS": "detect_leaks=0",
+        "UBSAN_OPTIONS": "print_stacktrace=1"
+      },
       "cwd": "${workspaceFolder}",
       "type": "lldb",
       "request": "launch",
@@ -506,6 +511,11 @@ Each workspace contains recommended extensions and settings for VSCode developme
       "args": [
         "${workspaceFolder}/extern/nvidia/app/apps/omni.code.kit"
       ],
+      "env": {
+        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
+        "ASAN_OPTIONS": "detect_leaks=0",
+        "UBSAN_OPTIONS": "print_stacktrace=1"
+      },
       "cwd": "${workspaceFolder}",
       "type": "lldb",
       "request": "launch",
@@ -546,6 +556,13 @@ Each workspace contains recommended extensions and settings for VSCode developme
           "text": "set print elements 0"
         }
       ]
+    },
+    {
+      "name": "Python Debugging (attach)",
+      "type": "python",
+      "request": "attach",
+      "port": 3000,
+      "host": "localhost"
     }
   ]
 }
@@ -593,6 +610,13 @@ Each workspace contains recommended extensions and settings for VSCode developme
       "request": "launch",
       "console": "internalConsole",
       "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "name": "Python Debugging (attach)",
+      "type": "python",
+      "request": "attach",
+      "port": 3000,
+      "host": "localhost"
     }
   ]
 }

--- a/exts/cesium.omniverse/cesium/omniverse/ui/__init__.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/__init__.py
@@ -12,4 +12,5 @@ from .credits_window import CesiumOmniverseCreditsWindow  # noqa: F401
 from .credits_viewport_frame import CesiumCreditsViewportFrame  # noqa: F401
 from .credits_parser import CesiumCreditsParser  # noqa: F401
 from .search_field_widget import CesiumSearchFieldWidget  # noqa: F401
+from .statistics_widget import CesiumOmniverseStatisticsWidget  # noqa: F401
 from .models import *  # noqa: F401 F403

--- a/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 import omni.ui as ui
+from .statistics_widget import CesiumOmniverseStatisticsWidget
 from ..bindings import ICesiumOmniverseInterface
 
 
@@ -17,13 +18,21 @@ class CesiumOmniverseDebugWindow(ui.Window):
         self._logger = logging.getLogger(__name__)
         self._cesium_omniverse_interface = cesium_omniverse_interface
         self._cesium_message_field: Optional[ui.SimpleStringModel] = None
+        self._statistics_widget: Optional[CesiumOmniverseStatisticsWidget] = None
 
         # Set the function that is called to build widgets when the window is visible
         self.frame.set_build_fn(self._build_fn)
 
     def destroy(self):
+        if self._statistics_widget is not None:
+            self._statistics_widget.destroy()
+            self._statistics_widget = None
+
         # It will destroy all the children
         super().destroy()
+
+    def __del__(self):
+        self.destroy()
 
     def _build_fn(self):
         """Builds out the UI buttons and their handlers."""
@@ -57,3 +66,4 @@ class CesiumOmniverseDebugWindow(ui.Window):
             with ui.VStack():
                 self._cesium_message_field = ui.SimpleStringModel("")
                 ui.StringField(self._cesium_message_field, multiline=True, read_only=True)
+            self._statistics_widget = CesiumOmniverseStatisticsWidget(self._cesium_omniverse_interface)

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -1,0 +1,76 @@
+import carb.events
+import omni.kit.app as app
+import omni.ui as ui
+from typing import List, Optional
+from ..bindings import ICesiumOmniverseInterface
+
+
+class CesiumOmniverseStatisticsWidget(ui.Frame):
+    """
+    Widget that displays statistics about the scene.
+    """
+
+    NUMBER_OF_MATERIALS_LOADED_TEXT = "Number of materials loaded: {0}"
+    NUMBER_OF_GEOMETRIES_LOADED_TEXT = "Number of geometries loaded: {0}"
+    NUMBER_OF_GEOMETRIES_VISIBLE_TEXT = "Number of geometries visible: {0}"
+
+    def __init__(self, cesium_omniverse_interface: ICesiumOmniverseInterface, **kwargs):
+        super().__init__(build_fn=self._build_fn, **kwargs)
+
+        self._cesium_omniverse_interface = cesium_omniverse_interface
+
+        self._statistics_number_of_materials_loaded_field: Optional[ui.SimpleStringModel] = None
+        self._statistics_number_of_geometries_loaded_field: Optional[ui.SimpleStringModel] = None
+        self._statistics_number_of_geometries_visible_field: Optional[ui.SimpleStringModel] = None
+
+        self._subscriptions: List[carb.events.ISubscription] = []
+        self._setup_subscriptions()
+
+    def __del__(self):
+        self.destroy()
+
+    def destroy(self):
+        for subscription in self._subscriptions:
+            subscription.unsubscribe()
+        self._subscriptions.clear()
+
+        super().destroy()
+
+    def _setup_subscriptions(self):
+        update_stream = app.get_app().get_update_event_stream()
+        self._subscriptions.append(
+            update_stream.create_subscription_to_pop(self._on_update_frame, name="on_update_frame")
+        )
+
+    def _on_update_frame(self, _e: carb.events.IEvent):
+        if not self.visible:
+            return
+
+        fabric_statistics = self._cesium_omniverse_interface.get_fabric_statistics()
+        self._statistics_number_of_materials_loaded_field.set_value(
+            CesiumOmniverseStatisticsWidget.NUMBER_OF_MATERIALS_LOADED_TEXT.format(
+                fabric_statistics.number_of_materials_loaded
+            )
+        )
+        self._statistics_number_of_geometries_loaded_field.set_value(
+            CesiumOmniverseStatisticsWidget.NUMBER_OF_GEOMETRIES_LOADED_TEXT.format(
+                fabric_statistics.number_of_geometries_loaded
+            )
+        )
+        self._statistics_number_of_geometries_visible_field.set_value(
+            CesiumOmniverseStatisticsWidget.NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(
+                fabric_statistics.number_of_geometries_visible
+            )
+        )
+
+    def _build_fn(self):
+        """Builds all UI components."""
+
+        with ui.VStack():
+            ui.Label("Statistics", height=0)
+            self._statistics_number_of_materials_loaded_field = ui.SimpleStringModel("")
+            self._statistics_number_of_geometries_loaded_field = ui.SimpleStringModel("")
+            self._statistics_number_of_geometries_visible_field = ui.SimpleStringModel("")
+            ui.StringField(self._statistics_number_of_materials_loaded_field, height=0, read_only=True)
+            ui.StringField(self._statistics_number_of_geometries_loaded_field, height=0, read_only=True)
+            ui.StringField(self._statistics_number_of_geometries_visible_field, height=0, read_only=True)

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -1,7 +1,7 @@
 import carb.events
 import omni.kit.app as app
 import omni.ui as ui
-from typing import List, Optional
+from typing import List
 from ..bindings import ICesiumOmniverseInterface
 
 NUMBER_OF_MATERIALS_LOADED_TEXT = "Number of materials loaded: {0}"

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -4,24 +4,24 @@ import omni.ui as ui
 from typing import List, Optional
 from ..bindings import ICesiumOmniverseInterface
 
+NUMBER_OF_MATERIALS_LOADED_TEXT = "Number of materials loaded: {0}"
+NUMBER_OF_GEOMETRIES_LOADED_TEXT = "Number of geometries loaded: {0}"
+NUMBER_OF_GEOMETRIES_VISIBLE_TEXT = "Number of geometries visible: {0}"
+
 
 class CesiumOmniverseStatisticsWidget(ui.Frame):
     """
     Widget that displays statistics about the scene.
     """
 
-    NUMBER_OF_MATERIALS_LOADED_TEXT = "Number of materials loaded: {0}"
-    NUMBER_OF_GEOMETRIES_LOADED_TEXT = "Number of geometries loaded: {0}"
-    NUMBER_OF_GEOMETRIES_VISIBLE_TEXT = "Number of geometries visible: {0}"
-
     def __init__(self, cesium_omniverse_interface: ICesiumOmniverseInterface, **kwargs):
         super().__init__(build_fn=self._build_fn, **kwargs)
 
         self._cesium_omniverse_interface = cesium_omniverse_interface
 
-        self._statistics_number_of_materials_loaded_field: Optional[ui.SimpleStringModel] = None
-        self._statistics_number_of_geometries_loaded_field: Optional[ui.SimpleStringModel] = None
-        self._statistics_number_of_geometries_visible_field: Optional[ui.SimpleStringModel] = None
+        self._statistics_number_of_materials_loaded_field: ui.SimpleStringModel = ui.SimpleStringModel("")
+        self._statistics_number_of_geometries_loaded_field: ui.SimpleStringModel = ui.SimpleStringModel("")
+        self._statistics_number_of_geometries_visible_field: ui.SimpleStringModel = ui.SimpleStringModel("")
 
         self._subscriptions: List[carb.events.ISubscription] = []
         self._setup_subscriptions()
@@ -48,19 +48,13 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
 
         fabric_statistics = self._cesium_omniverse_interface.get_fabric_statistics()
         self._statistics_number_of_materials_loaded_field.set_value(
-            CesiumOmniverseStatisticsWidget.NUMBER_OF_MATERIALS_LOADED_TEXT.format(
-                fabric_statistics.number_of_materials_loaded
-            )
+            NUMBER_OF_MATERIALS_LOADED_TEXT.format(fabric_statistics.number_of_materials_loaded)
         )
         self._statistics_number_of_geometries_loaded_field.set_value(
-            CesiumOmniverseStatisticsWidget.NUMBER_OF_GEOMETRIES_LOADED_TEXT.format(
-                fabric_statistics.number_of_geometries_loaded
-            )
+            NUMBER_OF_GEOMETRIES_LOADED_TEXT.format(fabric_statistics.number_of_geometries_loaded)
         )
         self._statistics_number_of_geometries_visible_field.set_value(
-            CesiumOmniverseStatisticsWidget.NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(
-                fabric_statistics.number_of_geometries_visible
-            )
+            NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(fabric_statistics.number_of_geometries_visible)
         )
 
     def _build_fn(self):
@@ -68,9 +62,6 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
 
         with ui.VStack():
             ui.Label("Statistics", height=0)
-            self._statistics_number_of_materials_loaded_field = ui.SimpleStringModel("")
-            self._statistics_number_of_geometries_loaded_field = ui.SimpleStringModel("")
-            self._statistics_number_of_geometries_visible_field = ui.SimpleStringModel("")
             ui.StringField(self._statistics_number_of_materials_loaded_field, height=0, read_only=True)
             ui.StringField(self._statistics_number_of_geometries_loaded_field, height=0, read_only=True)
             ui.StringField(self._statistics_number_of_geometries_visible_field, height=0, read_only=True)

--- a/include/cesium/omniverse/CesiumOmniverse.h
+++ b/include/cesium/omniverse/CesiumOmniverse.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cesium/omniverse/FabricStatistics.h"
 #include "cesium/omniverse/SetDefaultTokenResult.h"
 #include "cesium/omniverse/TokenTroubleshooter.h"
 
@@ -237,6 +238,13 @@ class ICesiumOmniverseInterface {
      * @returns A string representation of the Fabric stage.
      */
     virtual std::string printFabricStage() noexcept = 0;
+
+    /**
+     * @brief Get Fabric statistics. For debugging only.
+     *
+     * @returns Object containing Fabric statistics.
+     */
+    virtual FabricStatistics getFabricStatistics() noexcept = 0;
 
     virtual bool creditsAvailable() noexcept = 0;
     virtual std::vector<std::pair<std::string, bool>> getCredits() noexcept = 0;

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -1,4 +1,7 @@
+#include "cesium/omniverse/CesiumIonSession.h"
 #include "cesium/omniverse/CesiumOmniverse.h"
+#include "cesium/omniverse/FabricStatistics.h"
+#include "cesium/omniverse/TokenTroubleshooter.h"
 
 #include <Cesium3DTilesSelection/CreditSystem.h>
 #include <carb/BindingsPythonUtils.h>
@@ -7,9 +10,6 @@
 
 // Needs to go after carb
 #include "pyboost11.h"
-
-#include "cesium/omniverse/CesiumIonSession.h"
-#include "cesium/omniverse/TokenTroubleshooter.h"
 
 namespace pybind11 {
 namespace detail {
@@ -59,6 +59,7 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def("update_troubleshooting_details", py::overload_cast<const char*, int64_t, uint64_t, uint64_t>(&ICesiumOmniverseInterface::updateTroubleshootingDetails))
         .def("update_troubleshooting_details", py::overload_cast<const char*, int64_t, int64_t, uint64_t, uint64_t>(&ICesiumOmniverseInterface::updateTroubleshootingDetails))
         .def("print_fabric_stage", &ICesiumOmniverseInterface::printFabricStage)
+        .def("get_fabric_statistics", &ICesiumOmniverseInterface::getFabricStatistics)
         .def("credits_available", &ICesiumOmniverseInterface::creditsAvailable)
         .def("get_credits", &ICesiumOmniverseInterface::getCredits);
     // clang-format on
@@ -126,4 +127,9 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
     py::class_<AssetTroubleshootingDetails>(m, "AssetTroubleshootingDetails")
         .def_readonly("asset_id", &AssetTroubleshootingDetails::assetId)
         .def_readonly("asset_exists_in_user_account", &AssetTroubleshootingDetails::assetExistsInUserAccount);
+
+    py::class_<FabricStatistics>(m, "FabricStatistics")
+        .def_readonly("number_of_materials_loaded", &FabricStatistics::numberOfMaterialsLoaded)
+        .def_readonly("number_of_geometries_loaded", &FabricStatistics::numberOfGeometriesLoaded)
+        .def_readonly("number_of_geometries_visible", &FabricStatistics::numberOfGeometriesVisible);
 }

--- a/src/core/include/cesium/omniverse/FabricStatistics.h
+++ b/src/core/include/cesium/omniverse/FabricStatistics.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace cesium::omniverse {
+struct FabricStatistics {
+    uint64_t numberOfMaterialsLoaded{0};
+    uint64_t numberOfGeometriesLoaded{0};
+    uint64_t numberOfGeometriesVisible{0};
+};
+} // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "cesium/omniverse/FabricStatistics.h"
+
 #include <string>
 
 namespace cesium::omniverse::FabricUtil {
 
 std::string printFabricStage();
+FabricStatistics getStatistics();
 
 } // namespace cesium::omniverse::FabricUtil

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -516,11 +516,8 @@ FabricStatistics getStatistics() {
 
         auto worldVisibilityFabric =
             sip.getAttributeArrayRd<bool>(geometryBuckets, bucketId, FabricTokens::_worldVisibility);
-        for (size_t i = 0; i < worldVisibilityFabric.size(); i++) {
-            if (worldVisibilityFabric[i]) {
-                statistics.numberOfGeometriesVisible++;
-            }
-        }
+        statistics.numberOfGeometriesVisible +=
+            std::count(worldVisibilityFabric.begin(), worldVisibilityFabric.end(), true);
     }
 
     for (size_t bucketId = 0; bucketId < materialBuckets.bucketCount(); bucketId++) {

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -497,4 +497,38 @@ std::string printFabricStage() {
     return stream.str();
 }
 
+FabricStatistics getStatistics() {
+    FabricStatistics statistics;
+
+    auto sip = UsdUtil::getFabricStageInProgress();
+
+    const auto geometryBuckets = sip.findPrims(
+        {carb::flatcache::AttrNameAndType(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId)},
+        {carb::flatcache::AttrNameAndType(FabricTypes::Mesh, FabricTokens::Mesh)});
+
+    const auto materialBuckets = sip.findPrims(
+        {carb::flatcache::AttrNameAndType(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId)},
+        {carb::flatcache::AttrNameAndType(FabricTypes::Material, FabricTokens::Material)});
+
+    for (size_t bucketId = 0; bucketId < geometryBuckets.bucketCount(); bucketId++) {
+        auto paths = sip.getPathArray(geometryBuckets, bucketId);
+        statistics.numberOfGeometriesLoaded += paths.size();
+
+        auto worldVisibilityFabric =
+            sip.getAttributeArrayRd<bool>(geometryBuckets, bucketId, FabricTokens::_worldVisibility);
+        for (size_t i = 0; i < worldVisibilityFabric.size(); i++) {
+            if (worldVisibilityFabric[i]) {
+                statistics.numberOfGeometriesVisible++;
+            }
+        }
+    }
+
+    for (size_t bucketId = 0; bucketId < materialBuckets.bucketCount(); bucketId++) {
+        auto paths = sip.getPathArray(materialBuckets, bucketId);
+        statistics.numberOfMaterialsLoaded += paths.size();
+    }
+
+    return statistics;
+}
+
 } // namespace cesium::omniverse::FabricUtil

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -172,6 +172,10 @@ class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
         return FabricUtil::printFabricStage();
     }
 
+    FabricStatistics getFabricStatistics() noexcept override {
+        return FabricUtil::getStatistics();
+    }
+
     bool creditsAvailable() noexcept override {
         return Context::instance().creditsAvailable();
     }


### PR DESCRIPTION
Adds a statistics widget to the Cesium Debugging window that shows number of materials and geometries in the scene. 

Originally I was going to make this a viewport overlay but I think it's fine in the Cesium Debugging window where the UI style isn't so important and there's more space. Also, there's a cost to gathering these statistics each frame. It only runs if the Cesium Debugging window is in the dock.

Aside from that I also added some stuff to help with Python debugging. I wanted to enable the omni debug extensions by default in our test app but it doesn't dock by default. So I left those extensions commented out.

![statistics](https://user-images.githubusercontent.com/915398/234620035-e2a79227-172d-4734-8d1e-eedd9752abd5.png)