### PR TITLE
Only select tiles when tileset is visible

### DIFF
--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -348,7 +348,9 @@ void OmniTileset::updateTransform() {
 }
 
 void OmniTileset::updateView(const std::vector<Viewport>& viewports) {
-    if (!getSuspendUpdate()) {
+    const auto visible = UsdUtil::isPrimVisible(_tilesetPath);
+
+    if (visible && !getSuspendUpdate()) {
         // Go ahead and select some tiles
         const auto& georeferenceOrigin = Context::instance().getGeoreferenceOrigin();
 
@@ -364,8 +366,6 @@ void OmniTileset::updateView(const std::vector<Viewport>& viewports) {
         // No tiles have ever been selected. Return early.
         return;
     }
-
-    const auto visible = UsdUtil::isPrimVisible(_tilesetPath);
 
     // Hide tiles that we no longer need
     for (const auto tile : _pViewUpdateResult->tilesFadingOut) {


### PR DESCRIPTION
While it could be useful to load tiles when a tileset is hidden (see [`preloadTilesWhenHidden`](https://cesium.com/learn/cesiumjs/ref-doc/Cesium3DTileset.html#preloadWhenHidden) in CesiumJS), this shouldn't be the default behavior. Another positive side effect of this fix is that credits aren't show when the tileset is hidden.