### PR TITLE
Tileset georeference binding

### DIFF
--- a/src/core/include/cesium/omniverse/AssetRegistry.h
+++ b/src/core/include/cesium/omniverse/AssetRegistry.h
@@ -28,7 +28,7 @@ class AssetRegistry {
     AssetRegistry& operator=(const AssetRegistry&) = delete;
     AssetRegistry& operator=(AssetRegistry) = delete;
 
-    void addTileset(const pxr::SdfPath &tilesetPath, const pxr::SdfPath &georeferencePath);
+    void addTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
     void removeTileset(const pxr::SdfPath& path);
     std::optional<std::shared_ptr<OmniTileset>> getTilesetByPath(const pxr::SdfPath& path) const;
     std::optional<std::shared_ptr<OmniTileset>> getTilesetByIonAssetId(int64_t ionAssetId) const;

--- a/src/core/include/cesium/omniverse/AssetRegistry.h
+++ b/src/core/include/cesium/omniverse/AssetRegistry.h
@@ -28,7 +28,7 @@ class AssetRegistry {
     AssetRegistry& operator=(const AssetRegistry&) = delete;
     AssetRegistry& operator=(AssetRegistry) = delete;
 
-    void addTileset(const pxr::SdfPath& path);
+    void addTileset(const pxr::SdfPath &tilesetPath, const pxr::SdfPath &georeferencePath);
     void removeTileset(const pxr::SdfPath& path);
     std::optional<std::shared_ptr<OmniTileset>> getTilesetByPath(const pxr::SdfPath& path) const;
     std::optional<std::shared_ptr<OmniTileset>> getTilesetByIonAssetId(int64_t ionAssetId) const;

--- a/src/core/include/cesium/omniverse/GeospatialUtil.h
+++ b/src/core/include/cesium/omniverse/GeospatialUtil.h
@@ -10,6 +10,6 @@ class Cartographic;
 
 namespace cesium::omniverse::GeospatialUtil {
 
-const CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference);
+CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference);
 
 }; // namespace cesium::omniverse::GeospatialUtil

--- a/src/core/include/cesium/omniverse/GeospatialUtil.h
+++ b/src/core/include/cesium/omniverse/GeospatialUtil.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <CesiumGeospatial/Cartographic.h>
+#include <CesiumUsdSchemas/georeference.h>
+#include <glm/glm.hpp>
+
+namespace CesiumGeospatial {
+class Cartographic;
+}
+
+namespace cesium::omniverse::GeospatialUtil {
+
+const CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference);
+
+}; // namespace cesium::omniverse::GeospatialUtil

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <CesiumIonClient/Token.h>
+#include <CesiumUsdSchemas/georeference.h>
 #include <glm/glm.hpp>
 #include <pxr/usd/sdf/path.h>
 
@@ -29,7 +30,7 @@ struct Viewport;
 
 class OmniTileset {
   public:
-    OmniTileset(const pxr::SdfPath& tilesetPath);
+    OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
     ~OmniTileset();
 
     pxr::SdfPath getPath() const;
@@ -52,6 +53,7 @@ class OmniTileset {
     bool getSuspendUpdate() const;
     bool getSmoothNormals() const;
     bool getShowCreditsOnScreen() const;
+    pxr::CesiumGeoreference getGeoreference() const;
 
     int64_t getTilesetId() const;
     uint64_t getCachedBytes() const;

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -87,6 +87,7 @@ pxr::CesiumImagery defineCesiumImagery(const pxr::SdfPath& path);
 pxr::CesiumData getOrCreateCesiumData();
 pxr::CesiumSession getOrCreateCesiumSession();
 pxr::CesiumGeoreference getOrCreateCesiumGeoreference();
+pxr::CesiumGeoreference getCesiumGeoreference(const pxr::SdfPath& path);
 pxr::CesiumTilesetAPI getCesiumTileset(const pxr::SdfPath& path);
 pxr::CesiumImagery getCesiumImagery(const pxr::SdfPath& path);
 std::vector<pxr::CesiumImagery> getChildCesiumImageryPrims(const pxr::SdfPath& path);
@@ -98,5 +99,7 @@ bool isCesiumTileset(const pxr::SdfPath& path);
 bool isCesiumImagery(const pxr::SdfPath& path);
 
 bool primExists(const pxr::SdfPath& path);
+
+[[maybe_unused]] void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
 
 }; // namespace cesium::omniverse::UsdUtil

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -55,6 +55,8 @@ class ScopedEdit {
     pxr::UsdEditTarget _originalEditTarget;
 };
 
+static const auto GEOREFERENCE_PATH = pxr::SdfPath("/CesiumGeoreference");
+
 pxr::UsdStageRefPtr getUsdStage();
 carb::flatcache::StageInProgress getFabricStageInProgress();
 bool hasStage();
@@ -100,6 +102,6 @@ bool isCesiumImagery(const pxr::SdfPath& path);
 
 bool primExists(const pxr::SdfPath& path);
 
-[[maybe_unused]] void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
+void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
 
 }; // namespace cesium::omniverse::UsdUtil

