### PR TITLE
fix-carbonite-import-error

### DIFF
--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -30,6 +30,7 @@
       "${workspaceFolder}/exts/cesium.omniverse",
       "${workspaceFolder}/extern/nvidia/app/kit/extscore/omni.kit.pip_archive/pip_prebundle",
       "${workspaceFolder}/extern/nvidia/app/kit/plugins/bindings-python",
+      "${workspaceFolder}/extern/nvidia/app/kit/kernel/py",
       "${workspaceFolder}/extern/nvidia/app/extscache/kaolin_app.research.dataset_visualizer-1.0.0+cp37",
       "${workspaceFolder}/extern/nvidia/app/extscache/kaolin_app.research.training_visualizer-1.0.0+cp37",
       "${workspaceFolder}/extern/nvidia/app/extscache/kaolin_app.research.utils-1.0.0+cp37",


### PR DESCRIPTION
It looks like NVIDIA has moved the location of the Carbonite SDK since I joined and installed Omniverse. extension.py has this issues:

![image](https://github.com/CesiumGS/cesium-omniverse/assets/1040194/a037588f-f321-4ffa-840e-77dcd72ab3f4)

This should fix it. 