### PR TITLE
Separate tile loading into stages

### DIFF
--- a/src/core/include/cesium/omniverse/FabricMesh.h
+++ b/src/core/include/cesium/omniverse/FabricMesh.h
@@ -21,6 +21,20 @@ class FabricMesh {
 
     void setVisibility(bool visible) const;
 
+    void setTile(
+        int64_t tilesetId,
+        int64_t tileId,
+        const glm::dmat4& ecefToUsdTransform,
+        const glm::dmat4& gltfToEcefTransform,
+        const glm::dmat4& nodeTransform,
+        const CesiumGltf::Model& model,
+        const CesiumGltf::MeshPrimitive& primitive,
+        bool smoothNormals,
+        const CesiumGltf::ImageCesium* imagery,
+        const glm::dvec2& imageryTexcoordTranslation,
+        const glm::dvec2& imageryTexcoordScale,
+        uint64_t imageryTexcoordSetIndex);
+
   private:
     std::shared_ptr<FabricGeometry> _geometry;
     std::shared_ptr<FabricMaterial> _material;

--- a/src/core/include/cesium/omniverse/FabricMeshManager.h
+++ b/src/core/include/cesium/omniverse/FabricMeshManager.h
@@ -30,17 +30,10 @@ class FabricMeshManager {
     }
 
     std::shared_ptr<FabricMesh> acquireMesh(
-        int64_t tilesetId,
-        int64_t tileId,
-        const glm::dmat4& ecefToUsdTransform,
-        const glm::dmat4& gltfToEcefTransform,
-        const glm::dmat4& nodeTransform,
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
         const CesiumGltf::ImageCesium* imagery,
-        const glm::dvec2& imageryTexcoordTranslation,
-        const glm::dvec2& imageryTexcoordScale,
         uint64_t imageryTexcoordSetIndex);
 
     void releaseMesh(std::shared_ptr<FabricMesh> mesh);

--- a/src/core/src/FabricMesh.cpp
+++ b/src/core/src/FabricMesh.cpp
@@ -18,4 +18,45 @@ void FabricMesh::setVisibility(bool visible) const {
     _geometry->setVisibility(visible);
 }
 
+void FabricMesh::setTile(
+    int64_t tilesetId,
+    int64_t tileId,
+    const glm::dmat4& ecefToUsdTransform,
+    const glm::dmat4& gltfToEcefTransform,
+    const glm::dmat4& nodeTransform,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    bool smoothNormals,
+    const CesiumGltf::ImageCesium* imagery,
+    const glm::dvec2& imageryTexcoordTranslation,
+    const glm::dvec2& imageryTexcoordScale,
+    uint64_t imageryTexcoordSetIndex) {
+
+    const auto geometry = getGeometry();
+    const auto material = getMaterial();
+
+    assert(geometry != nullptr);
+
+    const auto hasImagery = imagery != nullptr;
+
+    geometry->setTile(
+        tilesetId,
+        tileId,
+        ecefToUsdTransform,
+        gltfToEcefTransform,
+        nodeTransform,
+        model,
+        primitive,
+        smoothNormals,
+        hasImagery,
+        imageryTexcoordTranslation,
+        imageryTexcoordScale,
+        imageryTexcoordSetIndex);
+
+    if (material != nullptr) {
+        material->setTile(tilesetId, tileId, model, primitive, imagery);
+        geometry->assignMaterial(material);
+    }
+}
+
 } // namespace cesium::omniverse

