### PR TITLE
Set better default values for unlit materials

### DIFF
--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <CesiumGltf/AccessorView.h>
+#include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
 #include <CesiumGltf/Model.h>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/quaternion.hpp>
@@ -330,6 +331,11 @@ pxr::GfVec3f getBaseColorFactor(const CesiumGltf::Material& material) {
 }
 
 float getMetallicFactor(const CesiumGltf::Material& material) {
+    if (material.hasExtension<CesiumGltf::ExtensionKhrMaterialsUnlit>()) {
+        // Unlit materials aren't supported in Omniverse yet but we can hard code the metallic factor to something reasonable
+        return 0.0f;
+    }
+
     const auto& pbrMetallicRoughness = material.pbrMetallicRoughness;
     if (pbrMetallicRoughness.has_value()) {
         return static_cast<float>(pbrMetallicRoughness->metallicFactor);
@@ -339,6 +345,11 @@ float getMetallicFactor(const CesiumGltf::Material& material) {
 }
 
 float getRoughnessFactor(const CesiumGltf::Material& material) {
+    if (material.hasExtension<CesiumGltf::ExtensionKhrMaterialsUnlit>()) {
+        // Unlit materials aren't supported in Omniverse yet but we can hard code the roughness factor to something reasonable
+        return 1.0f;
+    }
+
     const auto& pbrMetallicRoughness = material.pbrMetallicRoughness;
     if (pbrMetallicRoughness.has_value()) {
         return static_cast<float>(pbrMetallicRoughness->roughnessFactor);


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/282

Sets metallicFactor to 0.0 and roughnessFactor to 1.0 for materials with the KHR_materials_unlit extension.

This improves the look of Google 3D Tiles until we're able to properly support unlit materials: #36