### PR TITLE
Fix type for tilesetId and tileId

### DIFF
--- a/src/core/include/cesium/omniverse/FabricAttributesBuilder.h
+++ b/src/core/include/cesium/omniverse/FabricAttributesBuilder.h
@@ -7,7 +7,7 @@ namespace cesium::omniverse {
 class FabricAttributesBuilder {
   public:
     void addAttribute(const carb::flatcache::Type& type, const carb::flatcache::TokenC& name);
-    void createAttributes(const carb::flatcache::Path& path);
+    void createAttributes(const carb::flatcache::Path& path) const;
 
   private:
     static const uint64_t MAX_ATTRIBUTES = 30;

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -171,8 +171,8 @@ const carb::flatcache::Type visibility(carb::flatcache::BaseDataType::eBool, 1, 
 const carb::flatcache::Type wrap_u(carb::flatcache::BaseDataType::eInt, 1, 0, carb::flatcache::AttributeRole::eNone);
 const carb::flatcache::Type wrap_v(carb::flatcache::BaseDataType::eInt, 1, 0, carb::flatcache::AttributeRole::eNone);
 const carb::flatcache::Type _cesium_localToEcefTransform(carb::flatcache::BaseDataType::eDouble, 16, 0, carb::flatcache::AttributeRole::eMatrix);
-const carb::flatcache::Type _cesium_tileId(carb::flatcache::BaseDataType::eUInt64, 1, 0, carb::flatcache::AttributeRole::eNone);
-const carb::flatcache::Type _cesium_tilesetId(carb::flatcache::BaseDataType::eUInt64, 1, 0, carb::flatcache::AttributeRole::eNone);
+const carb::flatcache::Type _cesium_tileId(carb::flatcache::BaseDataType::eInt64, 1, 0, carb::flatcache::AttributeRole::eNone);
+const carb::flatcache::Type _cesium_tilesetId(carb::flatcache::BaseDataType::eInt64, 1, 0, carb::flatcache::AttributeRole::eNone);
 const carb::flatcache::Type _localExtent(carb::flatcache::BaseDataType::eDouble, 6, 0, carb::flatcache::AttributeRole::eNone);
 const carb::flatcache::Type _localMatrix(carb::flatcache::BaseDataType::eDouble, 16, 0, carb::flatcache::AttributeRole::eMatrix);
 const carb::flatcache::Type _nodePaths(carb::flatcache::BaseDataType::eUInt64, 1, 1, carb::flatcache::AttributeRole::eNone);

--- a/src/core/src/FabricAttributesBuilder.cpp
+++ b/src/core/src/FabricAttributesBuilder.cpp
@@ -8,7 +8,7 @@ void FabricAttributesBuilder::addAttribute(const carb::flatcache::Type& type, co
     _attributes[_size++] = carb::flatcache::AttrNameAndType{type, name};
 }
 
-void FabricAttributesBuilder::createAttributes(const carb::flatcache::Path& path) {
+void FabricAttributesBuilder::createAttributes(const carb::flatcache::Path& path) const {
     // Somewhat annoyingly, stageInProgress.createAttributes takes an std::array instead of a gsl::span. This is fine if
     // you know exactly which set of attributes to create at compile time but we don't. For example, not all prims will
     // have UV coordinates or materials. This class allows attributes to be added dynamically up to a hardcoded maximum


### PR DESCRIPTION
Copying over some changes from the [pool](https://github.com/CesiumGS/cesium-omniverse/tree/pool) branch:

* Fixes a mismatch between the Fabric type and the internal type. `tilesetId` and `tileId` should be `int64` everywhere.
* Adds some missing `const`