### PR TITLE
Update Visual Studio settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ trace.csv
 .idea
 
 # Visual Studio Cache/Options
-.vs
+.vs/*
+!.vs/launch.vs.json
 
 # Installed python bindings
 exts/cesium.omniverse/cesium/omniverse/bindings/CesiumOmniversePythonBindings.cpython-37m-x86_64-linux-gnu.so

--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.1",
+  "configurations": [
+    {
+      "name": "Kit App",
+      "project": "extern/nvidia/_build/target-deps/kit-sdk/kit.exe",
+      "args": [
+        "apps/cesium.omniverse.app.kit"
+      ],
+      "currentDir": "${workspaceRoot}"
+    }
+  ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -2,39 +2,43 @@
   "configurations": [
     {
       "name": "x64-Debug",
-      "generator": "Visual Studio 17 2022 Win64",
+      "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\build-debug",
-      "installRoot": "${projectDir}\\install-debug",
+      "buildRoot": "${projectDir}\\build-vs-d",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "cmakeExecutable": "C:\\Program Files\\CMake\\bin\\cmake.exe"
-    },
-    {
-      "name": "x64-RelWithDebInfo",
-      "generator": "Visual Studio 17 2022 Win64",
-      "configurationType": "RelWithDebInfo",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\build-r",
-      "installRoot": "${projectDir}\\install-debug",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "cmakeExecutable": "C:\\Program Files\\CMake\\bin\\cmake.exe"
+      "buildCommandArgs": "-v install",
+      "ctestCommandArgs": ""
     },
     {
       "name": "x64-Release",
-      "generator": "Visual Studio 17 2022 Win64",
+      "generator": "Ninja",
       "configurationType": "Release",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\build",
-      "installRoot": "${projectDir}\\install",
+      "buildRoot": "${projectDir}\\build-vs-r",
       "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "cmakeExecutable": "C:\\Program Files\\CMake\\bin\\cmake.exe"
+      "buildCommandArgs": "-v install",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\build-vs-rd",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v install",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-MinSizeRel",
+      "generator": "Ninja",
+      "configurationType": "MinSizeRel",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\build-vs-rm",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v install",
+      "ctestCommandArgs": ""
     }
   ]
 }


### PR DESCRIPTION
I'm about to start profiling with Visual Studio and did a few things to improve the build process. These changes are mainly relevant if you open the `cesium-omniverse` folder instead of a solution file.

* Renamed build folders to `build-vs-*` to deconflict with VSCode build folders. It's not really possible for VSCode and Visual Studio to use the same build folder since they use different generators, `Ninja Multi-Config` and `Ninja` respectively.
* Added `-v install` so that the install target is always run during build
* Added `launch.vs.json` so that we can launch and debug kit applications from within Visual Studio

I couldn't figure out how to invoke a pre-build task from `launch.vs.json`. What I wanted to do was force a rebuild whenever `Kit App` is run. If I figure that out I can open a separate PR.