### PR TITLE
Set black to Python formatter

### DIFF
--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -55,7 +55,8 @@
       "editorconfig.editorconfig",
       "cheshirekow.cmake-format",
       "redhat.vscode-yaml",
-      "tamasfe.even-better-toml"
+      "tamasfe.even-better-toml",
+      "ms-python.black-formatter"
     ],
     "unwantedRecommendations": []
   }

--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -42,6 +42,7 @@
     "python.linting.flake8Enabled": true,
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"
+    }
   },
   "extensions": {
     "recommendations": [

--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -39,7 +39,9 @@
     "python.analysis.typeCheckingMode": "basic",
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true
+    "python.linting.flake8Enabled": true,
+    "[python]": {
+      "editor.defaultFormatter": "ms-python.black-formatter"
   },
   "extensions": {
     "recommendations": [

--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -427,7 +427,10 @@
     "python.analysis.typeCheckingMode": "basic",
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true
+    "python.linting.flake8Enabled": true,
+    "[python]": {
+      "editor.defaultFormatter": "ms-python.black-formatter"
+    }
   },
   "extensions": {
     "recommendations": [

--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -441,7 +441,8 @@
       "editorconfig.editorconfig",
       "cheshirekow.cmake-format",
       "redhat.vscode-yaml",
-      "tamasfe.even-better-toml"
+      "tamasfe.even-better-toml",
+      "ms-python.black-formatter"
     ],
     "unwantedRecommendations": []
   }


### PR DESCRIPTION
Resolve #291 

This sets the default Python interpret to Black in the VS Code workspace files. It will highlight more formatting issues at code time that could cause continuous integration to fail.