### PR TITLE
Store Fabric paths in FabricGeometry and FabricMaterial

### DIFF
--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -2,6 +2,7 @@
 
 #include "cesium/omniverse/FabricGeometryDefinition.h"
 
+#include <carb/flatcache/IPath.h>
 #include <glm/glm.hpp>
 #include <pxr/usd/sdf/path.h>
 
@@ -36,7 +37,7 @@ class FabricGeometry {
     void setActive(bool active);
     void setVisibility(bool visible);
 
-    pxr::SdfPath getPath() const;
+    carb::flatcache::Path getPathFabric() const;
     const FabricGeometryDefinition& getGeometryDefinition() const;
 
     void assignMaterial(std::shared_ptr<FabricMaterial> material);
@@ -45,7 +46,7 @@ class FabricGeometry {
     void initialize();
     void reset();
 
-    const pxr::SdfPath _path;
+    const carb::flatcache::Path _pathFabric;
     const FabricGeometryDefinition _geometryDefinition;
 };
 

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -2,6 +2,7 @@
 
 #include "cesium/omniverse/FabricMaterialDefinition.h"
 
+#include <carb/flatcache/IPath.h>
 #include <pxr/usd/sdf/path.h>
 
 namespace omni::ui {
@@ -30,7 +31,7 @@ class FabricMaterial {
 
     void setActive(bool active);
 
-    pxr::SdfPath getPath() const;
+    carb::flatcache::Path getPathFabric() const;
     const FabricMaterialDefinition& getMaterialDefinition() const;
 
   private:
@@ -40,11 +41,11 @@ class FabricMaterial {
 
     const FabricMaterialDefinition _materialDefinition;
 
-    pxr::SdfPath _materialPath;
-    pxr::SdfPath _shaderPath;
-    pxr::SdfPath _displacementPath;
-    pxr::SdfPath _surfacePath;
-    pxr::SdfPath _baseColorTexPath;
+    carb::flatcache::Path _materialPathFabric;
+    carb::flatcache::Path _shaderPathFabric;
+    carb::flatcache::Path _displacementPathFabric;
+    carb::flatcache::Path _surfacePathFabric;
+    carb::flatcache::Path _baseColorTexPathFabric;
 
     std::unique_ptr<omni::ui::DynamicTextureProvider> _baseColorTexture;
 };

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -2,6 +2,7 @@
 
 #include "cesium/omniverse/RenderStatistics.h"
 
+#include <carb/flatcache/IPath.h>
 #include <glm/glm.hpp>
 #include <pxr/usd/sdf/path.h>
 
@@ -23,9 +24,9 @@ namespace cesium::omniverse::FabricUtil {
 
 std::string printFabricStage();
 FabricStatistics getStatistics();
-void destroyPrim(const pxr::SdfPath& path);
-void destroyPrims(const std::vector<pxr::SdfPath>& paths);
+void destroyPrim(const carb::flatcache::Path& path);
+void destroyPrims(const std::vector<carb::flatcache::Path>& paths);
 void setTilesetTransform(int64_t tilesetId, const glm::dmat4& ecefToUsdTransform);
-void setTilesetIdAndTileId(const pxr::SdfPath& path, int64_t tilesetId, int64_t tileId);
+void setTilesetIdAndTileId(const carb::flatcache::Path& pathFabric, int64_t tilesetId, int64_t tileId);
 
 } // namespace cesium::omniverse::FabricUtil

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -543,7 +543,7 @@ FabricStatistics getStatistics() {
 }
 
 namespace {
-void destroyPrimsSpan(gsl::span<const pxr::SdfPath> paths) {
+void destroyPrimsSpan(gsl::span<const carb::flatcache::Path> paths) {
     // Only delete prims if there's still a stage to delete them from
     if (!UsdUtil::hasStage()) {
         return;
@@ -552,7 +552,7 @@ void destroyPrimsSpan(gsl::span<const pxr::SdfPath> paths) {
     auto sip = UsdUtil::getFabricStageInProgress();
 
     for (const auto& path : paths) {
-        sip.destroyPrim(carb::flatcache::asInt(path));
+        sip.destroyPrim(path);
     }
 
     // Prims removed from Fabric need special handling for their removal to be reflected in the Hydra render index
@@ -568,16 +568,16 @@ void destroyPrimsSpan(gsl::span<const pxr::SdfPath> paths) {
     auto deletedPrimsFabric = sip.getArrayAttributeWr<uint64_t>(changeTrackingPath, FabricTokens::_deletedPrims);
 
     for (size_t i = 0; i < paths.size(); i++) {
-        deletedPrimsFabric[deletedPrimsSize + i] = carb::flatcache::asInt(paths[i]).path;
+        deletedPrimsFabric[deletedPrimsSize + i] = carb::flatcache::PathC(paths[i]).path;
     }
 }
 } // namespace
 
-void destroyPrim(const pxr::SdfPath& path) {
+void destroyPrim(const carb::flatcache::Path& path) {
     destroyPrimsSpan(gsl::span(&path, 1));
 }
 
-void destroyPrims(const std::vector<pxr::SdfPath>& paths) {
+void destroyPrims(const std::vector<carb::flatcache::Path>& paths) {
     destroyPrimsSpan(gsl::span(paths));
 }
 
@@ -619,10 +619,9 @@ void setTilesetTransform(int64_t tilesetId, const glm::dmat4& ecefToUsdTransform
     }
 }
 
-void setTilesetIdAndTileId(const pxr::SdfPath& path, int64_t tilesetId, int64_t tileId) {
+void setTilesetIdAndTileId(const carb::flatcache::Path& pathFabric, int64_t tilesetId, int64_t tileId) {
     auto sip = UsdUtil::getFabricStageInProgress();
 
-    const auto pathFabric = carb::flatcache::Path(carb::flatcache::asInt(path));
     auto tilesetIdFabric = sip.getAttributeWr<int64_t>(pathFabric, FabricTokens::_cesium_tilesetId);
     auto tileIdFabric = sip.getAttributeWr<int64_t>(pathFabric, FabricTokens::_cesium_tileId);
 


### PR DESCRIPTION
Fabric paths, like USD paths, are reference counted, so to make lifetime more explicit we should store them as member variables in `FabricGeometry` and `FabricMaterial`. Previously we were storing the USD paths.

This change might not be necessary since the Fabric stage is already holding onto the prim paths, but it's still good practice and a bit cleaner to do it this way.