### PR TITLE
Fix typo in USD schema UI

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/attributes/tileset_attributes_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/attributes/tileset_attributes_widget.py
@@ -43,7 +43,7 @@ class CesiumTilesetAttributesWidget(SchemaPropertiesWidget):
                 CustomLayoutProperty("cesium:maximumCachedBytes")
                 CustomLayoutProperty("cesium:loadingDescendantLimit")
             with CustomLayoutGroup("Tile Culling"):
-                CustomLayoutProperty("cesium:enableFrustrumCulling")
+                CustomLayoutProperty("cesium:enableFrustumCulling")
                 CustomLayoutProperty("cesium:enableFogCulling")
                 CustomLayoutProperty("cesium:enforceCulledScreenSpaceError")
                 CustomLayoutProperty("cesium:culledScreenSpaceError")


### PR DESCRIPTION
Fixed typo `cesium:enableFrustrumCulling` -> `cesium:enableFrustumCulling` so that it appears properly in the UI.