### PR TITLE
update_certs.py was silently failing on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,12 +115,13 @@ jobs:
       # hardcoding their locations instead. Followed these instructions for adding to the PATH on PowerShell:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
       # Note that this is only a problem on CI, not with local builds
+      # Also requests is not installed by default on windows, but is expected by scripts/update_certs.py
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
         run: |
           choco install -y conan --version 1.58.0
           choco install -y llvm --version=14.0.6 --allow-downgrade
-          pip3 install black==23.1.0 flake8==6.0.0
+          pip3 install black==23.1.0 flake8==6.0.0 requests
           echo "C:/Program Files/conan/conan" >> $env:GITHUB_PATH
 
       # Note: CMAKE_BUILD_TYPE is only used by Linux. It is ignored for Windows.

--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -107,6 +107,10 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
     cd <first_path_in_list>
     mklink python3.exe python.exe
     ```
+- Install `requests` module for Python
+  ```sh
+  pip3 install requests
+  ```
 - Install `cmake-format`
   ```sh
   pip3 install cmake-format
@@ -156,6 +160,10 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
   where python
   cd <first_path_in_list>
   mklink python3.exe python.exe
+  ```
+- Install `requests`
+  ```sh
+  pip3 install requests
   ```
 - Install `cmake-format`
   ```sh

--- a/scripts/update_certs.py
+++ b/scripts/update_certs.py
@@ -33,7 +33,8 @@ def main():
         print(f"failed to fetch certificates from {CERT_URL}")
         return -1
 
-    with open(CERT_FILE_PATH, "w") as f:
+    # explicit encoding is required for windows
+    with open(CERT_FILE_PATH, "w", encoding='utf-8') as f:
         f.write(req.text)
 
     return 0


### PR DESCRIPTION
fixes #327. It needed `requests` and to explicitly write the cert file as `utf-8`