--- a/src/core/src/FabricMeshManager.cpp
+++ b/src/core/src/FabricMeshManager.cpp
@@ -13,45 +13,19 @@
 namespace cesium::omniverse {
 
 std::shared_ptr<FabricMesh> FabricMeshManager::acquireMesh(
-    int64_t tilesetId,
-    int64_t tileId,
-    const glm::dmat4& ecefToUsdTransform,
-    const glm::dmat4& gltfToEcefTransform,
-    const glm::dmat4& nodeTransform,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
     const CesiumGltf::ImageCesium* imagery,
-    const glm::dvec2& imageryTexcoordTranslation,
-    const glm::dvec2& imageryTexcoordScale,
     uint64_t imageryTexcoordSetIndex) {
 
-    const auto hasImagery = imagery != nullptr;
     const auto geometry = acquireGeometry(model, primitive, smoothNormals, imagery, imageryTexcoordSetIndex);
-
-    geometry->setTile(
-        tilesetId,
-        tileId,
-        ecefToUsdTransform,
-        gltfToEcefTransform,
-        nodeTransform,
-        model,
-        primitive,
-        smoothNormals,
-        hasImagery,
-        imageryTexcoordTranslation,
-        imageryTexcoordScale,
-        imageryTexcoordSetIndex);
 
     const auto hasMaterial = geometry->getGeometryDefinition().hasMaterial();
     auto material = std::shared_ptr<FabricMaterial>(nullptr);
 
     if (hasMaterial) {
         material = acquireMaterial(model, primitive, imagery);
-
-        material->setTile(tilesetId, tileId, model, primitive, imagery);
-
-        geometry->assignMaterial(material);
     }
 
     return std::make_shared<FabricMesh>(geometry, material);

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -19,12 +19,32 @@
 namespace cesium::omniverse {
 
 namespace {
+
+template <typename T> size_t getIndexFromRef(const std::vector<T>& vector, const T& item) {
+    return static_cast<size_t>(&item - vector.data());
+};
+
 struct TileLoadThreadResult {
     glm::dmat4 tileTransform;
     std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
 };
 
-std::vector<std::shared_ptr<FabricMesh>> createFabricMeshes(
+struct IntermediaryMesh {
+    const int64_t tilesetId;
+    const int64_t tileId;
+    const glm::dmat4 ecefToUsdTransform;
+    const glm::dmat4 gltfToEcefTransform;
+    const glm::dmat4 nodeTransform;
+    const uint64_t meshId;
+    const uint64_t primitiveId;
+    const bool smoothNormals;
+    const CesiumGltf::ImageCesium* imagery;
+    const glm::dvec2 imageryTexcoordTranslation;
+    const glm::dvec2 imageryTexcoordScale;
+    const uint64_t imageryTexcoordSetIndex;
+};
+
+std::vector<IntermediaryMesh> gatherMeshes(
     const OmniTileset& tileset,
     const glm::dmat4& tileTransform,
     const CesiumGltf::Model& model,
@@ -44,7 +64,7 @@ std::vector<std::shared_ptr<FabricMesh>> createFabricMeshes(
     auto gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyRtcCenter(model, tileTransform);
     gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyGltfUpAxisTransform(model, gltfToEcefTransform);
 
-    std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
+    std::vector<IntermediaryMesh> meshes;
 
     model.forEachPrimitiveInScene(
         -1,
@@ -57,34 +77,74 @@ std::vector<std::shared_ptr<FabricMesh>> createFabricMeshes(
          &imageryTexcoordTranslation,
          &imageryTexcoordScale,
          imageryTexcoordSetIndex,
-         &fabricMeshes](
+         &meshes](
             const CesiumGltf::Model& gltf,
             [[maybe_unused]] const CesiumGltf::Node& node,
             [[maybe_unused]] const CesiumGltf::Mesh& mesh,
             const CesiumGltf::MeshPrimitive& primitive,
             const glm::dmat4& transform) {
-            const auto fabricMesh = FabricMeshManager::getInstance().acquireMesh(
+            const auto meshId = getIndexFromRef(gltf.meshes, mesh);
+            const auto primitiveId = getIndexFromRef(mesh.primitives, primitive);
+            meshes.emplace_back(IntermediaryMesh{
                 tilesetId,
                 tileId,
                 ecefToUsdTransform,
                 gltfToEcefTransform,
                 transform,
-                gltf,
-                primitive,
+                meshId,
+                primitiveId,
                 smoothNormals,
                 imagery,
                 imageryTexcoordTranslation,
                 imageryTexcoordScale,
-                imageryTexcoordSetIndex);
-            fabricMeshes.push_back(fabricMesh);
+                imageryTexcoordSetIndex,
+            });
         });
+
+    return meshes;
+}
+
+std::vector<IntermediaryMesh>
+gatherMeshes(const OmniTileset& tileset, const glm::dmat4& tileTransform, const CesiumGltf::Model& model) {
+    return gatherMeshes(tileset, tileTransform, model, nullptr, glm::dvec2(), glm::dvec2(), 0);
+}
+
+std::vector<std::shared_ptr<FabricMesh>>
+acquireFabricMeshes(const CesiumGltf::Model& model, const std::vector<IntermediaryMesh>& meshes) {
+    std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
+    fabricMeshes.reserve(meshes.size());
+
+    for (const auto& mesh : meshes) {
+        const auto& primitive = model.meshes[mesh.meshId].primitives[mesh.primitiveId];
+        fabricMeshes.emplace_back(FabricMeshManager::getInstance().acquireMesh(
+            model, primitive, mesh.smoothNormals, mesh.imagery, mesh.imageryTexcoordSetIndex));
+    }
 
     return fabricMeshes;
 }
 
-std::vector<std::shared_ptr<FabricMesh>>
-createFabricMeshes(const OmniTileset& tileset, const glm::dmat4& tileTransform, const CesiumGltf::Model& model) {
-    return createFabricMeshes(tileset, tileTransform, model, nullptr, glm::dvec2(), glm::dvec2(), 0);
+void setFabricMeshes(
+    const CesiumGltf::Model& model,
+    const std::vector<IntermediaryMesh>& meshes,
+    const std::vector<std::shared_ptr<FabricMesh>>& fabricMeshes) {
+    for (size_t i = 0; i < meshes.size(); i++) {
+        const auto& mesh = meshes[i];
+        const auto& fabricMesh = fabricMeshes[i];
+        const auto& primitive = model.meshes[mesh.meshId].primitives[mesh.primitiveId];
+        fabricMesh->setTile(
+            mesh.tilesetId,
+            mesh.tileId,
+            mesh.ecefToUsdTransform,
+            mesh.gltfToEcefTransform,
+            mesh.nodeTransform,
+            model,
+            primitive,
+            mesh.smoothNormals,
+            mesh.imagery,
+            mesh.imageryTexcoordTranslation,
+            mesh.imageryTexcoordScale,
+            mesh.imageryTexcoordSetIndex);
+    }
 }
 
 } // namespace
@@ -104,31 +164,46 @@ FabricPrepareRenderResources::prepareInLoadThread(
             Cesium3DTilesSelection::TileLoadResultAndRenderResources{std::move(tileLoadResult), nullptr});
     }
 
-    return asyncSystem.runInMainThread([this, asyncSystem, transform, tileLoadResult = std::move(tileLoadResult)]() {
-        const auto pModel = std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
+    struct IntermediateMainThreadResult {
+        std::vector<IntermediaryMesh> meshes;
+        std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
+        Cesium3DTilesSelection::TileLoadResult tileLoadResult;
+    };
 
-        // If there are no imagery layers attached to the tile add the tile right away
-        if (!tileLoadResult.rasterOverlayDetails.has_value()) {
+    // If there are no imagery layers attached to the tile add the tile right away
+    if (!tileLoadResult.rasterOverlayDetails.has_value()) {
+        auto meshes = gatherMeshes(_tileset, transform, *pModel);
+        return asyncSystem
+            .runInMainThread([meshes = std::move(meshes), tileLoadResult = std::move(tileLoadResult)]() {
+                const auto& model = *std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
+                auto fabricMeshes = acquireFabricMeshes(model, meshes);
+                return IntermediateMainThreadResult{
+                    std::move(meshes), std::move(fabricMeshes), std::move(tileLoadResult)};
+            })
+            .thenInWorkerThread([transform](IntermediateMainThreadResult&& mainThreadResult) {
+                auto meshes = std::move(mainThreadResult.meshes);
+                auto fabricMeshes = std::move(mainThreadResult.fabricMeshes);
+                auto tileLoadResult = std::move(mainThreadResult.tileLoadResult);
+                const auto& model = *std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
 
-            const auto fabricMeshes = createFabricMeshes(_tileset, transform, *pModel);
-
-            return asyncSystem.createResolvedFuture(Cesium3DTilesSelection::TileLoadResultAndRenderResources{
-                std::move(tileLoadResult),
-                new TileLoadThreadResult{
-                    transform,
-                    std::move(fabricMeshes),
-                },
+                setFabricMeshes(model, meshes, fabricMeshes);
+                return Cesium3DTilesSelection::TileLoadResultAndRenderResources{
+                    std::move(tileLoadResult),
+                    new TileLoadThreadResult{
+                        transform,
+                        std::move(fabricMeshes),
+                    },
+                };
             });
-        }
+    }
 
-        // Otherwise add the tile + imagery later
-        return asyncSystem.createResolvedFuture(Cesium3DTilesSelection::TileLoadResultAndRenderResources{
-            std::move(tileLoadResult),
-            new TileLoadThreadResult{
-                transform,
-                {},
-            },
-        });
+    // Otherwise add the tile + imagery later
+    return asyncSystem.createResolvedFuture(Cesium3DTilesSelection::TileLoadResultAndRenderResources{
+        std::move(tileLoadResult),
+        new TileLoadThreadResult{
+            transform,
+            {},
+        },
     });
 }
 
@@ -220,14 +295,19 @@ void FabricPrepareRenderResources::attachRasterInMainThread(
         }
     }
 
-    const auto fabricMeshes = createFabricMeshes(
+    const auto& model = tile.getContent().getRenderContent()->getModel();
+
+    const auto meshes = gatherMeshes(
         _tileset,
         pTileRenderResources->tileTransform,
-        tile.getContent().getRenderContent()->getModel(),
+        model,
         &rasterTile.getImage(),
         translation,
         scale,
         static_cast<uint64_t>(overlayTextureCoordinateID));
+
+    const auto fabricMeshes = acquireFabricMeshes(model, meshes);
+    setFabricMeshes(model, meshes, fabricMeshes);
 
     pTileRenderResources->fabricMeshes = fabricMeshes;
 }


### PR DESCRIPTION
Separates tile loading into three stages:

1. Gather meshes from the glTF
2. Acquire Fabric prims from the pool
3. Set mesh data on the Fabric prims

The eventual goal is to do step 1 in the load thread, step 2 in the main thread, and step 3 back in the load thread. The is based on the recommendation that Fabric topology edits should happen on the main thread (topology edits being prim or attribute creation/destruction) while value updates could happen on the load thread.

Unfortunately step 3 is not working in the load thread yet, but to see what that looks like revert https://github.com/CesiumGS/cesium-omniverse/pull/299/commits/b2b0e078e78f66096bfa6a54fe86a2252e7cc893.