### PR TITLE
Fix adding imagery to existing tileset

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
@@ -78,7 +78,7 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
         if len(selection) > 0 and self._cesium_omniverse_interface.is_tileset(selection[0]):
             tileset_path = selection[0]
 
-        if tileset_path is not None:
+        if tileset_path is None:
             all_tileset_paths = self._cesium_omniverse_interface.get_all_tileset_paths()
 
             if len(all_tileset_paths) > 0:


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/CesiumGS/cesium-omniverse/pull/204 when adding imagery to an existing tileset. I thought this bug was fixed already in another PR but I guess not.