### PR TITLE
More statistics in Cesium Debugging window

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -7,11 +7,13 @@ from ..bindings import ICesiumOmniverseInterface
 from .models.space_delimited_number_model import SpaceDelimitedNumberModel
 from .models.human_readable_bytes_model import HumanReadableBytesModel
 
+MATERIALS_CAPACITY_TEXT = "Materials capacity"
 MATERIALS_LOADED_TEXT = "Materials loaded"
+GEOMETRIES_CAPACITY_TEXT = "Geometries capacity"
 GEOMETRIES_LOADED_TEXT = "Geometries loaded"
-GEOMETRIES_VISIBLE_TEXT = "Geometries visible"
+GEOMETRIES_RENDERED_TEXT = "Geometries rendered"
 TRIANGLES_LOADED_TEXT = "Triangles loaded"
-TRIANGLES_VISIBLE_TEXT = "Triangles visible"
+TRIANGLES_RENDERED_TEXT = "Triangles rendered"
 TILESET_CACHED_BYTES_TEXT = "Tileset cached bytes"
 TILESET_CACHED_BYTES_HUMAN_READABLE_TEXT = "Tileset cached bytes (Human-readable)"
 
@@ -28,11 +30,13 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
 
         self._cesium_omniverse_interface = cesium_omniverse_interface
 
+        self._materials_capacity_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._materials_loaded_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._geometries_capacity_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._geometries_loaded_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
-        self._geometries_visible_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._geometries_rendered_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._triangles_loaded_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
-        self._triangles_visible_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._triangles_rendered_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._tileset_cached_bytes_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._tileset_cached_bytes_human_readable_model: HumanReadableBytesModel = HumanReadableBytesModel(0)
 
@@ -60,11 +64,13 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
             return
 
         render_statistics = self._cesium_omniverse_interface.get_render_statistics()
-        self._materials_loaded_model.set_value(render_statistics.number_of_materials_loaded)
-        self._geometries_loaded_model.set_value(render_statistics.number_of_geometries_loaded)
-        self._geometries_visible_model.set_value(render_statistics.number_of_geometries_visible)
-        self._triangles_loaded_model.set_value(render_statistics.number_of_triangles_loaded)
-        self._triangles_visible_model.set_value(render_statistics.number_of_triangles_visible)
+        self._materials_capacity_model.set_value(render_statistics.materials_capacity)
+        self._materials_loaded_model.set_value(render_statistics.materials_loaded)
+        self._geometries_capacity_model.set_value(render_statistics.geometries_capacity)
+        self._geometries_loaded_model.set_value(render_statistics.geometries_loaded)
+        self._geometries_rendered_model.set_value(render_statistics.geometries_rendered)
+        self._triangles_loaded_model.set_value(render_statistics.triangles_loaded)
+        self._triangles_rendered_model.set_value(render_statistics.triangles_rendered)
         self._tileset_cached_bytes_model.set_value(render_statistics.tileset_cached_bytes)
         self._tileset_cached_bytes_human_readable_model.set_value(render_statistics.tileset_cached_bytes)
 
@@ -77,11 +83,13 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
                 ui.Spacer()
 
             for label, model in [
+                (MATERIALS_CAPACITY_TEXT, self._materials_capacity_model),
                 (MATERIALS_LOADED_TEXT, self._materials_loaded_model),
+                (GEOMETRIES_CAPACITY_TEXT, self._geometries_capacity_model),
                 (GEOMETRIES_LOADED_TEXT, self._geometries_loaded_model),
-                (GEOMETRIES_VISIBLE_TEXT, self._geometries_visible_model),
+                (GEOMETRIES_RENDERED_TEXT, self._geometries_rendered_model),
                 (TRIANGLES_LOADED_TEXT, self._triangles_loaded_model),
-                (TRIANGLES_VISIBLE_TEXT, self._triangles_visible_model),
+                (TRIANGLES_RENDERED_TEXT, self._triangles_rendered_model),
                 (TILESET_CACHED_BYTES_TEXT, self._tileset_cached_bytes_model),
                 (TILESET_CACHED_BYTES_HUMAN_READABLE_TEXT, self._tileset_cached_bytes_human_readable_model),
             ]:

