### PR TITLE
update docker caching to address CI action deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       # The -v{num} is a cache key buster to invalidate the Docker image cache
       - name: Load Docker image cache
         if: matrix.config.name == 'CentOS 7 - GCC'
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
         with:
           key: docker-layer-caching-v1-${{ github.workflow }}-{hash}


### PR DESCRIPTION
fixes #303. These were caused by the docker layer caching action using an old deprecated version of node. That action no longer appears to be in development, but a fork is. See [this issue on the original action repo](https://github.com/satackey/action-docker-layer-caching/issues/347). This switches the action to use the active fork