--- a/src/core/src/AssetRegistry.cpp
+++ b/src/core/src/AssetRegistry.cpp
@@ -5,8 +5,8 @@
 
 namespace cesium::omniverse {
 
-void AssetRegistry::addTileset(const pxr::SdfPath& path) {
-    _tilesets.insert(_tilesets.end(), std::make_shared<OmniTileset>(path));
+void AssetRegistry::addTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath) {
+    _tilesets.insert(_tilesets.end(), std::make_shared<OmniTileset>(tilesetPath, georeferencePath));
 }
 
 void AssetRegistry::removeTileset(const pxr::SdfPath& path) {

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -215,7 +215,7 @@ void Context::reloadStage() {
     for (const auto& prim : stage->Traverse()) {
         const auto& path = prim.GetPath();
         if (UsdUtil::isCesiumTileset(path)) {
-            AssetRegistry::getInstance().addTileset(path, pxr::SdfPath("/CesiumGeoreference"));
+            AssetRegistry::getInstance().addTileset(path, UsdUtil::GEOREFERENCE_PATH);
         } else if (UsdUtil::isCesiumImagery(path)) {
             AssetRegistry::getInstance().addImagery(path);
         }

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -214,7 +214,7 @@ void Context::reloadStage() {
     for (const auto& prim : stage->Traverse()) {
         const auto& path = prim.GetPath();
         if (UsdUtil::isCesiumTileset(path)) {
-            AssetRegistry::getInstance().addTileset(path);
+            AssetRegistry::getInstance().addTileset(path, pxr::SdfPath("/CesiumGeoreference"));
         } else if (UsdUtil::isCesiumImagery(path)) {
             AssetRegistry::getInstance().addImagery(path);
         }
@@ -349,7 +349,7 @@ void Context::processPrimAdded(const ChangedPrim& changedPrim) {
     if (changedPrim.primType == ChangedPrimType::CESIUM_TILESET) {
         // Add the tileset to the asset registry
         const auto tilesetPath = changedPrim.path;
-        AssetRegistry::getInstance().addTileset(tilesetPath);
+        AssetRegistry::getInstance().addTileset(tilesetPath, pxr::SdfPath("/CesiumGeoreference"));
     } else if (changedPrim.primType == ChangedPrimType::CESIUM_IMAGERY) {
         // Add the imagery to the asset registry and reload the tileset that the imagery is attached to
         const auto imageryPath = changedPrim.path;

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -5,6 +5,7 @@
 #include "cesium/omniverse/CesiumIonSession.h"
 #include "cesium/omniverse/FabricMeshManager.h"
 #include "cesium/omniverse/FabricUtil.h"
+#include "cesium/omniverse/GeospatialUtil.h"
 #include "cesium/omniverse/HttpAssetAccessor.h"
 #include "cesium/omniverse/LoggerSink.h"
 #include "cesium/omniverse/OmniImagery.h"
@@ -457,14 +458,7 @@ int64_t Context::getNextTileId() const {
 const CesiumGeospatial::Cartographic Context::getGeoreferenceOrigin() const {
     const auto georeference = UsdUtil::getOrCreateCesiumGeoreference();
 
-    double longitude;
-    double latitude;
-    double height;
-    georeference.GetGeoreferenceOriginLongitudeAttr().Get<double>(&longitude);
-    georeference.GetGeoreferenceOriginLatitudeAttr().Get<double>(&latitude);
-    georeference.GetGeoreferenceOriginHeightAttr().Get<double>(&height);
-
-    return CesiumGeospatial::Cartographic(glm::radians(longitude), glm::radians(latitude), height);
+    return GeospatialUtil::convertGeoreferenceToCartographic(georeference);
 }
 
 void Context::setGeoreferenceOrigin(const CesiumGeospatial::Cartographic& origin) {

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -3,6 +3,7 @@
 #include "cesium/omniverse/Context.h"
 #include "cesium/omniverse/FabricMesh.h"
 #include "cesium/omniverse/FabricMeshManager.h"
+#include "cesium/omniverse/GeospatialUtil.h"
 #include "cesium/omniverse/OmniTileset.h"
 #include "cesium/omniverse/UsdUtil.h"
 
@@ -59,8 +60,8 @@ std::vector<IntermediaryMesh> gatherMeshes(
 
     const auto smoothNormals = tileset.getSmoothNormals();
 
-    const auto ecefToUsdTransform =
-        UsdUtil::computeEcefToUsdTransformForPrim(Context::instance().getGeoreferenceOrigin(), tileset.getPath());
+    const auto georeferenceOrigin = GeospatialUtil::convertGeoreferenceToCartographic(tileset.getGeoreference());
+    const auto ecefToUsdTransform = UsdUtil::computeEcefToUsdTransformForPrim(georeferenceOrigin, tileset.getPath());
 
     auto gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyRtcCenter(model, tileTransform);
     gltfToEcefTransform = Cesium3DTilesSelection::GltfUtilities::applyGltfUpAxisTransform(model, gltfToEcefTransform);

--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -2,7 +2,7 @@
 
 namespace cesium::omniverse::GeospatialUtil {
 
-const CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference) {
+CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference) {
     double longitude;
     double latitude;
     double height;

--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -1,0 +1,16 @@
+#include "cesium/omniverse/GeospatialUtil.h"
+
+namespace cesium::omniverse::GeospatialUtil {
+
+const CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference) {
+    double longitude;
+    double latitude;
+    double height;
+    georeference.GetGeoreferenceOriginLongitudeAttr().Get<double>(&longitude);
+    georeference.GetGeoreferenceOriginLatitudeAttr().Get<double>(&latitude);
+    georeference.GetGeoreferenceOriginHeightAttr().Get<double>(&height);
+
+    return CesiumGeospatial::Cartographic(glm::radians(longitude), glm::radians(latitude), height);
+}
+
+}

--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -13,4 +13,4 @@ const CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr
     return CesiumGeospatial::Cartographic(glm::radians(longitude), glm::radians(latitude), height);
 }
 
-}
+} // namespace cesium::omniverse::GeospatialUtil

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -5,6 +5,7 @@
 #include "cesium/omniverse/FabricMesh.h"
 #include "cesium/omniverse/FabricPrepareRenderResources.h"
 #include "cesium/omniverse/FabricUtil.h"
+#include "cesium/omniverse/GeospatialUtil.h"
 #include "cesium/omniverse/HttpAssetAccessor.h"
 #include "cesium/omniverse/LoggerSink.h"
 #include "cesium/omniverse/OmniImagery.h"
@@ -28,7 +29,7 @@
 
 namespace cesium::omniverse {
 
-OmniTileset::OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath &georeferencePath)
+OmniTileset::OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath)
     : _tilesetPath(tilesetPath)
     , _tilesetId(Context::instance().getNextTilesetId()) {
     reload();
@@ -367,7 +368,7 @@ void OmniTileset::updateTransform() {
     // about changes to the current prim and not its ancestor prims. Also Tf::Notice may notify us in a thread other
     // than the main thread and we would have to be careful to synchronize updates to Fabric in the main thread.
 
-    const auto georeferenceOrigin = Context::instance().getGeoreferenceOrigin();
+    const auto georeferenceOrigin = GeospatialUtil::convertGeoreferenceToCartographic(getGeoreference());
     const auto ecefToUsdTransform = UsdUtil::computeEcefToUsdTransformForPrim(georeferenceOrigin, _tilesetPath);
 
     // Check for transform changes and update prims accordingly
@@ -382,7 +383,7 @@ void OmniTileset::updateView(const std::vector<Viewport>& viewports) {
 
     if (visible && !getSuspendUpdate()) {
         // Go ahead and select some tiles
-        const auto& georeferenceOrigin = Context::instance().getGeoreferenceOrigin();
+        const auto& georeferenceOrigin = GeospatialUtil::convertGeoreferenceToCartographic(getGeoreference());
 
         _viewStates.clear();
         for (const auto& viewport : viewports) {

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -370,15 +370,17 @@ pxr::CesiumSession getOrCreateCesiumSession() {
 }
 
 pxr::CesiumGeoreference getOrCreateCesiumGeoreference() {
-    return getCesiumGeoreference(pxr::SdfPath("/CesiumGeoreference"));
+    if (isCesiumGeoreference(GEOREFERENCE_PATH)) {
+        return pxr::CesiumGeoreference::Get(getUsdStage(), GEOREFERENCE_PATH);
+    }
+
+    return defineCesiumGeoreference(GEOREFERENCE_PATH);
 }
 
 pxr::CesiumGeoreference getCesiumGeoreference(const pxr::SdfPath& path) {
-    if (isCesiumGeoreference(path)) {
-        return pxr::CesiumGeoreference::Get(getUsdStage(), path);
-    }
-
-    return defineCesiumGeoreference(path);
+    auto georeference = pxr::CesiumGeoreference::Get(getUsdStage(), path);
+    assert(georeference.GetPrim().IsValid());
+    return georeference;
 }
 
 pxr::CesiumTilesetAPI getCesiumTileset(const pxr::SdfPath& path) {
@@ -467,7 +469,7 @@ bool primExists(const pxr::SdfPath& path) {
     return prim.IsValid();
 }
 
-[[maybe_unused]] void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath) {
+void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath) {
     auto stage = getUsdStage();
 
     if (isCesiumTileset(tilesetPath)) {

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -370,8 +370,10 @@ pxr::CesiumSession getOrCreateCesiumSession() {
 }
 
 pxr::CesiumGeoreference getOrCreateCesiumGeoreference() {
-    static const auto path = pxr::SdfPath("/CesiumGeoreference");
+    return getCesiumGeoreference(pxr::SdfPath("/CesiumGeoreference"));
+}
 
+pxr::CesiumGeoreference getCesiumGeoreference(const pxr::SdfPath& path) {
     if (isCesiumGeoreference(path)) {
         return pxr::CesiumGeoreference::Get(getUsdStage(), path);
     }
@@ -463,6 +465,16 @@ bool primExists(const pxr::SdfPath& path) {
     auto stage = getUsdStage();
     auto prim = stage->GetPrimAtPath(path);
     return prim.IsValid();
+}
+
+[[maybe_unused]] void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath) {
+    auto stage = getUsdStage();
+
+    if (isCesiumTileset(tilesetPath)) {
+        auto tileset = getCesiumTileset(tilesetPath);
+
+        tileset.GetGeoreferenceBindingRel().AddTarget(georeferencePath);
+    }
 }
 
 } // namespace cesium::omniverse::UsdUtil


### PR DESCRIPTION
Another step towards getting #235 implemented.

Tilesets now have the Georeference prim they're using property related, and this relation is used during most of the rendering step. It's important to note this does not mean we support multiple-georeference points yet. I had concerns about removing the direct call to the Georeference prim in `Context::onUpdateFrame` for performance reasons, so I didn't change that. Additionally, on the reload step we are referencing the Georeference prim directly there for potential performance reasons as well.