--- a/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/statistics_widget.py
@@ -16,6 +16,14 @@ TRIANGLES_LOADED_TEXT = "Triangles loaded"
 TRIANGLES_RENDERED_TEXT = "Triangles rendered"
 TILESET_CACHED_BYTES_TEXT = "Tileset cached bytes"
 TILESET_CACHED_BYTES_HUMAN_READABLE_TEXT = "Tileset cached bytes (Human-readable)"
+TILES_VISITED_TEXT = "Tiles visited"
+CULLED_TILES_VISITED_TEXT = "Culled tiles visited"
+TILES_RENDERED_TEXT = "Tiles rendered"
+TILES_CULLED_TEXT = "Tiles culled"
+MAX_DEPTH_VISITED_TEXT = "Max depth visited"
+TILES_LOADING_WORKER_TEXT = "Tiles loading (worker)"
+TILES_LOADING_MAIN_TEXT = "Tiles loading (main)"
+TILES_LOADED_TEXT = "Tiles loaded"
 
 
 class CesiumOmniverseStatisticsWidget(ui.Frame):
@@ -39,6 +47,14 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
         self._triangles_rendered_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._tileset_cached_bytes_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
         self._tileset_cached_bytes_human_readable_model: HumanReadableBytesModel = HumanReadableBytesModel(0)
+        self._tiles_visited_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._culled_tiles_visited_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._tiles_rendered_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._tiles_culled_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._max_depth_visited_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._tiles_loading_worker_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._tiles_loading_main_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._tiles_loaded_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
 
         self._subscriptions: List[carb.events.ISubscription] = []
         self._setup_subscriptions()
@@ -73,6 +89,14 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
         self._triangles_rendered_model.set_value(render_statistics.triangles_rendered)
         self._tileset_cached_bytes_model.set_value(render_statistics.tileset_cached_bytes)
         self._tileset_cached_bytes_human_readable_model.set_value(render_statistics.tileset_cached_bytes)
+        self._tiles_visited_model.set_value(render_statistics.tiles_visited)
+        self._culled_tiles_visited_model.set_value(render_statistics.culled_tiles_visited)
+        self._tiles_rendered_model.set_value(render_statistics.tiles_rendered)
+        self._tiles_culled_model.set_value(render_statistics.tiles_culled)
+        self._max_depth_visited_model.set_value(render_statistics.max_depth_visited)
+        self._tiles_loading_worker_model.set_value(render_statistics.tiles_loading_worker)
+        self._tiles_loading_main_model.set_value(render_statistics.tiles_loading_main)
+        self._tiles_loaded_model.set_value(render_statistics.tiles_loaded)
 
     def _build_fn(self):
         """Builds all UI components."""
@@ -92,6 +116,14 @@ class CesiumOmniverseStatisticsWidget(ui.Frame):
                 (TRIANGLES_RENDERED_TEXT, self._triangles_rendered_model),
                 (TILESET_CACHED_BYTES_TEXT, self._tileset_cached_bytes_model),
                 (TILESET_CACHED_BYTES_HUMAN_READABLE_TEXT, self._tileset_cached_bytes_human_readable_model),
+                (TILES_VISITED_TEXT, self._tiles_visited_model),
+                (CULLED_TILES_VISITED_TEXT, self._culled_tiles_visited_model),
+                (TILES_RENDERED_TEXT, self._tiles_rendered_model),
+                (TILES_CULLED_TEXT, self._tiles_culled_model),
+                (MAX_DEPTH_VISITED_TEXT, self._max_depth_visited_model),
+                (TILES_LOADING_WORKER_TEXT, self._tiles_loading_worker_model),
+                (TILES_LOADING_MAIN_TEXT, self._tiles_loading_main_model),
+                (TILES_LOADED_TEXT, self._tiles_loaded_model),
             ]:
                 with ui.HStack(height=0):
                     ui.Label(label, height=0)

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -131,11 +131,13 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def_readonly("asset_exists_in_user_account", &AssetTroubleshootingDetails::assetExistsInUserAccount);
 
     py::class_<RenderStatistics>(m, "RenderStatistics")
