### PR TITLE
builds now use larger runners and windows returns to github runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - {
               name: 'Windows - MSVC',
               artifact: 'windows-msvc.tar.xz',
-              os: ['self-hosted', 'windows', 'x64', 'vs2022'],
+              os: windows-latest-l,
               cc: 'cl',
               cxx: 'cl',
               build-type: 'Release',
@@ -39,7 +39,7 @@ jobs:
           - {
               name: 'CentOS 7 - GCC',
               artifact: 'linux-gcc.tar.xz',
-              os: ubuntu-22.04,
+              os: ubuntu-latest-m,
               cc: 'gcc-11',
               cxx: 'g++-11',
               build-type: 'Release',
@@ -70,7 +70,7 @@ jobs:
       - name: Conan Set build directory (Windows)
         if: runner.os == 'Windows'
         run: |
-          echo "CONAN_USER_HOME=d:\" >> $env:GITHUB_ENV
+          echo "CONAN_USER_HOME=$env:GITHUB_WORKSPACE" >> $env:GITHUB_ENV
           echo "CONAN_USER_HOME_SHORT=None" >> $env:GITHUB_ENV
 
       # The -v{num} is a cache key buster because we were starting to use the same cache keys from previous tests
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.CONAN_USER_HOME }}/.conan
-          key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v2
+          key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v3
 
       # The -v{num} is a cache key buster to invalidate the Docker image cache
       - name: Load Docker image cache


### PR DESCRIPTION
fixes #324. Github opened a beta for larger runners, which fixes the problem of CentOS builds running OOM, which is a pretty simple drop-in replacement. It also allows us to bring windows builds back to github from the current self-hosted runner, which was a bit more involved. 

Part of moving the windows builds back to github is adjusting the `conan` setup. The self-hosted runner placed the conan home dir on a separate volume ([explained here](https://github.com/CesiumGS/cesium-omniverse/pull/125#issuecomment-1409589587)), but this no longer seems necessary so I've removed the `d:\`. Also this move was potentially causing us to not find the conan home dir as a result of the previously cached docker image containing the conan dir in a different location. As a result we've incremented the cache busting counter. 