### PR TITLE
Added premake5.lua files to better support Kit templates

### DIFF
--- a/exts/cesium.omniverse/premake5.lua
+++ b/exts/cesium.omniverse/premake5.lua
@@ -1,0 +1,10 @@
+local ext = get_current_extension_info()
+
+project_ext (ext)
+
+-- Link only those files and folders into the extension target directory
+repo_build.prebuild_link { "bin", ext.target_dir.."/bin" }
+repo_build.prebuild_link { "certs", ext.target_dir.."/certs" }
+repo_build.prebuild_link { "cesium", ext.target_dir.."/cesium" }
+repo_build.prebuild_link { "doc", ext.target_dir.."/doc" }
+repo_build.prebuild_link { "images", ext.target_dir.."/images" }

--- a/exts/cesium.usd.plugins/premake5.lua
+++ b/exts/cesium.usd.plugins/premake5.lua
@@ -1,0 +1,10 @@
+local ext = get_current_extension_info()
+
+project_ext (ext)
+
+-- Link only those files and folders into the extension target directory
+repo_build.prebuild_link { "bin", ext.target_dir.."/bin" }
+repo_build.prebuild_link { "cesium", ext.target_dir.."/cesium" }
+repo_build.prebuild_link { "doc", ext.target_dir.."/doc" }
+repo_build.prebuild_link { "plugins", ext.target_dir.."/plugins" }
+repo_build.prebuild_link { "schemas", ext.target_dir.."/schemas" }


### PR DESCRIPTION
These are used by several of the Kit templates, including the Kit Application template. This way installing the extension into a Kit app template is as simple as dragging and dropping our extensions into the extensions folder.