### PR TITLE
Change material loading color

### DIFF
--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -20,7 +20,7 @@ namespace cesium::omniverse {
 
 namespace {
 
-const auto MATERIAL_LOADING_COLOR = pxr::GfVec3f(1.0f, 1.0f, 1.0f);
+const auto MATERIAL_LOADING_COLOR = pxr::GfVec3f(0.0f, 0.0f, 0.0f);
 const auto DEFAULT_COLOR = pxr::GfVec3f(1.0f, 1.0f, 1.0f);
 const auto DEFAULT_EXTENT = pxr::GfRange3d(pxr::GfVec3d(0.0, 0.0, 0.0), pxr::GfVec3d(0.0, 0.0, 0.0));
 const auto DEFAULT_POSITION = pxr::GfVec3d(0.0, 0.0, 0.0);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -20,7 +20,7 @@ namespace cesium::omniverse {
 
 namespace {
 
-const auto MATERIAL_LOADING_COLOR = pxr::GfVec3f(1.0f, 0.0f, 0.0f);
+const auto MATERIAL_LOADING_COLOR = pxr::GfVec3f(1.0f, 1.0f, 1.0f);
 const auto DEFAULT_COLOR = pxr::GfVec3f(1.0f, 1.0f, 1.0f);
 const auto DEFAULT_EXTENT = pxr::GfRange3d(pxr::GfVec3d(0.0, 0.0, 0.0), pxr::GfVec3d(0.0, 0.0, 0.0));
 const auto DEFAULT_POSITION = pxr::GfVec3d(0.0, 0.0, 0.0);


### PR DESCRIPTION
When materials are compiling we draw a solid red color. I changed it to white which is a bit less harsh looking.

I was also considering black because it blends with the empty background better. Or cyan because that's what Cesium for Unity does. If anyone has any strong preferences I'd be happy to change it.