### PR TITLE
Delete shader node prims

### DIFF
--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -44,6 +44,8 @@ class FabricMaterial {
     pxr::SdfPath _shaderPath;
     pxr::SdfPath _displacementPath;
     pxr::SdfPath _surfacePath;
+    pxr::SdfPath _lookupColorPath;
+    pxr::SdfPath _textureCoordinate2dPath;
 
     std::unique_ptr<omni::ui::DynamicTextureProvider> _baseColorTexture;
 };

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -37,6 +37,8 @@ FabricMaterial::~FabricMaterial() {
     FabricUtil::destroyPrim(_shaderPath);
     FabricUtil::destroyPrim(_displacementPath);
     FabricUtil::destroyPrim(_surfacePath);
+    FabricUtil::destroyPrim(_lookupColorPath);
+    FabricUtil::destroyPrim(_textureCoordinate2dPath);
 }
 
 void FabricMaterial::setActive(bool active) {
@@ -348,6 +350,8 @@ void FabricMaterial::initialize(pxr::SdfPath path, const FabricMaterialDefinitio
     _shaderPath = shaderPath;
     _displacementPath = displacementPath;
     _surfacePath = surfacePath;
+    _lookupColorPath = lookupColorPath;
+    _textureCoordinate2dPath = textureCoordinate2dPath;
 
     reset();
 }


### PR DESCRIPTION
`lookup_color` and `texture_coordinate_2d` shader node prims were not being deleted, an oversight from https://github.com/CesiumGS/cesium-omniverse/pull/276.

To reproduce the bug on main:

* Load Cesium World Terrain + Bing Maps Aerial Imagery
* Disable the extension
* Delete the `Cesium_World_Terrain` prim
* Enable the extension
* Open the Cesium Debugging window
* Click `Print Fabric stage`

You'll see stray `lookup_color` and `texture_coordinate_2d` prims.

This fix is mainly relevant when material pooling is disabled and materials are being destroyed frequently.