### PR TITLE
Add more render statistics

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/bindings/CesiumOmniversePythonBindings.pyi
+++ b/exts/cesium.omniverse/cesium/omniverse/bindings/CesiumOmniversePythonBindings.pyi
@@ -10,7 +10,6 @@ __all__ = [
     "TokenTroubleshootingDetails",
     "AssetTroubleshootingDetails",
     "RenderStatistics",
-    "FabricStatistics",
     "Viewport",
     "acquire_cesium_omniverse_interface",
     "release_cesium_omniverse_interface",

--- a/exts/cesium.omniverse/cesium/omniverse/bindings/CesiumOmniversePythonBindings.pyi
+++ b/exts/cesium.omniverse/cesium/omniverse/bindings/CesiumOmniversePythonBindings.pyi
@@ -9,6 +9,7 @@ __all__ = [
     "Token",
     "TokenTroubleshootingDetails",
     "AssetTroubleshootingDetails",
+    "RenderStatistics",
     "FabricStatistics",
     "Viewport",
     "acquire_cesium_omniverse_interface",

--- a/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
@@ -17,7 +17,7 @@ class CesiumOmniverseDebugWindow(ui.Window):
 
         self._logger = logging.getLogger(__name__)
         self._cesium_omniverse_interface = cesium_omniverse_interface
-        self._cesium_message_field: Optional[ui.SimpleStringModel] = None
+        self._cesium_message_field: ui.SimpleStringModel = ui.SimpleStringModel("")
         self._statistics_widget: Optional[CesiumOmniverseStatisticsWidget] = None
 
         # Set the function that is called to build widgets when the window is visible
@@ -60,10 +60,8 @@ class CesiumOmniverseDebugWindow(ui.Window):
             self._cesium_message_field.set_value(fabric_stage)
 
         with ui.VStack():
-            ui.Button("Remove all Tilesets", clicked_fn=lambda: remove_all_tilesets())
-            ui.Button("Reload all Tilesets", clicked_fn=lambda: reload_all_tilesets())
-            ui.Button("Print Fabric stage", clicked_fn=lambda: print_fabric_stage())
-            with ui.VStack():
-                self._cesium_message_field = ui.SimpleStringModel("")
-                ui.StringField(self._cesium_message_field, multiline=True, read_only=True)
+            ui.Button("Remove all Tilesets", height=20, clicked_fn=lambda: remove_all_tilesets())
+            ui.Button("Reload all Tilesets", height=20, clicked_fn=lambda: reload_all_tilesets())
+            ui.Button("Print Fabric stage", height=20, clicked_fn=lambda: print_fabric_stage())
+            ui.StringField(self._cesium_message_field, height=100, multiline=True, read_only=True)
             self._statistics_widget = CesiumOmniverseStatisticsWidget(self._cesium_omniverse_interface)

--- a/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
@@ -60,8 +60,8 @@ class CesiumOmniverseDebugWindow(ui.Window):
             self._cesium_message_field.set_value(fabric_stage)
 
         with ui.VStack():
-            ui.Button("Remove all Tilesets", height=20, clicked_fn=lambda: remove_all_tilesets())
-            ui.Button("Reload all Tilesets", height=20, clicked_fn=lambda: reload_all_tilesets())
-            ui.Button("Print Fabric stage", height=20, clicked_fn=lambda: print_fabric_stage())
+            ui.Button("Remove all Tilesets", height=20, clicked_fn=remove_all_tilesets)
+            ui.Button("Reload all Tilesets", height=20, clicked_fn=reload_all_tilesets)
+            ui.Button("Print Fabric stage", height=20, clicked_fn=print_fabric_stage)
             ui.StringField(self._cesium_message_field, height=100, multiline=True, read_only=True)
             self._statistics_widget = CesiumOmniverseStatisticsWidget(self._cesium_omniverse_interface)

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -7,6 +7,9 @@ from ..bindings import ICesiumOmniverseInterface
 NUMBER_OF_MATERIALS_LOADED_TEXT = "Number of materials loaded: {0}"
 NUMBER_OF_GEOMETRIES_LOADED_TEXT = "Number of geometries loaded: {0}"
 NUMBER_OF_GEOMETRIES_VISIBLE_TEXT = "Number of geometries visible: {0}"
+NUMBER_OF_TRIANGLES_LOADED_TEXT = "Number of triangles loaded: {0}"
+NUMBER_OF_TRIANGLES_VISIBLE_TEXT = "Number of triangles visible: {0}"
+TILESET_CACHED_BYTES_TEXT = "Tileset cached bytes: {0}"
 
 
 class CesiumOmniverseStatisticsWidget(ui.Frame):
@@ -22,6 +25,9 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
         self._statistics_number_of_materials_loaded_field: ui.SimpleStringModel = ui.SimpleStringModel("")
         self._statistics_number_of_geometries_loaded_field: ui.SimpleStringModel = ui.SimpleStringModel("")
         self._statistics_number_of_geometries_visible_field: ui.SimpleStringModel = ui.SimpleStringModel("")
+        self._statistics_number_of_triangles_loaded_field: ui.SimpleStringModel = ui.SimpleStringModel("")
+        self._statistics_number_of_triangles_visible_field: ui.SimpleStringModel = ui.SimpleStringModel("")
+        self._statistics_tileset_cached_bytes_field: ui.SimpleStringModel = ui.SimpleStringModel("")
 
         self._subscriptions: List[carb.events.ISubscription] = []
         self._setup_subscriptions()
@@ -46,7 +52,8 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
         if not self.visible:
             return
 
-        fabric_statistics = self._cesium_omniverse_interface.get_fabric_statistics()
+        render_statistics = self._cesium_omniverse_interface.get_render_statistics()
+        fabric_statistics = render_statistics.fabric_statistics
         self._statistics_number_of_materials_loaded_field.set_value(
             NUMBER_OF_MATERIALS_LOADED_TEXT.format(fabric_statistics.number_of_materials_loaded)
         )
@@ -55,6 +62,15 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
         )
         self._statistics_number_of_geometries_visible_field.set_value(
             NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(fabric_statistics.number_of_geometries_visible)
+        )
+        self._statistics_number_of_triangles_loaded_field.set_value(
+            NUMBER_OF_TRIANGLES_LOADED_TEXT.format(fabric_statistics.number_of_triangles_loaded)
+        )
+        self._statistics_number_of_triangles_visible_field.set_value(
+            NUMBER_OF_TRIANGLES_VISIBLE_TEXT.format(fabric_statistics.number_of_triangles_visible)
+        )
+        self._statistics_tileset_cached_bytes_field.set_value(
+            TILESET_CACHED_BYTES_TEXT.format(render_statistics.tileset_cached_bytes)
         )
 
     def _build_fn(self):
@@ -65,3 +81,6 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
             ui.StringField(self._statistics_number_of_materials_loaded_field, height=0, read_only=True)
             ui.StringField(self._statistics_number_of_geometries_loaded_field, height=0, read_only=True)
             ui.StringField(self._statistics_number_of_geometries_visible_field, height=0, read_only=True)
+            ui.StringField(self._statistics_number_of_triangles_loaded_field, height=0, read_only=True)
+            ui.StringField(self._statistics_number_of_triangles_visible_field, height=0, read_only=True)
+            ui.StringField(self._statistics_tileset_cached_bytes_field, height=0, read_only=True)

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -53,21 +53,20 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
             return
 
         render_statistics = self._cesium_omniverse_interface.get_render_statistics()
-        fabric_statistics = render_statistics.fabric_statistics
         self._statistics_number_of_materials_loaded_field.set_value(
-            NUMBER_OF_MATERIALS_LOADED_TEXT.format(fabric_statistics.number_of_materials_loaded)
+            NUMBER_OF_MATERIALS_LOADED_TEXT.format(render_statistics.number_of_materials_loaded)
         )
         self._statistics_number_of_geometries_loaded_field.set_value(
-            NUMBER_OF_GEOMETRIES_LOADED_TEXT.format(fabric_statistics.number_of_geometries_loaded)
+            NUMBER_OF_GEOMETRIES_LOADED_TEXT.format(render_statistics.number_of_geometries_loaded)
         )
         self._statistics_number_of_geometries_visible_field.set_value(
-            NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(fabric_statistics.number_of_geometries_visible)
+            NUMBER_OF_GEOMETRIES_VISIBLE_TEXT.format(render_statistics.number_of_geometries_visible)
         )
         self._statistics_number_of_triangles_loaded_field.set_value(
-            NUMBER_OF_TRIANGLES_LOADED_TEXT.format(fabric_statistics.number_of_triangles_loaded)
+            NUMBER_OF_TRIANGLES_LOADED_TEXT.format(render_statistics.number_of_triangles_loaded)
         )
         self._statistics_number_of_triangles_visible_field.set_value(
-            NUMBER_OF_TRIANGLES_VISIBLE_TEXT.format(fabric_statistics.number_of_triangles_visible)
+            NUMBER_OF_TRIANGLES_VISIBLE_TEXT.format(render_statistics.number_of_triangles_visible)
         )
         self._statistics_tileset_cached_bytes_field.set_value(
             TILESET_CACHED_BYTES_TEXT.format(render_statistics.tileset_cached_bytes)

--- a/include/cesium/omniverse/CesiumOmniverse.h
+++ b/include/cesium/omniverse/CesiumOmniverse.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "cesium/omniverse/FabricStatistics.h"
+#include "cesium/omniverse/RenderStatistics.h"
 #include "cesium/omniverse/SetDefaultTokenResult.h"
 #include "cesium/omniverse/TokenTroubleshooter.h"
 
@@ -234,11 +234,11 @@ class ICesiumOmniverseInterface {
     virtual std::string printFabricStage() noexcept = 0;
 
     /**
-     * @brief Get Fabric statistics. For debugging only.
+     * @brief Get render statistics. For debugging only.
      *
-     * @returns Object containing Fabric statistics.
+     * @returns Object containing render statistics.
      */
-    virtual FabricStatistics getFabricStatistics() noexcept = 0;
+    virtual RenderStatistics getRenderStatistics() noexcept = 0;
 
     virtual bool creditsAvailable() noexcept = 0;
     virtual std::vector<std::pair<std::string, bool>> getCredits() noexcept = 0;

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -1,6 +1,6 @@
 #include "cesium/omniverse/CesiumIonSession.h"
 #include "cesium/omniverse/CesiumOmniverse.h"
-#include "cesium/omniverse/FabricStatistics.h"
+#include "cesium/omniverse/RenderStatistics.h"
 #include "cesium/omniverse/TokenTroubleshooter.h"
 #include "cesium/omniverse/Viewport.h"
 
@@ -60,7 +60,7 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def("update_troubleshooting_details", py::overload_cast<const char*, int64_t, uint64_t, uint64_t>(&ICesiumOmniverseInterface::updateTroubleshootingDetails))
         .def("update_troubleshooting_details", py::overload_cast<const char*, int64_t, int64_t, uint64_t, uint64_t>(&ICesiumOmniverseInterface::updateTroubleshootingDetails))
         .def("print_fabric_stage", &ICesiumOmniverseInterface::printFabricStage)
-        .def("get_fabric_statistics", &ICesiumOmniverseInterface::getFabricStatistics)
+        .def("get_render_statistics", &ICesiumOmniverseInterface::getRenderStatistics)
         .def("credits_available", &ICesiumOmniverseInterface::creditsAvailable)
         .def("get_credits", &ICesiumOmniverseInterface::getCredits)
         .def("credits_start_next_frame", &ICesiumOmniverseInterface::creditsStartNextFrame);
@@ -133,7 +133,13 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
     py::class_<FabricStatistics>(m, "FabricStatistics")
         .def_readonly("number_of_materials_loaded", &FabricStatistics::numberOfMaterialsLoaded)
         .def_readonly("number_of_geometries_loaded", &FabricStatistics::numberOfGeometriesLoaded)
-        .def_readonly("number_of_geometries_visible", &FabricStatistics::numberOfGeometriesVisible);
+        .def_readonly("number_of_geometries_visible", &FabricStatistics::numberOfGeometriesVisible)
+        .def_readonly("number_of_triangles_loaded", &FabricStatistics::numberOfTrianglesLoaded)
+        .def_readonly("number_of_triangles_visible", &FabricStatistics::numberOfTrianglesVisible);
+
+    py::class_<RenderStatistics>(m, "RenderStatistics")
+        .def_readonly("fabric_statistics", &RenderStatistics::fabricStatistics)
+        .def_readonly("tileset_cached_bytes", &RenderStatistics::tilesetCachedBytes);
 
     py::class_<Viewport>(m, "Viewport")
         .def(py::init())

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -130,15 +130,12 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def_readonly("asset_id", &AssetTroubleshootingDetails::assetId)
         .def_readonly("asset_exists_in_user_account", &AssetTroubleshootingDetails::assetExistsInUserAccount);
 
-    py::class_<FabricStatistics>(m, "FabricStatistics")
-        .def_readonly("number_of_materials_loaded", &FabricStatistics::numberOfMaterialsLoaded)
-        .def_readonly("number_of_geometries_loaded", &FabricStatistics::numberOfGeometriesLoaded)
-        .def_readonly("number_of_geometries_visible", &FabricStatistics::numberOfGeometriesVisible)
-        .def_readonly("number_of_triangles_loaded", &FabricStatistics::numberOfTrianglesLoaded)
-        .def_readonly("number_of_triangles_visible", &FabricStatistics::numberOfTrianglesVisible);
-
     py::class_<RenderStatistics>(m, "RenderStatistics")
-        .def_readonly("fabric_statistics", &RenderStatistics::fabricStatistics)
+        .def_readonly("number_of_materials_loaded", &RenderStatistics::numberOfMaterialsLoaded)
+        .def_readonly("number_of_geometries_loaded", &RenderStatistics::numberOfGeometriesLoaded)
+        .def_readonly("number_of_geometries_visible", &RenderStatistics::numberOfGeometriesVisible)
+        .def_readonly("number_of_triangles_loaded", &RenderStatistics::numberOfTrianglesLoaded)
+        .def_readonly("number_of_triangles_visible", &RenderStatistics::numberOfTrianglesVisible)
         .def_readonly("tileset_cached_bytes", &RenderStatistics::tilesetCachedBytes);
 
     py::class_<Viewport>(m, "Viewport")

--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cesium/omniverse/RenderStatistics.h"
 #include "cesium/omniverse/SetDefaultTokenResult.h"
 #include "cesium/omniverse/TokenTroubleshooter.h"
 #include "cesium/omniverse/UsdNotificationHandler.h"
@@ -118,6 +119,8 @@ class Context {
     bool creditsAvailable() const;
     std::vector<std::pair<std::string, bool>> getCredits() const;
     void creditsStartNextFrame();
+
+    RenderStatistics getRenderStatistics() const;
 
   private:
     void processPropertyChanged(const ChangedPrim& changedPrim);

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "cesium/omniverse/FabricStatistics.h"
+#include "cesium/omniverse/RenderStatistics.h"
 
 #include <glm/glm.hpp>
 #include <pxr/usd/sdf/path.h>

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -7,6 +7,18 @@
 
 #include <string>
 
+namespace cesium::omniverse {
+
+struct FabricStatistics {
+    uint64_t numberOfMaterialsLoaded{0};
+    uint64_t numberOfGeometriesLoaded{0};
+    uint64_t numberOfGeometriesVisible{0};
+    uint64_t numberOfTrianglesLoaded{0};
+    uint64_t numberOfTrianglesVisible{0};
+};
+
+} // namespace cesium::omniverse
+
 namespace cesium::omniverse::FabricUtil {
 
 std::string printFabricStage();

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -54,6 +54,7 @@ class OmniTileset {
     bool getShowCreditsOnScreen() const;
 
     int64_t getTilesetId() const;
+    uint64_t getCachedBytes() const;
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);

--- a/src/core/include/cesium/omniverse/RenderStatistics.h
+++ b/src/core/include/cesium/omniverse/RenderStatistics.h
@@ -7,5 +7,13 @@ struct FabricStatistics {
     uint64_t numberOfMaterialsLoaded{0};
     uint64_t numberOfGeometriesLoaded{0};
     uint64_t numberOfGeometriesVisible{0};
+    uint64_t numberOfTrianglesLoaded{0};
+    uint64_t numberOfTrianglesVisible{0};
 };
+
+struct RenderStatistics {
+    FabricStatistics fabricStatistics{};
+    uint64_t tilesetCachedBytes{0};
+};
+
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/RenderStatistics.h
+++ b/src/core/include/cesium/omniverse/RenderStatistics.h
@@ -3,16 +3,13 @@
 #include <cstdint>
 
 namespace cesium::omniverse {
-struct FabricStatistics {
+
+struct RenderStatistics {
     uint64_t numberOfMaterialsLoaded{0};
     uint64_t numberOfGeometriesLoaded{0};
     uint64_t numberOfGeometriesVisible{0};
     uint64_t numberOfTrianglesLoaded{0};
     uint64_t numberOfTrianglesVisible{0};
-};
-
-struct RenderStatistics {
-    FabricStatistics fabricStatistics{};
     uint64_t tilesetCachedBytes{0};
 };
 

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -645,7 +645,13 @@ void Context::creditsStartNextFrame() {
 
 RenderStatistics Context::getRenderStatistics() const {
     RenderStatistics renderStatistics;
-    renderStatistics.fabricStatistics = FabricUtil::getStatistics();
+
+    FabricStatistics fabricStatistics = FabricUtil::getStatistics();
+    renderStatistics.numberOfMaterialsLoaded = fabricStatistics.numberOfMaterialsLoaded;
+    renderStatistics.numberOfGeometriesLoaded = fabricStatistics.numberOfGeometriesLoaded;
+    renderStatistics.numberOfGeometriesVisible = fabricStatistics.numberOfGeometriesVisible;
+    renderStatistics.numberOfTrianglesLoaded = fabricStatistics.numberOfTrianglesLoaded;
+    renderStatistics.numberOfTrianglesVisible = fabricStatistics.numberOfTrianglesVisible;
 
     const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
     for (const auto& tileset : tilesets) {

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -4,6 +4,7 @@
 #include "cesium/omniverse/Broadcast.h"
 #include "cesium/omniverse/CesiumIonSession.h"
 #include "cesium/omniverse/FabricMeshManager.h"
+#include "cesium/omniverse/FabricUtil.h"
 #include "cesium/omniverse/HttpAssetAccessor.h"
 #include "cesium/omniverse/LoggerSink.h"
 #include "cesium/omniverse/OmniImagery.h"
@@ -640,6 +641,18 @@ std::vector<std::pair<std::string, bool>> Context::getCredits() const {
 
 void Context::creditsStartNextFrame() {
     _creditSystem->startNextFrame();
+}
+
+RenderStatistics Context::getRenderStatistics() const {
+    RenderStatistics renderStatistics;
+    renderStatistics.fabricStatistics = FabricUtil::getStatistics();
+
+    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
+    for (const auto& tileset : tilesets) {
+        renderStatistics.tilesetCachedBytes += tileset->getCachedBytes();
+    }
+
+    return renderStatistics;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -520,8 +520,18 @@ FabricStatistics getStatistics() {
 
         auto worldVisibilityFabric =
             sip.getAttributeArrayRd<bool>(geometryBuckets, bucketId, FabricTokens::_worldVisibility);
-        statistics.numberOfGeometriesVisible +=
-            std::count(worldVisibilityFabric.begin(), worldVisibilityFabric.end(), true);
+        auto faceVertexCountsFabric =
+            sip.getArrayAttributeArrayRd<int>(geometryBuckets, bucketId, FabricTokens::faceVertexCounts);
+
+        for (size_t i = 0; i < paths.size(); i++) {
+            const auto triangleCount = faceVertexCountsFabric[i].size();
+            statistics.numberOfTrianglesLoaded += triangleCount;
+
+            if (worldVisibilityFabric[i]) {
+                statistics.numberOfGeometriesVisible++;
+                statistics.numberOfTrianglesVisible += triangleCount;
+            }
+        }
     }
 
     for (size_t bucketId = 0; bucketId < materialBuckets.bucketCount(); bucketId++) {

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -222,6 +222,10 @@ int64_t OmniTileset::getTilesetId() const {
     return _tilesetId;
 }
 
+uint64_t OmniTileset::getCachedBytes() const {
+    return _tileset->getTotalDataBytes();
+}
+
 void OmniTileset::reload() {
     _renderResourcesPreparer = std::make_shared<FabricPrepareRenderResources>(*this);
     auto& context = Context::instance();

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -167,8 +167,8 @@ class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
         return FabricUtil::printFabricStage();
     }
 
-    FabricStatistics getFabricStatistics() noexcept override {
-        return FabricUtil::getStatistics();
+    RenderStatistics getRenderStatistics() noexcept override {
+        return Context::instance().getRenderStatistics();
     }
 
     bool creditsAvailable() noexcept override {


### PR DESCRIPTION
Added some more render statistics to help with debugging:

* Number of triangles loaded
* Number of triangles visible
* Tileset cached bytes

I eventually want to add "Number of texels loaded" and "Number of texels visible" but it isn't as easy to add right now due to how things are structured.

<img width="575" alt="image" src="https://github.com/CesiumGS/cesium-omniverse/assets/915398/701961cd-b9d2-4a1b-915f-0409b249940a">
