### PR TITLE
Fix printing text attributes in "Print Fabric stage"

### DIFF
--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -107,7 +107,11 @@ std::string printAttributeValue(const T* values, uint64_t elementCount, uint64_t
 }
 
 template <bool IsArray, typename BaseType, uint64_t ComponentCount>
-std::string printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache::Token& attributeName) {
+std::string printAttributeValue(
+    const carb::flatcache::Path& primPath,
+    const carb::flatcache::Token& attributeName,
+    const carb::flatcache::AttributeRole& role) {
+
     using ElementType = std::array<BaseType, ComponentCount>;
 
     auto stageInProgress = UsdUtil::getFabricStageInProgress();
@@ -120,7 +124,13 @@ std::string printAttributeValue(const carb::flatcache::Path& primPath, const car
             return NO_DATA_STRING;
         }
 
-        return printAttributeValue<BaseType>(values.front().data(), elementCount, ComponentCount, true);
+        const auto valuesPtr = values.front().data();
+
+        if (role == carb::flatcache::AttributeRole::eText) {
+            return std::string(reinterpret_cast<const char*>(valuesPtr), elementCount);
+        }
+
+        return printAttributeValue<BaseType>(valuesPtr, elementCount, ComponentCount, true);
     } else {
         const auto value = stageInProgress.getAttributeRd<ElementType>(primPath, attributeName);
 
@@ -141,6 +151,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
     const auto componentCount = attributeType.componentCount;
     const auto name = attribute.name;
     const auto arrayDepth = attributeType.arrayDepth;
+    const auto role = attributeType.role;
 
     // This switch statement should cover most of the attribute types we expect to see on the stage.
     // This includes the USD types in SdfValueTypeNames and Fabric types like assets and tokens.
@@ -150,7 +161,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eAsset: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, AssetWrapper, 1>(primPath, name);
+                        return printAttributeValue<false, AssetWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -161,7 +172,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eToken: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, TokenWrapper, 1>(primPath, name);
+                        return printAttributeValue<false, TokenWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -172,7 +183,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eBool: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, BoolWrapper, 1>(primPath, name);
+                        return printAttributeValue<false, BoolWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -183,7 +194,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUChar: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, uint8_t, 1>(primPath, name);
+                        return printAttributeValue<false, uint8_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -194,16 +205,16 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eInt: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, int32_t, 1>(primPath, name);
+                        return printAttributeValue<false, int32_t, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<false, int32_t, 2>(primPath, name);
+                        return printAttributeValue<false, int32_t, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<false, int32_t, 3>(primPath, name);
+                        return printAttributeValue<false, int32_t, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<false, int32_t, 4>(primPath, name);
+                        return printAttributeValue<false, int32_t, 4>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -214,7 +225,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUInt: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, uint32_t, 1>(primPath, name);
+                        return printAttributeValue<false, uint32_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -225,7 +236,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eInt64: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, int64_t, 1>(primPath, name);
+                        return printAttributeValue<false, int64_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -236,7 +247,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUInt64: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, uint64_t, 1>(primPath, name);
+                        return printAttributeValue<false, uint64_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -247,16 +258,16 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eFloat: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, float, 1>(primPath, name);
+                        return printAttributeValue<false, float, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<false, float, 2>(primPath, name);
+                        return printAttributeValue<false, float, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<false, float, 3>(primPath, name);
+                        return printAttributeValue<false, float, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<false, float, 4>(primPath, name);
+                        return printAttributeValue<false, float, 4>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -267,25 +278,25 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eDouble: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<false, double, 1>(primPath, name);
+                        return printAttributeValue<false, double, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<false, double, 2>(primPath, name);
+                        return printAttributeValue<false, double, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<false, double, 3>(primPath, name);
+                        return printAttributeValue<false, double, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<false, double, 4>(primPath, name);
+                        return printAttributeValue<false, double, 4>(primPath, name, role);
                     }
                     case 6: {
-                        return printAttributeValue<false, double, 6>(primPath, name);
+                        return printAttributeValue<false, double, 6>(primPath, name, role);
                     }
                     case 9: {
-                        return printAttributeValue<false, double, 9>(primPath, name);
+                        return printAttributeValue<false, double, 9>(primPath, name, role);
                     }
                     case 16: {
-                        return printAttributeValue<false, double, 16>(primPath, name);
+                        return printAttributeValue<false, double, 16>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -302,7 +313,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eAsset: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, AssetWrapper, 1>(primPath, name);
+                        return printAttributeValue<true, AssetWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -313,7 +324,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eToken: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, TokenWrapper, 1>(primPath, name);
+                        return printAttributeValue<true, TokenWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -324,7 +335,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eBool: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, BoolWrapper, 1>(primPath, name);
+                        return printAttributeValue<true, BoolWrapper, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -335,7 +346,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUChar: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, uint8_t, 1>(primPath, name);
+                        return printAttributeValue<true, uint8_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -346,16 +357,16 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eInt: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, int32_t, 1>(primPath, name);
+                        return printAttributeValue<true, int32_t, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<true, int32_t, 2>(primPath, name);
+                        return printAttributeValue<true, int32_t, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<true, int32_t, 3>(primPath, name);
+                        return printAttributeValue<true, int32_t, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<true, int32_t, 4>(primPath, name);
+                        return printAttributeValue<true, int32_t, 4>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -366,7 +377,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUInt: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, uint32_t, 1>(primPath, name);
+                        return printAttributeValue<true, uint32_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -377,7 +388,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eInt64: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, int64_t, 1>(primPath, name);
+                        return printAttributeValue<true, int64_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -388,7 +399,7 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eUInt64: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, uint64_t, 1>(primPath, name);
+                        return printAttributeValue<true, uint64_t, 1>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -399,16 +410,16 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eFloat: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, float, 1>(primPath, name);
+                        return printAttributeValue<true, float, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<true, float, 2>(primPath, name);
+                        return printAttributeValue<true, float, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<true, float, 3>(primPath, name);
+                        return printAttributeValue<true, float, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<true, float, 4>(primPath, name);
+                        return printAttributeValue<true, float, 4>(primPath, name, role);
                     }
                     default: {
                         break;
@@ -419,25 +430,25 @@ printAttributeValue(const carb::flatcache::Path& primPath, const carb::flatcache
             case carb::flatcache::BaseDataType::eDouble: {
                 switch (componentCount) {
                     case 1: {
-                        return printAttributeValue<true, double, 1>(primPath, name);
+                        return printAttributeValue<true, double, 1>(primPath, name, role);
                     }
                     case 2: {
-                        return printAttributeValue<true, double, 2>(primPath, name);
+                        return printAttributeValue<true, double, 2>(primPath, name, role);
                     }
                     case 3: {
-                        return printAttributeValue<true, double, 3>(primPath, name);
+                        return printAttributeValue<true, double, 3>(primPath, name, role);
                     }
                     case 4: {
-                        return printAttributeValue<true, double, 4>(primPath, name);
+                        return printAttributeValue<true, double, 4>(primPath, name, role);
                     }
                     case 6: {
-                        return printAttributeValue<true, double, 6>(primPath, name);
+                        return printAttributeValue<true, double, 6>(primPath, name, role);
                     }
                     case 9: {
-                        return printAttributeValue<true, double, 9>(primPath, name);
+                        return printAttributeValue<true, double, 9>(primPath, name, role);
                     }
                     case 16: {
-                        return printAttributeValue<true, double, 16>(primPath, name);
+                        return printAttributeValue<true, double, 16>(primPath, name, role);
                     }
                     default: {
                         break;


### PR DESCRIPTION
Previously we ignored the attribute role when printing fabric attributes. For the "text" attribute role it's nicer to see `primvars:vertexColor` instead of `[p,r,i,m,v,a,r,s,:,v,e,r,t,e,x,C,o,l,o,r]`

**Before**
```
    Attribute: vertex_color_name
      Type: uchar[] (text)
      Value: [p,r,i,m,v,a,r,s,:,v,e,r,t,e,x,C,o,l,o,r]
```

**After**
```
    Attribute: vertex_color_name
      Type: uchar[] (text)
      Value: primvars:vertexColor
```