-        .def_readonly("number_of_materials_loaded", &RenderStatistics::numberOfMaterialsLoaded)
-        .def_readonly("number_of_geometries_loaded", &RenderStatistics::numberOfGeometriesLoaded)
-        .def_readonly("number_of_geometries_visible", &RenderStatistics::numberOfGeometriesVisible)
-        .def_readonly("number_of_triangles_loaded", &RenderStatistics::numberOfTrianglesLoaded)
-        .def_readonly("number_of_triangles_visible", &RenderStatistics::numberOfTrianglesVisible)
+        .def_readonly("materials_capacity", &RenderStatistics::materialsCapacity)
+        .def_readonly("materials_loaded", &RenderStatistics::materialsLoaded)
+        .def_readonly("geometries_capacity", &RenderStatistics::geometriesCapacity)
+        .def_readonly("geometries_loaded", &RenderStatistics::geometriesLoaded)
+        .def_readonly("geometries_rendered", &RenderStatistics::geometriesRendered)
+        .def_readonly("triangles_loaded", &RenderStatistics::trianglesLoaded)
+        .def_readonly("triangles_rendered", &RenderStatistics::trianglesRendered)
         .def_readonly("tileset_cached_bytes", &RenderStatistics::tilesetCachedBytes);
 
     py::class_<Viewport>(m, "Viewport")

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -138,7 +138,15 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def_readonly("geometries_rendered", &RenderStatistics::geometriesRendered)
         .def_readonly("triangles_loaded", &RenderStatistics::trianglesLoaded)
         .def_readonly("triangles_rendered", &RenderStatistics::trianglesRendered)
