### PR TITLE
Avoid unnecessary allocations when adding geometry data to Fabric

### DIFF
--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#ifdef CESIUM_OMNI_MSVC
+#pragma push_macro("OPAQUE")
+#undef OPAQUE
+#endif
+
+#include <CesiumGltf/AccessorView.h>
+#include <glm/glm.hpp>
+#include <pxr/base/gf/vec2f.h>
+#include <pxr/base/gf/vec3f.h>
+
+#include <gsl/span>
+
+namespace cesium::omniverse {
+
+class PositionsAccessor {
+  public:
+    PositionsAccessor();
+    PositionsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view);
+
+    void fill(const gsl::span<pxr::GfVec3f>& values) const;
+    const glm::fvec3& get(uint64_t index) const;
+    uint64_t size() const;
+
+  private:
+    CesiumGltf::AccessorView<glm::fvec3> _view;
+    uint64_t _size;
+};
+
+class IndicesAccessor {
+  public:
+    IndicesAccessor();
+    IndicesAccessor(uint64_t size);
+    IndicesAccessor(const CesiumGltf::AccessorView<uint8_t>& uint8View);
+    IndicesAccessor(const CesiumGltf::AccessorView<uint16_t>& uint16View);
+    IndicesAccessor(const CesiumGltf::AccessorView<uint32_t>& uint32View);
+
+    template <typename T> static IndicesAccessor FromTriangleStrips(const CesiumGltf::AccessorView<T>& view);
+    template <typename T> static IndicesAccessor FromTriangleFans(const CesiumGltf::AccessorView<T>& view);
+
+    void fill(const gsl::span<int>& values) const;
+    uint32_t get(uint64_t index) const;
+    uint64_t size() const;
+
+  private:
+    std::vector<uint32_t> _computed;
+    CesiumGltf::AccessorView<uint8_t> _uint8View;
+    CesiumGltf::AccessorView<uint16_t> _uint16View;
+    CesiumGltf::AccessorView<uint32_t> _uint32View;
+    uint64_t _size;
+};
+
+class NormalsAccessor {
+  public:
+    NormalsAccessor();
+    NormalsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view);
+
+    static NormalsAccessor GenerateSmooth(const PositionsAccessor& positions, const IndicesAccessor& indices);
+
+    void fill(const gsl::span<pxr::GfVec3f>& values) const;
+    uint64_t size() const;
+
+  private:
+    std::vector<glm::fvec3> _computed;
+    CesiumGltf::AccessorView<glm::fvec3> _view;
+    uint64_t _size;
+};
+
+class TexcoordsAccessor {
+  public:
+    TexcoordsAccessor();
+    TexcoordsAccessor(
+        const CesiumGltf::AccessorView<glm::fvec2>& view,
+        const glm::fvec2& translation,
+        const glm::fvec2& scale,
+        bool flipVertical);
+
+    void fill(const gsl::span<pxr::GfVec2f>& values) const;
+    uint64_t size() const;
+
+  private:
+    CesiumGltf::AccessorView<glm::fvec2> _view;
+    glm::fvec2 _translation;
+    glm::fvec2 _scale;
+    bool _applyTransform;
+    bool _flipVertical;
+    uint64_t _size;
+};
+
+class FaceVertexCountsAccessor {
+  public:
+    FaceVertexCountsAccessor();
+    FaceVertexCountsAccessor(uint64_t size);
+
+    void fill(const gsl::span<int>& values) const;
+    uint64_t size() const;
+
+  private:
+    uint64_t _size;
+};
+
+} // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "cesium/omniverse/GltfAccessors.h"
+
 #include <glm/glm.hpp>
