### PR TITLE
Fix debug statistics crash

### DIFF
--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -500,6 +500,10 @@ std::string printFabricStage() {
 FabricStatistics getStatistics() {
     FabricStatistics statistics;
 
+    if (!UsdUtil::hasStage()) {
+        return statistics;
+    }
+
     auto sip = UsdUtil::getFabricStageInProgress();
 
     const auto geometryBuckets = sip.findPrims(


### PR DESCRIPTION
If you have the Cesium Debugging window open and reload the stage there's a moment where no stage exists and `getStatistics` will crash. The fix is to return early if no stage exists.