### PR TITLE
Enable async rendering in cesium.omniverse.app.kit

### DIFF
--- a/apps/cesium.omniverse.app.kit
+++ b/apps/cesium.omniverse.app.kit
@@ -14,7 +14,6 @@ app = true
 
 [settings]
 app.window.title = "Cesium for Omniverse Test App"
-app.asyncRendering = false
 app.useFabricSceneDelegate = true
 app.usdrt.scene_delegate.enableProxyCubes = false
 app.usdrt.scene_delegate.geometryStreaming.enabled = false


### PR DESCRIPTION
Originally we needed to set `app.asyncRendering = false` to work with Fabric, but this is no longer required.

`asyncRendering` is true by default so we can just remove the entry from `cesium.omniverse.app.kit`.