-#include <pxr/base/vt/array.h>
-#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/base/gf/range3d.h>
 
 namespace CesiumGltf {
 struct ImageCesium;
@@ -14,30 +15,30 @@ struct Texture;
 
 namespace cesium::omniverse::GltfUtil {
 
-pxr::VtArray<pxr::GfVec3f> getPositions(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+PositionsAccessor getPositions(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
 std::optional<pxr::GfRange3d> getExtent(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-pxr::VtArray<int> getIndices(
+IndicesAccessor getIndices(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const pxr::VtArray<pxr::GfVec3f>& positions);
+    const PositionsAccessor& positions);
 
-pxr::VtArray<pxr::GfVec3f> getNormals(
+NormalsAccessor getNormals(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const pxr::VtArray<pxr::GfVec3f>& positions,
-    const pxr::VtArray<int>& indices,
+    const PositionsAccessor& positionsAccessor,
+    const IndicesAccessor& indices,
     bool smoothNormals);
 
-pxr::VtArray<pxr::GfVec2f> getTexcoords(
+TexcoordsAccessor getTexcoords(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     uint64_t setIndex,
     const glm::fvec2& translation,
     const glm::fvec2& scale);
 
-pxr::VtArray<int> getFaceVertexCounts(const pxr::VtArray<int>& indices);
+FaceVertexCountsAccessor getFaceVertexCounts(const IndicesAccessor& indices);
 
 pxr::GfVec3f getBaseColorFactor(const CesiumGltf::Material& material);
 float getMetallicFactor(const CesiumGltf::Material& material);
@@ -51,7 +52,7 @@ std::optional<uint64_t> getBaseColorTextureIndex(const CesiumGltf::Model& model,
 
 bool getDoubleSided(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-pxr::VtArray<pxr::GfVec2f> getImageryTexcoords(
+TexcoordsAccessor getImageryTexcoords(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     uint64_t setIndex,

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -240,7 +240,7 @@ void FabricGeometry::setTile(
     const auto localExtent = GltfUtil::getExtent(model, primitive);
     const auto faceVertexCounts = GltfUtil::getFaceVertexCounts(indices);
 
-    if (positions.empty() || indices.empty() || !localExtent.has_value()) {
+    if (positions.size() == 0 || indices.size() == 0 || !localExtent.has_value()) {
         return;
     }
 
@@ -269,9 +269,9 @@ void FabricGeometry::setTile(
     auto displayColorFabric = sip.getArrayAttributeWr<pxr::GfVec3f>(pathFabric, FabricTokens::primvars_displayColor);
     // clang-format on
 
-    std::copy(faceVertexCounts.begin(), faceVertexCounts.end(), faceVertexCountsFabric.begin());
-    std::copy(indices.begin(), indices.end(), faceVertexIndicesFabric.begin());
-    std::copy(positions.begin(), positions.end(), pointsFabric.begin());
+    faceVertexCounts.fill(faceVertexCountsFabric);
+    indices.fill(faceVertexIndicesFabric);
+    positions.fill(pointsFabric);
 
     *localExtentFabric = localExtent.value();
     *worldExtentFabric = worldExtent;
@@ -291,7 +291,7 @@ void FabricGeometry::setTile(
 
         auto stFabric = sip.getArrayAttributeWr<pxr::GfVec2f>(pathFabric, FabricTokens::primvars_st);
 
-        std::copy(texcoords.begin(), texcoords.end(), stFabric.begin());
+        texcoords.fill(stFabric);
     }
 
     if (hasNormals) {
@@ -299,7 +299,7 @@ void FabricGeometry::setTile(
 
         auto normalsFabric = sip.getArrayAttributeWr<pxr::GfVec3f>(pathFabric, FabricTokens::primvars_normals);
 
-        std::copy(normals.begin(), normals.end(), normalsFabric.begin());
+        normals.fill(normalsFabric);
     }
 }
 

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -53,6 +53,7 @@ std::vector<IntermediaryMesh> gatherMeshes(
     const glm::dvec2& imageryTexcoordScale,
     uint64_t imageryTexcoordSetIndex) {
 
+    CESIUM_TRACE("FabricPrepareRenderResources::gatherMeshes");
     const auto tilesetId = tileset.getTilesetId();
     const auto tileId = Context::instance().getNextTileId();
 
@@ -111,6 +112,7 @@ gatherMeshes(const OmniTileset& tileset, const glm::dmat4& tileTransform, const 
 
 std::vector<std::shared_ptr<FabricMesh>>
 acquireFabricMeshes(const CesiumGltf::Model& model, const std::vector<IntermediaryMesh>& meshes) {
+    CESIUM_TRACE("FabricPrepareRenderResources::acquireFabricMeshes");
     std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
     fabricMeshes.reserve(meshes.size());
 
@@ -127,6 +129,7 @@ void setFabricMeshes(
     const CesiumGltf::Model& model,
     const std::vector<IntermediaryMesh>& meshes,
     const std::vector<std::shared_ptr<FabricMesh>>& fabricMeshes) {
+    CESIUM_TRACE("FabricPrepareRenderResources::setFabricMeshes");
     for (size_t i = 0; i < meshes.size(); i++) {
         const auto& mesh = meshes[i];
         const auto& fabricMesh = fabricMeshes[i];

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -1,0 +1,238 @@
+#include "cesium/omniverse/GltfAccessors.h"
+
+namespace cesium::omniverse {
+PositionsAccessor::PositionsAccessor()
+    : _size(0) {}
+
+PositionsAccessor::PositionsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view)
+    : _view(view)
+    , _size(view.size()) {}
+
+void PositionsAccessor::fill(const gsl::span<pxr::GfVec3f>& values) const {
+    for (uint64_t i = 0; i < _size; i++) {
+        values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[i]);
+    }
+}
+
+const glm::fvec3& PositionsAccessor::get(uint64_t index) const {
+    return _view[index];
+}
+
+uint64_t PositionsAccessor::size() const {
+    return _size;
+}
+
+IndicesAccessor::IndicesAccessor()
+    : _size(0) {}
+
+IndicesAccessor::IndicesAccessor(uint64_t size)
+    : _size(size) {}
+
+IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint8_t>& uint8View)
+    : _uint8View(uint8View)
+    , _size(uint8View.size()) {}
+
+IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint16_t>& uint16View)
+    : _uint16View(uint16View)
+    , _size(uint16View.size()) {}
+
+IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint32_t>& uint32View)
+    : _uint32View(uint32View)
+    , _size(uint32View.size()) {}
+
+template <typename T> IndicesAccessor IndicesAccessor::FromTriangleStrips(const CesiumGltf::AccessorView<T>& view) {
+    auto indices = std::vector<uint32_t>();
+    indices.reserve(static_cast<uint64_t>(view.size() - 2) * 3);
+
+    for (auto i = 0; i < view.size() - 2; i++) {
+        if (i % 2) {
+            indices.push_back(static_cast<uint32_t>(view[i]));
+            indices.push_back(static_cast<uint32_t>(view[i + 2]));
+            indices.push_back(static_cast<uint32_t>(view[i + 1]));
+        } else {
+            indices.push_back(static_cast<uint32_t>(view[i]));
+            indices.push_back(static_cast<uint32_t>(view[i + 1]));
+            indices.push_back(static_cast<uint32_t>(view[i + 2]));
+        }
+    }
+
+    auto accessor = IndicesAccessor();
+    accessor._computed = std::move(indices);
+    accessor._size = indices.size();
+    return accessor;
+}
+
+// Explicit template instantiation
+template IndicesAccessor IndicesAccessor::FromTriangleStrips<uint8_t>(const CesiumGltf::AccessorView<uint8_t>& view);
+template IndicesAccessor IndicesAccessor::FromTriangleStrips<uint16_t>(const CesiumGltf::AccessorView<uint16_t>& view);
+template IndicesAccessor IndicesAccessor::FromTriangleStrips<uint32_t>(const CesiumGltf::AccessorView<uint32_t>& view);
+
+template <typename T> IndicesAccessor IndicesAccessor::FromTriangleFans(const CesiumGltf::AccessorView<T>& view) {
+    auto indices = std::vector<uint32_t>();
+    indices.reserve(static_cast<uint64_t>(view.size() - 2) * 3);
+
+    for (auto i = 0; i < view.size() - 2; i++) {
+        indices.push_back(static_cast<uint32_t>(view[0]));
+        indices.push_back(static_cast<uint32_t>(view[i + 1]));
+        indices.push_back(static_cast<uint32_t>(view[i + 2]));
+    }
+
+    auto accessor = IndicesAccessor();
+    accessor._computed = std::move(indices);
+    accessor._size = indices.size();
+    return accessor;
+}
+
+// Explicit template instantiation
+template IndicesAccessor IndicesAccessor::FromTriangleFans<uint8_t>(const CesiumGltf::AccessorView<uint8_t>& view);
+template IndicesAccessor IndicesAccessor::FromTriangleFans<uint16_t>(const CesiumGltf::AccessorView<uint16_t>& view);
+template IndicesAccessor IndicesAccessor::FromTriangleFans<uint32_t>(const CesiumGltf::AccessorView<uint32_t>& view);
+
+void IndicesAccessor::fill(const gsl::span<int>& values) const {
+    if (!_computed.empty()) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = static_cast<int>(_computed[i]);
+        }
+    } else if (_uint8View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = static_cast<int>(_uint8View[i]);
+        }
+    } else if (_uint16View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = static_cast<int>(_uint16View[i]);
+        }
+    } else if (_uint32View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = static_cast<int>(_uint32View[i]);
+        }
+    } else {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = static_cast<int>(i);
+        }
+    }
+}
+
+uint32_t IndicesAccessor::get(uint64_t index) const {
+    if (!_computed.empty()) {
+        return _computed[index];
+    } else if (_uint8View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        return static_cast<uint32_t>(_uint8View[index]);
+    } else if (_uint16View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        return static_cast<uint32_t>(_uint16View[index]);
+    } else if (_uint32View.status() == CesiumGltf::AccessorViewStatus::Valid) {
+        return static_cast<uint32_t>(_uint32View[index]);
+    } else {
+        return static_cast<uint32_t>(index);
+    }
+}
+
+uint64_t IndicesAccessor::size() const {
+    return _size;
+}
+
+NormalsAccessor::NormalsAccessor()
+    : _size(0) {}
+
+NormalsAccessor::NormalsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view)
+    : _view(view)
+    , _size(view.size()) {}
+
+NormalsAccessor NormalsAccessor::GenerateSmooth(const PositionsAccessor& positions, const IndicesAccessor& indices) {
+    auto normals = std::vector<glm::fvec3>(positions.size(), glm::fvec3(0.0f));
+
+    for (uint64_t i = 0; i < indices.size(); i += 3) {
+        auto idx0 = static_cast<uint64_t>(indices.get(i));
+        auto idx1 = static_cast<uint64_t>(indices.get(i + 1));
+        auto idx2 = static_cast<uint64_t>(indices.get(i + 2));
+
+        const auto& p0 = positions.get(idx0);
+        const auto& p1 = positions.get(idx1);
+        const auto& p2 = positions.get(idx2);
+        auto n = glm::normalize(glm::cross(p1 - p0, p2 - p0));
+
+        normals[idx0] += n;
+        normals[idx1] += n;
+        normals[idx2] += n;
+    }
+
+    for (auto& n : normals) {
+        n = glm::normalize(n);
+    }
+
+    auto accessor = NormalsAccessor();
+    accessor._computed = std::move(normals);
+    accessor._size = indices.size();
+    return accessor;
+}
+
+void NormalsAccessor::fill(const gsl::span<pxr::GfVec3f>& values) const {
+    if (!_computed.empty()) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_computed[i]);
+        }
+    } else {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[i]);
+        }
+    }
+}
+
+uint64_t NormalsAccessor::size() const {
+    return _size;
+}
+
+TexcoordsAccessor::TexcoordsAccessor()
+    : _size(0) {}
+
+TexcoordsAccessor::TexcoordsAccessor(
+    const CesiumGltf::AccessorView<glm::fvec2>& view,
+    const glm::fvec2& translation,
+    const glm::fvec2& scale,
+    bool flipVertical)
+    : _view(view)
+    , _translation(translation)
+    , _scale(scale)
+    , _applyTransform(translation != glm::fvec2(0.0, 0.0) && scale != glm::fvec2(1.0, 1.0))
+    , _flipVertical(flipVertical)
+    , _size(view.size()) {}
+
+void TexcoordsAccessor::fill(const gsl::span<pxr::GfVec2f>& values) const {
+    for (uint64_t i = 0; i < _size; i++) {
+        values[i] = *reinterpret_cast<const pxr::GfVec2f*>(&_view[i]);
+    }
+
+    if (_flipVertical) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i][1] = 1.0f - values[i][1];
+        }
+    }
+
+    if (_applyTransform) {
+        for (uint64_t i = 0; i < _size; i++) {
+            values[i][0] = values[i][0] * _scale.x + _translation.x;
+            values[i][1] = values[i][1] * _scale.y + _translation.y;
+        }
+    }
+}
+
+uint64_t TexcoordsAccessor::size() const {
+    return _size;
+}
+
+FaceVertexCountsAccessor::FaceVertexCountsAccessor()
+    : _size(0) {}
+
+FaceVertexCountsAccessor::FaceVertexCountsAccessor(uint64_t size)
+    : _size(size) {}
+
+void FaceVertexCountsAccessor::fill(const gsl::span<int>& values) const {
+    for (uint64_t i = 0; i < _size; i++) {
+        values[i] = 3;
+    }
+}
+
+uint64_t FaceVertexCountsAccessor::size() const {
+    return _size;
+}
+
+} // namespace cesium::omniverse


### PR DESCRIPTION
Instead of reading positions, texcoords, indices, etc into `pxr::VtArray`'s and then copying into Fabric arrays, we can skip the middle step. This saves about 0.1 to 0.2 ms per `FabricPrepareRenderResources::setFabricMeshes` call.


To reproduce: build with [tracing enabled](https://github.com/CesiumGS/cesium-omniverse/blob/main/docs/developer-setup/README.md#tracing), fly around the scene a bit, drag the result into https://ui.perfetto.dev/, and run the SQL query:
```
SELECT AVG(dur) / 1000000 FROM (SELECT dur FROM slice WHERE name = 'FabricPrepareRenderResources::setFabricMeshes')
```