### PR TITLE
GltfUtil cleanup

### DIFF
--- a/src/core/include/cesium/omniverse/FabricStageUtil.h
+++ b/src/core/include/cesium/omniverse/FabricStageUtil.h
@@ -40,9 +40,9 @@ AddTileResults addTileWithImagery(
     const CesiumGltf::ImageCesium& image,
     const std::string& imageryName,
     const CesiumGeometry::Rectangle& imageryRectangle,
-    const glm::dvec2& imageryUvTranslation,
-    const glm::dvec2& imageryUvScale,
-    uint64_t imageryUvSetIndex);
+    const glm::dvec2& imageryTexcoordTranslation,
+    const glm::dvec2& imageryTexcoordScale,
+    uint64_t imageryTexcoordSetIndex);
 
 void removeTile(const std::vector<pxr::SdfPath>& allPrimPaths, const std::vector<std::string>& textureAssetNames);
 void setTileVisibility(const std::vector<pxr::SdfPath>& geomPaths, bool visible);

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -14,40 +14,58 @@ struct Texture;
 
 namespace cesium::omniverse::GltfUtil {
 
-pxr::VtArray<pxr::GfVec3f>
-getPrimitivePositions(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+pxr::VtArray<pxr::GfVec3f> getPositions(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-std::optional<pxr::GfRange3d>
-getPrimitiveExtent(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+std::optional<pxr::GfRange3d> getExtent(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-pxr::VtArray<int> getPrimitiveIndices(
+pxr::VtArray<int> getIndices(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     const pxr::VtArray<pxr::GfVec3f>& positions);
 
-pxr::VtArray<pxr::GfVec3f> getPrimitiveNormals(
+pxr::VtArray<pxr::GfVec3f> getNormals(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     const pxr::VtArray<pxr::GfVec3f>& positions,
     const pxr::VtArray<int>& indices,
     bool smoothNormals);
 
-pxr::VtArray<pxr::GfVec2f>
-getPrimitiveUVs(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
+pxr::VtArray<pxr::GfVec2f> getTexcoords(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    uint64_t setIndex,
+    const glm::fvec2& translation,
+    const glm::fvec2& scale);
 
-pxr::VtArray<int> getPrimitiveFaceVertexCounts(const pxr::VtArray<int>& indices);
+pxr::VtArray<int> getFaceVertexCounts(const pxr::VtArray<int>& indices);
 
 pxr::GfVec3f getBaseColorFactor(const CesiumGltf::Material& material);
 float getMetallicFactor(const CesiumGltf::Material& material);
 float getRoughnessFactor(const CesiumGltf::Material& material);
 
+pxr::GfVec3f getDefaultBaseColorFactor();
+float getDefaultMetallicFactor();
+float getDefaultRoughnessFactor();
+
 std::optional<uint64_t> getBaseColorTextureIndex(const CesiumGltf::Model& model, const CesiumGltf::Material& material);
 
 bool getDoubleSided(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-pxr::VtArray<pxr::GfVec2f>
-getImageryUVs(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
+pxr::VtArray<pxr::GfVec2f> getImageryTexcoords(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    uint64_t setIndex,
+    const glm::fvec2& translation,
+    const glm::fvec2& scale);
 
 const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, const CesiumGltf::Texture& texture);
+
+bool hasNormals(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, bool smoothNormals);
+
+bool hasTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
+
+bool hasImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
+
+bool hasMaterial(const CesiumGltf::MeshPrimitive& primitive);
 
 } // namespace cesium::omniverse::GltfUtil

--- a/src/core/src/FabricAttributesBuilder.cpp
+++ b/src/core/src/FabricAttributesBuilder.cpp
@@ -11,7 +11,7 @@ void FabricAttributesBuilder::addAttribute(const carb::flatcache::Type& type, co
 void FabricAttributesBuilder::createAttributes(const carb::flatcache::Path& path) {
     // Somewhat annoyingly, stageInProgress.createAttributes takes an std::array instead of a gsl::span. This is fine if
     // you know exactly which set of attributes to create at compile time but we don't. For example, not all prims will
-    // have UV coordinates or materials. This class allows attributes to be added dynamically up to a hardcoded maximum
+    // have texture coordinates or materials. This class allows attributes to be added dynamically up to a hardcoded maximum
     // count (MAX_ATTRIBUTES) and avoids heap allocations. The downside is that we need this ugly if/else chain below.
 
     auto stageInProgress = UsdUtil::getFabricStageInProgress();

--- a/src/core/src/FabricStageUtil.cpp
+++ b/src/core/src/FabricStageUtil.cpp
@@ -318,8 +318,8 @@ std::vector<pxr::SdfPath> addMaterialImagery(
     const pxr::SdfPath& materialPath,
     const pxr::SdfAssetPath& textureAssetPath,
     const CesiumGltf::Material& material,
-    const glm::dvec2& uvTranslation,
-    const glm::dvec2& uvScale) {
+    const glm::dvec2& texcoordTranslation,
+    const glm::dvec2& texcoordScale) {
     auto sip = UsdUtil::getFabricStageInProgress();
 
     const auto metallicFactor = GltfUtil::getMetallicFactor(material);
@@ -618,7 +618,7 @@ std::vector<pxr::SdfPath> addMaterialImagery(
         auto tileIdFabric = sip.getAttributeWr<int64_t>(multiplyPathFabric, FabricTokens::_cesium_tileId);
         // clang-format on
 
-        *bFabric = pxr::GfVec2f(static_cast<float>(uvScale.x), static_cast<float>(uvScale.y));
+        *bFabric = pxr::GfVec2f(static_cast<float>(texcoordScale.x), static_cast<float>(texcoordScale.y));
         *infoIdFabric = FabricTokens::nvidia_support_definitions_mdl;
         *infoSourceAssetSubIdentifierFabric = FabricTokens::multiply_float2_float2;
         parametersFabric[0] = FabricTokens::b;
@@ -658,7 +658,7 @@ std::vector<pxr::SdfPath> addMaterialImagery(
         auto tileIdFabric = sip.getAttributeWr<int64_t>(addPathFabric, FabricTokens::_cesium_tileId);
         // clang-format on
 
-        *bFabric = pxr::GfVec2f(static_cast<float>(uvTranslation.x), static_cast<float>(uvTranslation.y));
+        *bFabric = pxr::GfVec2f(static_cast<float>(texcoordTranslation.x), static_cast<float>(texcoordTranslation.y));
         *infoIdFabric = FabricTokens::nvidia_support_definitions_mdl;
         *infoSourceAssetSubIdentifierFabric = FabricTokens::add_float2_float2;
         parametersFabric[0] = FabricTokens::b;
@@ -739,19 +739,20 @@ void addPrimitive(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     const std::vector<pxr::SdfPath>& materialPaths,
-    uint64_t imageryUvSetIndex,
+    uint64_t imageryTexcoordSetIndex,
     bool smoothNormals) {
 
     auto sip = UsdUtil::getFabricStageInProgress();
     const auto geomPathFabric = carb::flatcache::Path(carb::flatcache::asInt(geomPath));
 
-    const auto positions = GltfUtil::getPrimitivePositions(model, primitive);
-    const auto indices = GltfUtil::getPrimitiveIndices(model, primitive, positions);
-    const auto normals = GltfUtil::getPrimitiveNormals(model, primitive, positions, indices, smoothNormals);
-    const auto st0 = GltfUtil::getPrimitiveUVs(model, primitive, 0);
-    const auto imagerySt = GltfUtil::getImageryUVs(model, primitive, imageryUvSetIndex);
-    const auto localExtent = GltfUtil::getPrimitiveExtent(model, primitive);
-    const auto faceVertexCounts = GltfUtil::getPrimitiveFaceVertexCounts(indices);
+    const auto positions = GltfUtil::getPositions(model, primitive);
+    const auto indices = GltfUtil::getIndices(model, primitive, positions);
+    const auto normals = GltfUtil::getNormals(model, primitive, positions, indices, smoothNormals);
+    const auto st0 = GltfUtil::getTexcoords(model, primitive, 0, glm::fvec2(0.0, 0.0), glm::fvec2(1.0, 1.0));
+    const auto imagerySt = GltfUtil::getImageryTexcoords(
+        model, primitive, imageryTexcoordSetIndex, glm::fvec2(0.0, 0.0), glm::fvec2(1.0, 1.0));
+    const auto localExtent = GltfUtil::getExtent(model, primitive);
+    const auto faceVertexCounts = GltfUtil::getFaceVertexCounts(indices);
     const auto doubleSided = GltfUtil::getDoubleSided(model, primitive);
 
     if (positions.empty() || indices.empty() || !localExtent.has_value()) {
@@ -1063,9 +1064,9 @@ AddTileResults addTileWithImagery(
     const CesiumGltf::ImageCesium& image,
     const std::string& imageryName,
     const CesiumGeometry::Rectangle& imageryRectangle,
-    const glm::dvec2& imageryUvTranslation,
-    const glm::dvec2& imageryUvScale,
-    uint64_t imageryUvSetIndex) {
+    const glm::dvec2& imageryTexcoordTranslation,
+    const glm::dvec2& imageryTexcoordScale,
+    uint64_t imageryTexcoordSetIndex) {
     auto gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyRtcCenter(model, tileTransform);
     gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyGltfUpAxisTransform(model, gltfToEcefTransform);
 
@@ -1088,8 +1089,8 @@ AddTileResults addTileWithImagery(
                 materialPath,
                 imageryAssetPath.assetPath,
                 model.materials[i],
-                imageryUvTranslation,
-                imageryUvScale);
+                imageryTexcoordTranslation,
+                imageryTexcoordScale);
 
             materialPaths.emplace_back(std::move(materialPath));
             allPrimPaths.insert(
@@ -1112,7 +1113,7 @@ AddTileResults addTileWithImagery(
          &gltfToEcefTransform,
          &materialPaths,
          &geomPaths,
-         imageryUvSetIndex,
+         imageryTexcoordSetIndex,
          smoothNormals](
             const CesiumGltf::Model& gltf,
             [[maybe_unused]] const CesiumGltf::Node& node,
@@ -1130,7 +1131,7 @@ AddTileResults addTileWithImagery(
                 gltf,
                 primitive,
                 materialPaths,
-                imageryUvSetIndex,
+                imageryTexcoordSetIndex,
                 smoothNormals);
             geomPaths.emplace_back(std::move(geomPath));
         });


### PR DESCRIPTION
Copying over some changes from the [pool](https://github.com/CesiumGS/cesium-omniverse/tree/pool) branch:

* Adds more helper functions to `GltfUtil`
  * `getDefaultBaseColorFactor`
  * `getDefaultMetallicFactor`
  * `getDefaultRoughnessFactor`
  * `hasNormals`
  * `hasTexcoords`
  * `hasImageryTexcoords`
  * `hasMaterial`
* Renamed `uv` to `texcoord` except when interacting with Fabric where the property is called `st`
* Ability to bake translation and scale into texcoords (used by the `pool` branch)