-        .def_readonly("tileset_cached_bytes", &RenderStatistics::tilesetCachedBytes);
+        .def_readonly("tileset_cached_bytes", &RenderStatistics::tilesetCachedBytes)
+        .def_readonly("tiles_visited", &RenderStatistics::tilesVisited)
+        .def_readonly("culled_tiles_visited", &RenderStatistics::culledTilesVisited)
+        .def_readonly("tiles_rendered", &RenderStatistics::tilesRendered)
+        .def_readonly("tiles_culled", &RenderStatistics::tilesCulled)
+        .def_readonly("max_depth_visited", &RenderStatistics::maxDepthVisited)
+        .def_readonly("tiles_loading_worker", &RenderStatistics::tilesLoadingWorker)
+        .def_readonly("tiles_loading_main", &RenderStatistics::tilesLoadingMain)
+        .def_readonly("tiles_loaded", &RenderStatistics::tilesLoaded);
 
     py::class_<Viewport>(m, "Viewport")
         .def(py::init())

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -11,11 +11,13 @@
 namespace cesium::omniverse {
 
 struct FabricStatistics {
-    uint64_t numberOfMaterialsLoaded{0};
-    uint64_t numberOfGeometriesLoaded{0};
-    uint64_t numberOfGeometriesVisible{0};
-    uint64_t numberOfTrianglesLoaded{0};
-    uint64_t numberOfTrianglesVisible{0};
+    uint64_t materialsCapacity{0};
+    uint64_t materialsLoaded{0};
+    uint64_t geometriesCapacity{0};
+    uint64_t geometriesLoaded{0};
+    uint64_t geometriesRendered{0};
+    uint64_t trianglesLoaded{0};
+    uint64_t trianglesRendered{0};
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -28,6 +28,18 @@ enum TilesetSourceType { ION = 0, URL = 1 };
 class FabricPrepareRenderResources;
 struct Viewport;
 
+struct TilesetStatistics {
+    uint64_t tilesetCachedBytes{0};
+    uint64_t tilesVisited{0};
+    uint64_t culledTilesVisited{0};
+    uint64_t tilesRendered{0};
+    uint64_t tilesCulled{0};
+    uint64_t maxDepthVisited{0};
+    uint64_t tilesLoadingWorker{0};
+    uint64_t tilesLoadingMain{0};
+    uint64_t tilesLoaded{0};
+};
+
 class OmniTileset {
   public:
     OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
@@ -56,7 +68,7 @@ class OmniTileset {
     pxr::CesiumGeoreference getGeoreference() const;
 
     int64_t getTilesetId() const;
-    uint64_t getCachedBytes() const;
+    TilesetStatistics getStatistics() const;
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);

--- a/src/core/include/cesium/omniverse/RenderStatistics.h
+++ b/src/core/include/cesium/omniverse/RenderStatistics.h
@@ -13,6 +13,14 @@ struct RenderStatistics {
     uint64_t trianglesLoaded{0};
     uint64_t trianglesRendered{0};
     uint64_t tilesetCachedBytes{0};
+    uint64_t tilesVisited{0};
+    uint64_t culledTilesVisited{0};
+    uint64_t tilesRendered{0};
+    uint64_t tilesCulled{0};
+    uint64_t maxDepthVisited{0};
+    uint64_t tilesLoadingWorker{0};
+    uint64_t tilesLoadingMain{0};
+    uint64_t tilesLoaded{0};
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/RenderStatistics.h
+++ b/src/core/include/cesium/omniverse/RenderStatistics.h
@@ -5,11 +5,13 @@
 namespace cesium::omniverse {
 
 struct RenderStatistics {
-    uint64_t numberOfMaterialsLoaded{0};
-    uint64_t numberOfGeometriesLoaded{0};
-    uint64_t numberOfGeometriesVisible{0};
-    uint64_t numberOfTrianglesLoaded{0};
-    uint64_t numberOfTrianglesVisible{0};
+    uint64_t materialsCapacity{0};
+    uint64_t materialsLoaded{0};
+    uint64_t geometriesCapacity{0};
+    uint64_t geometriesLoaded{0};
+    uint64_t geometriesRendered{0};
+    uint64_t trianglesLoaded{0};
+    uint64_t trianglesRendered{0};
     uint64_t tilesetCachedBytes{0};
 };
 

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -731,11 +731,13 @@ RenderStatistics Context::getRenderStatistics() const {
     RenderStatistics renderStatistics;
 
     FabricStatistics fabricStatistics = FabricUtil::getStatistics();
-    renderStatistics.numberOfMaterialsLoaded = fabricStatistics.numberOfMaterialsLoaded;
-    renderStatistics.numberOfGeometriesLoaded = fabricStatistics.numberOfGeometriesLoaded;
-    renderStatistics.numberOfGeometriesVisible = fabricStatistics.numberOfGeometriesVisible;
-    renderStatistics.numberOfTrianglesLoaded = fabricStatistics.numberOfTrianglesLoaded;
-    renderStatistics.numberOfTrianglesVisible = fabricStatistics.numberOfTrianglesVisible;
+    renderStatistics.materialsCapacity = fabricStatistics.materialsCapacity;
+    renderStatistics.materialsLoaded = fabricStatistics.materialsLoaded;
+    renderStatistics.geometriesCapacity = fabricStatistics.geometriesCapacity;
+    renderStatistics.geometriesLoaded = fabricStatistics.geometriesLoaded;
+    renderStatistics.geometriesRendered = fabricStatistics.geometriesRendered;
+    renderStatistics.trianglesLoaded = fabricStatistics.trianglesLoaded;
+    renderStatistics.trianglesRendered = fabricStatistics.trianglesRendered;
 
     const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
     for (const auto& tileset : tilesets) {

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -730,7 +730,7 @@ void Context::creditsStartNextFrame() {
 RenderStatistics Context::getRenderStatistics() const {
     RenderStatistics renderStatistics;
 
-    FabricStatistics fabricStatistics = FabricUtil::getStatistics();
+    auto fabricStatistics = FabricUtil::getStatistics();
     renderStatistics.materialsCapacity = fabricStatistics.materialsCapacity;
     renderStatistics.materialsLoaded = fabricStatistics.materialsLoaded;
     renderStatistics.geometriesCapacity = fabricStatistics.geometriesCapacity;
@@ -741,7 +741,16 @@ RenderStatistics Context::getRenderStatistics() const {
 
     const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
     for (const auto& tileset : tilesets) {
-        renderStatistics.tilesetCachedBytes += tileset->getCachedBytes();
+        auto tilesetStatistics = tileset->getStatistics();
+        renderStatistics.tilesetCachedBytes += tilesetStatistics.tilesetCachedBytes;
+        renderStatistics.tilesVisited += tilesetStatistics.tilesVisited;
+        renderStatistics.culledTilesVisited += tilesetStatistics.culledTilesVisited;
+        renderStatistics.tilesRendered += tilesetStatistics.tilesRendered;
+        renderStatistics.tilesCulled += tilesetStatistics.tilesCulled;
+        renderStatistics.maxDepthVisited += tilesetStatistics.maxDepthVisited;
+        renderStatistics.tilesLoadingWorker += tilesetStatistics.tilesLoadingWorker;
+        renderStatistics.tilesLoadingMain += tilesetStatistics.tilesLoadingMain;
+        renderStatistics.tilesLoaded += tilesetStatistics.tilesLoaded;
     }
 
     return renderStatistics;

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -237,8 +237,24 @@ int64_t OmniTileset::getTilesetId() const {
     return _tilesetId;
 }
 
-uint64_t OmniTileset::getCachedBytes() const {
-    return static_cast<uint64_t>(_tileset->getTotalDataBytes());
+TilesetStatistics OmniTileset::getStatistics() const {
+    TilesetStatistics statistics;
+
+    statistics.tilesetCachedBytes = static_cast<uint64_t>(_tileset->getTotalDataBytes());
+    statistics.tilesLoaded = static_cast<uint64_t>(_tileset->getNumberOfTilesLoaded());
+
+    if (_pViewUpdateResult) {
+        // Note: this only updates statistics for the last updateView call. It does not take into account multiple viewports.
+        statistics.tilesVisited = static_cast<uint64_t>(_pViewUpdateResult->tilesVisited);
+        statistics.culledTilesVisited = static_cast<uint64_t>(_pViewUpdateResult->culledTilesVisited);
+        statistics.tilesRendered = static_cast<uint64_t>(_pViewUpdateResult->tilesToRenderThisFrame.size());
+        statistics.tilesCulled = static_cast<uint64_t>(_pViewUpdateResult->tilesCulled);
+        statistics.maxDepthVisited = static_cast<uint64_t>(_pViewUpdateResult->maxDepthVisited);
+        statistics.tilesLoadingWorker = static_cast<uint64_t>(_pViewUpdateResult->workerThreadTileLoadQueueLength);
+        statistics.tilesLoadingMain = static_cast<uint64_t>(_pViewUpdateResult->mainThreadTileLoadQueueLength);
+    }
+
+    return statistics;
 }
 
 void OmniTileset::reload() {

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -244,7 +244,6 @@ TilesetStatistics OmniTileset::getStatistics() const {
     statistics.tilesLoaded = static_cast<uint64_t>(_tileset->getNumberOfTilesLoaded());
 
     if (_pViewUpdateResult) {
-        // Note: this only updates statistics for the last updateView call. It does not take into account multiple viewports.
         statistics.tilesVisited = static_cast<uint64_t>(_pViewUpdateResult->tilesVisited);
         statistics.culledTilesVisited = static_cast<uint64_t>(_pViewUpdateResult->culledTilesVisited);
         statistics.tilesRendered = static_cast<uint64_t>(_pViewUpdateResult->tilesToRenderThisFrame.size());


### PR DESCRIPTION
Adds more statistics to help with profiling:

* For geometries and materials, distinguish between capacity (pool size) vs. loaded. Previously only the capacity was shown.
  * Note that we aren't using a geometry pool in Kit 104.2, which is why the numbers are equal
* Renamed "visible" to "rendered"
* Adds more stats that you would find in Cesium for Unity and Cesium for Unreal
  * Tiles visited
  * Culled tiles visited
  * Tiles rendered
  * Tiles culled
  * Max depth visited
  * Tiles loading (worker)
  * Tiles loading (main)
  * Tiles loaded

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/86e36bc9-e00c-4585-acec-14c1c48a4131)
