### PR TITLE
update doctest main, add example tests, add ObjectPool tests

### DIFF
--- a/src/core/include/cesium/omniverse/ObjectPool.h
+++ b/src/core/include/cesium/omniverse/ObjectPool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <queue>
 
@@ -62,7 +63,7 @@ template <typename T> class ObjectPool {
 
         assert(newCapacity >= oldCapacity);
 
-        if (capacity < newCapacity) {
+        if (newCapacity <= oldCapacity) {
             // We can't shrink capacity because it would mean destroying objects currently in use
             return;
         }

--- a/tests/CesiumOmniverseTest.cpp
+++ b/tests/CesiumOmniverseTest.cpp
@@ -1,7 +1,0 @@
-#include <doctest/doctest.h>
-
-TEST_SUITE("Test") {
-    TEST_CASE("getNumber") {
-        CHECK(2 == 2);
-    }
-}

--- a/tests/ExampleTests.cpp
+++ b/tests/ExampleTests.cpp
@@ -23,11 +23,11 @@ TEST_SUITE("Example Tests") {
         int x = 1;
 
         // Note that these two subcases run independantly of each other!
-        SUBCASE("increment") {
+        SUBCASE("Increment") {
             x += 1;
             CHECK(x == 2);
         }
-        SUBCASE("decrement") {
+        SUBCASE("Decrement") {
             x -= 1;
             CHECK(x == 0);
         }
@@ -76,7 +76,7 @@ TEST_SUITE("Example Tests") {
         CHECK_THROWS(throw "test exception!");
         CHECK_NOTHROW(if (false) throw "should not throw");
 
-        // prints a warning if the assert fails, but does not fail the test
+        // Prints a warning if the assert fails, but does not fail the test
         WARN(true);
     }
 }

--- a/tests/ExampleTests.cpp
+++ b/tests/ExampleTests.cpp
@@ -1,0 +1,82 @@
+/*
+* A collection of simple tests to demonstrate Doctest
+*/
+
+#include "doctestUtils.h"
+
+#include <doctest/doctest.h>
+
+#include <cstdint>
+#include <list>
+#include <stdexcept>
+
+// Test Suites are not required, but this sort of grouping makes it possible
+// to select which tests do/don't run via command line options
+TEST_SUITE("Example Tests") {
+
+    TEST_CASE("The most basic test") {
+        CHECK(1 + 1 == 2);
+    }
+
+    TEST_CASE("Demonstrating Subcases") {
+        // This initialization is shared between all subcases
+        int x = 1;
+
+        // Note that these two subcases run independantly of each other!
+        SUBCASE("increment") {
+            x += 1;
+            CHECK(x == 2);
+        }
+        SUBCASE("decrement") {
+            x -= 1;
+            CHECK(x == 0);
+        }
+    }
+    // A few notes on subcases:
+    //  - You can nest subcases
+    //  - Subcases work by creating multiple calls to the higher level case,
+    //    where each call proceeds to only one of the subcases. If you generate
+    //    excessive subcases, watch out for a stack overflow.
+
+    void runPositiveCheck(int64_t val) {
+        // helper function for parameterized test method 1
+        CHECK(val > 0);
+    }
+
+    TEST_CASE("Demonstrate Parameterized Tests - method 1") {
+        // Generate the data you want the tests to iterate over
+        std::list<uint32_t> dataContainer = {42, 64, 8675309, 1024};
+
+        for (auto i : dataContainer) {
+            CAPTURE(i);
+            runPositiveCheck(i);
+        }
+    }
+
+    TEST_CASE("Demonstrate Parameterized Tests - method 2") {
+        // Generate the data you want the tests to iterate over
+        uint32_t item;
+        std::list<uint32_t> dataContainer = {42, 64, 8675309, 1024};
+
+        // This macro from doctestUtils.h will generate a subcase per datum
+        DOCTEST_VALUE_PARAMETERIZED_DATA(item, dataContainer);
+
+        // this check will now be run for each datum
+        CHECK(item > 0);
+    }
+
+    TEST_CASE("A few other useful macros") {
+        // The most common test macro is CHECK, but others are available
+        // Here are just a few
+
+        // Any failures here will prevent the rest of the test from running
+        REQUIRE(0 == 0);
+
+        // Make sure the enclosed code does/doesn't throw an exception
+        CHECK_THROWS(throw "test exception!");
+        CHECK_NOTHROW(if (false) throw "should not throw");
+
+        // prints a warning if the assert fails, but does not fail the test
+        WARN(true);
+    }
+}

--- a/tests/ObjectPoolTests.cpp
+++ b/tests/ObjectPoolTests.cpp
@@ -1,0 +1,146 @@
+#include "doctestUtils.h"
+
+#include <cesium/omniverse/ObjectPool.h>
+#include <doctest/doctest.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <queue>
+
+#define MAX_TESTED_POOL_SIZE 1024 // the max size pool to randomly generate
+
+// ObjectPool is a virtual class so we cannot directly instantiate it for
+// testing, and instatiating the classes that implement it (FabricGeometryPool
+// and FabricMaterialPool) requires mocking more complicated classes, so we
+// create a bare-bones class here.
+
+class mockObj {
+  public:
+    mockObj(uint64_t objectId) {
+        this->id = objectId;
+        this->active = false;
+    };
+    uint64_t id;
+    bool active;
+};
+
+class mockObjPool final : public cesium::omniverse::ObjectPool<mockObj> {
+  protected:
+    std::shared_ptr<mockObj> createObject(uint64_t objectId) override {
+        return std::make_shared<mockObj>(objectId);
+    };
+    void setActive(const std::shared_ptr<mockObj> obj, bool active) override {
+        obj->active = active;
+    };
+};
+
+void testRandomSequenceOfCmds(mockObjPool* opl, int numEvents, bool setCap) {
+
+    // track the objects we've acquired so we can release them
+    std::queue<std::shared_ptr<mockObj>> activeObjs;
+
+    // the total number of acquires performed, which becomes the minimum
+    // expected size of the pool
+    auto maxActiveCount = opl->getNumberActive();
+
+    // perform a random sequence of acquires/releases while
+    // ensuring we only release what we've acquired
+    for (int i = 0; i < numEvents; i++) {
+        if (!activeObjs.empty() && rand() % 2 == 0) {
+            opl->release(activeObjs.front());
+            activeObjs.pop();
+        } else {
+            activeObjs.push(opl->acquire());
+        }
+        maxActiveCount = std::max(maxActiveCount, activeObjs.size());
+
+        if (setCap && i == numEvents / 2) {
+            // at the halfway point, try resetting the capacity
+
+            // TODO uncomment and place both setCapacity calls in subcases once
+            // assert workaround has been found
+            // see https://github.com/CesiumGS/cesium-omniverse/issues/342
+            // // ensure we don't rollover 0
+            // uint64_t oldCap = opl->getCapacity();
+            // uint64_t guaranteedSmaller = std::min((uint64_t)0, oldCap - 1);
+            // opl->setCapacity(guaranteedSmaller);
+            // // verify that we cannot shrink the capacity
+            // CHECK(oldCap == opl->getCapacity());
+
+            // ensure the new size is GTE, avoiding rollover
+            uint64_t guaranteedGTE =
+                std::max(opl->getCapacity(), opl->getCapacity() + (uint64_t)(rand() % MAX_TESTED_POOL_SIZE));
+            opl->setCapacity(guaranteedGTE);
+        }
+    }
+
+    auto numActive = activeObjs.size();
+
+    // ensure our math matches
+    CHECK(opl->getNumberActive() == numActive);
+
+    // make sure there's capacity for all objects
+    CHECK(opl->getCapacity() >= numActive + opl->getNumberInactive());
+    CHECK(opl->getCapacity() >= maxActiveCount);
+
+    // the percent active is calculated out of the pool's total capacity
+    // which must be gte our max observed active count
+    CHECK(opl->computePercentActive() <= (float)numActive / (float)maxActiveCount);
+}
+
+// ---- Begin tests ----
+
+TEST_SUITE("Test ObjectPool") {
+    TEST_CASE("test initializiation") {
+        mockObjPool opl = mockObjPool();
+
+        SUBCASE("initial capacity") {
+            CHECK(opl.getCapacity() == 0);
+        }
+        SUBCASE("initial active") {
+            CHECK(opl.getNumberActive() == 0);
+        }
+        SUBCASE("initial inactive") {
+            CHECK(opl.getNumberInactive() == 0);
+        }
+        SUBCASE("initial percent active") {
+            // initial percent active is assumed to be 100% in parts of the code
+            CHECK(opl.computePercentActive() == 1);
+        }
+    }
+
+    TEST_CASE("test acquire/release") {
+
+        mockObjPool opl = mockObjPool();
+
+        // Generate a random number of actions to perform
+        int numEvents;
+        std::list<int> randEventCounts;
+
+        fillWithRandomInts(&randEventCounts, 0, MAX_TESTED_POOL_SIZE, NUM_TEST_REPETITIONS);
+
+        SUBCASE("test repeated acquires") {
+            DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
+
+            for (int i = 0; i < numEvents; i++) {
+                opl.acquire();
+            }
+
+            CHECK(opl.getNumberActive() == numEvents);
+            CHECK(opl.getCapacity() >= numEvents);
+        }
+
+        SUBCASE("test random acquire/release patterns") {
+            DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
+            testRandomSequenceOfCmds(&opl, numEvents, false);
+        }
+
+        SUBCASE("test random setting capacity") {
+            DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
+            testRandomSequenceOfCmds(&opl, numEvents, true);
+        }
+    }
+}

--- a/tests/ObjectPoolTests.cpp
+++ b/tests/ObjectPoolTests.cpp
@@ -37,7 +37,7 @@ class MockObjectPool final : public cesium::omniverse::ObjectPool<MockObject> {
     };
 };
 
-void testRandomSequenceOfCmds(MockObjectPool &opl, int numEvents, bool setCap) {
+void testRandomSequenceOfCmds(MockObjectPool& opl, int numEvents, bool setCap) {
     // Track the objects we've acquired so we can release them
     std::queue<std::shared_ptr<MockObject>> activeObjects;
 
@@ -61,8 +61,7 @@ void testRandomSequenceOfCmds(MockObjectPool &opl, int numEvents, bool setCap) {
 
             // Ensure the new size is GTE, avoiding rollover
             uint64_t guaranteedGTE =
-                std::max(opl.getCapacity(), opl.getCapacity() +
-                static_cast<uint64_t>(rand() % MAX_TESTED_POOL_SIZE));
+                std::max(opl.getCapacity(), opl.getCapacity() + static_cast<uint64_t>(rand() % MAX_TESTED_POOL_SIZE));
             opl.setCapacity(guaranteedGTE);
         }
     }

--- a/tests/ObjectPoolTests.cpp
+++ b/tests/ObjectPoolTests.cpp
@@ -10,119 +10,109 @@
 #include <memory>
 #include <queue>
 
-#define MAX_TESTED_POOL_SIZE 1024 // the max size pool to randomly generate
+constexpr int MAX_TESTED_POOL_SIZE = 1024; // The max size pool to randomly generate
 
 // ObjectPool is a virtual class so we cannot directly instantiate it for
 // testing, and instatiating the classes that implement it (FabricGeometryPool
 // and FabricMaterialPool) requires mocking more complicated classes, so we
 // create a bare-bones class here.
 
-class mockObj {
+class MockObject {
   public:
-    mockObj(uint64_t objectId) {
-        this->id = objectId;
-        this->active = false;
+    MockObject(uint64_t objectId) {
+        id = objectId;
+        active = false;
     };
     uint64_t id;
     bool active;
 };
 
-class mockObjPool final : public cesium::omniverse::ObjectPool<mockObj> {
+class MockObjectPool final : public cesium::omniverse::ObjectPool<MockObject> {
   protected:
-    std::shared_ptr<mockObj> createObject(uint64_t objectId) override {
-        return std::make_shared<mockObj>(objectId);
+    std::shared_ptr<MockObject> createObject(uint64_t objectId) override {
+        return std::make_shared<MockObject>(objectId);
     };
-    void setActive(const std::shared_ptr<mockObj> obj, bool active) override {
+    void setActive(const std::shared_ptr<MockObject> obj, bool active) override {
         obj->active = active;
     };
 };
 
-void testRandomSequenceOfCmds(mockObjPool* opl, int numEvents, bool setCap) {
+void testRandomSequenceOfCmds(MockObjectPool &opl, int numEvents, bool setCap) {
+    // Track the objects we've acquired so we can release them
+    std::queue<std::shared_ptr<MockObject>> activeObjects;
 
-    // track the objects we've acquired so we can release them
-    std::queue<std::shared_ptr<mockObj>> activeObjs;
-
-    // the total number of acquires performed, which becomes the minimum
+    // The total number of acquires performed, which becomes the minimum
     // expected size of the pool
-    auto maxActiveCount = opl->getNumberActive();
+    auto maxActiveCount = opl.getNumberActive();
 
-    // perform a random sequence of acquires/releases while
+    // Perform a random sequence of acquires/releases while
     // ensuring we only release what we've acquired
     for (int i = 0; i < numEvents; i++) {
-        if (!activeObjs.empty() && rand() % 2 == 0) {
-            opl->release(activeObjs.front());
-            activeObjs.pop();
+        if (!activeObjects.empty() && rand() % 2 == 0) {
+            opl.release(activeObjects.front());
+            activeObjects.pop();
         } else {
-            activeObjs.push(opl->acquire());
+            activeObjects.push(opl.acquire());
         }
-        maxActiveCount = std::max(maxActiveCount, activeObjs.size());
+        maxActiveCount = std::max(maxActiveCount, activeObjects.size());
 
         if (setCap && i == numEvents / 2) {
-            // at the halfway point, try resetting the capacity
+            // At the halfway point, try resetting the capacity
 
-            // TODO uncomment and place both setCapacity calls in subcases once
-            // assert workaround has been found
-            // see https://github.com/CesiumGS/cesium-omniverse/issues/342
-            // // ensure we don't rollover 0
-            // uint64_t oldCap = opl->getCapacity();
-            // uint64_t guaranteedSmaller = std::min((uint64_t)0, oldCap - 1);
-            // opl->setCapacity(guaranteedSmaller);
-            // // verify that we cannot shrink the capacity
-            // CHECK(oldCap == opl->getCapacity());
-
-            // ensure the new size is GTE, avoiding rollover
+            // Ensure the new size is GTE, avoiding rollover
             uint64_t guaranteedGTE =
-                std::max(opl->getCapacity(), opl->getCapacity() + (uint64_t)(rand() % MAX_TESTED_POOL_SIZE));
-            opl->setCapacity(guaranteedGTE);
+                std::max(opl.getCapacity(), opl.getCapacity() +
+                static_cast<uint64_t>(rand() % MAX_TESTED_POOL_SIZE));
+            opl.setCapacity(guaranteedGTE);
         }
     }
 
-    auto numActive = activeObjs.size();
+    auto numActive = activeObjects.size();
 
-    // ensure our math matches
-    CHECK(opl->getNumberActive() == numActive);
+    // Ensure our math matches
+    CHECK(opl.getNumberActive() == numActive);
 
-    // make sure there's capacity for all objects
-    CHECK(opl->getCapacity() >= numActive + opl->getNumberInactive());
-    CHECK(opl->getCapacity() >= maxActiveCount);
+    // Make sure there's capacity for all objects
+    CHECK(opl.getCapacity() >= numActive + opl.getNumberInactive());
+    CHECK(opl.getCapacity() >= maxActiveCount);
 
-    // the percent active is calculated out of the pool's total capacity
+    // The percent active is calculated out of the pool's total capacity
     // which must be gte our max observed active count
-    CHECK(opl->computePercentActive() <= (float)numActive / (float)maxActiveCount);
+    CHECK(opl.computePercentActive() <= (float)numActive / (float)maxActiveCount);
 }
 
 // ---- Begin tests ----
 
 TEST_SUITE("Test ObjectPool") {
-    TEST_CASE("test initializiation") {
-        mockObjPool opl = mockObjPool();
+    TEST_CASE("Test initializiation") {
+        MockObjectPool opl = MockObjectPool();
 
-        SUBCASE("initial capacity") {
+        SUBCASE("Initial capacity") {
             CHECK(opl.getCapacity() == 0);
         }
-        SUBCASE("initial active") {
+        SUBCASE("Initial active") {
             CHECK(opl.getNumberActive() == 0);
         }
-        SUBCASE("initial inactive") {
+        SUBCASE("Initial inactive") {
             CHECK(opl.getNumberInactive() == 0);
         }
-        SUBCASE("initial percent active") {
-            // initial percent active is assumed to be 100% in parts of the code
+        SUBCASE("Initial percent active") {
+            // Initial percent active is assumed to be 100% in parts of the code
             CHECK(opl.computePercentActive() == 1);
         }
     }
 
-    TEST_CASE("test acquire/release") {
+    TEST_CASE("Test acquire/release") {
 
-        mockObjPool opl = mockObjPool();
+        MockObjectPool opl = MockObjectPool();
 
         // Generate a random number of actions to perform
         int numEvents;
         std::list<int> randEventCounts;
 
-        fillWithRandomInts(&randEventCounts, 0, MAX_TESTED_POOL_SIZE, NUM_TEST_REPETITIONS);
+        fillWithRandomInts(randEventCounts, 0, MAX_TESTED_POOL_SIZE, NUM_TEST_REPETITIONS);
 
-        SUBCASE("test repeated acquires") {
+        SUBCASE("Test repeated acquires") {
             DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
 
             for (int i = 0; i < numEvents; i++) {
@@ -133,14 +123,14 @@ TEST_SUITE("Test ObjectPool") {
             CHECK(opl.getCapacity() >= numEvents);
         }
 
-        SUBCASE("test random acquire/release patterns") {
+        SUBCASE("Test random acquire/release patterns") {
             DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
-            testRandomSequenceOfCmds(&opl, numEvents, false);
+            testRandomSequenceOfCmds(opl, numEvents, false);
         }
 
-        SUBCASE("test random setting capacity") {
+        SUBCASE("Test random setting capacity") {
             DOCTEST_VALUE_PARAMETERIZED_DATA(numEvents, randEventCounts);
-            testRandomSequenceOfCmds(&opl, numEvents, true);
+            testRandomSequenceOfCmds(opl, numEvents, true);
         }
     }
 }

--- a/tests/doctestMain.cpp
+++ b/tests/doctestMain.cpp
@@ -1,18 +1,9 @@
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-#define DOCTEST_CONFIG_IMPLEMENT
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 
+// Defining this magic variable and importing doctest are all that's required
+// Doctest will automatically find all the TEST_CASEs linked/defined elsewhere
+// and include them in a main function it builds
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
 #include <doctest/doctest.h>
-
-#include <cstdio>
-
-int main(int argc, char* argv[]) {
-    // Initialize doctest
-    doctest::Context context;
-    context.applyCommandLine(argc, argv);
-
-    // Run tests
-    const int result = context.run();
-
-    return result;
-}

--- a/tests/doctestUtils.cpp
+++ b/tests/doctestUtils.cpp
@@ -1,6 +1,6 @@
 #include "doctestUtils.h"
 
-void fillWithRandomInts(std::list<int> &lst, int min, int max, int n) {
+void fillWithRandomInts(std::list<int>& lst, int min, int max, int n) {
 
     for (int i = 0; i < n; i++) {
         // The odd order here is to avoid issues with rollover

--- a/tests/doctestUtils.cpp
+++ b/tests/doctestUtils.cpp
@@ -1,10 +1,10 @@
 #include "doctestUtils.h"
 
-void fillWithRandomInts(std::list<int>* lst, int min, int max, int n) {
+void fillWithRandomInts(std::list<int> &lst, int min, int max, int n) {
 
     for (int i = 0; i < n; i++) {
         // The odd order here is to avoid issues with rollover
         int x = (rand() % (max - min)) + min;
-        lst->push_back(x);
+        lst.push_back(x);
     }
 }

--- a/tests/doctestUtils.cpp
+++ b/tests/doctestUtils.cpp
@@ -1,0 +1,10 @@
+#include "doctestUtils.h"
+
+void fillWithRandomInts(std::list<int>* lst, int min, int max, int n) {
+
+    for (int i = 0; i < n; i++) {
+        // The odd order here is to avoid issues with rollover
+        int x = (rand() % (max - min)) + min;
+        lst->push_back(x);
+    }
+}

--- a/tests/doctestUtils.h
+++ b/tests/doctestUtils.h
@@ -20,4 +20,4 @@
     });                                                                                                              \
     _doctest_subcase_idx = 0
 
-void fillWithRandomInts(std::list<int> &lst, int min, int max, int n);
+void fillWithRandomInts(std::list<int>& lst, int min, int max, int n);

--- a/tests/doctestUtils.h
+++ b/tests/doctestUtils.h
@@ -1,0 +1,21 @@
+#include <algorithm>
+#include <cstdlib>
+#include <list>
+#include <string>
+
+#define NUM_TEST_REPETITIONS 100
+
+// Macro for parameterizing test data using one currently recommended method.
+// See the doctest docs for more info:
+// https://github.com/doctest/doctest/blob/ae7a13539fb71f270b87eb2e874fbac80bc8dda2/doc/markdown/parameterized-tests.md
+
+#define DOCTEST_VALUE_PARAMETERIZED_DATA(data, data_container)                                                       \
+    static size_t _doctest_subcase_idx = 0;                                                                          \
+    std::for_each(data_container.begin(), data_container.end(), [&](const auto& in) {                                \
+        DOCTEST_SUBCASE((std::string(#data_container "[") + std::to_string(_doctest_subcase_idx++) + "]").c_str()) { \
+            data = in;                                                                                               \
+        }                                                                                                            \
+    });                                                                                                              \
+    _doctest_subcase_idx = 0
+
+void fillWithRandomInts(std::list<int>* lst, int min, int max, int n);

--- a/tests/doctestUtils.h
+++ b/tests/doctestUtils.h
@@ -20,4 +20,4 @@
     });                                                                                                              \
     _doctest_subcase_idx = 0
 
-void fillWithRandomInts(std::list<int>* lst, int min, int max, int n);
+void fillWithRandomInts(std::list<int> &lst, int min, int max, int n);

--- a/tests/doctestUtils.h
+++ b/tests/doctestUtils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <cstdlib>
 #include <list>


### PR DESCRIPTION
fixes #307. This update does a few things:

1. update the `main` function used by the test build target to be the stock main provided by a macro in doctest.
2. add example tests to distill the doctest documentation and provide templates for future tests.
3. fix a small bug in `ObjectPools`
4. create tests for `ObjectPools`

I'd welcome feedback on the quality of the actual tests. I tried to figure out a balance between 'not overly complicated' and 'thorough enough to be useful', and may have erred more towards the latter. For example, we will probably not use an `ObjectPool` of size 2^64, but the tests have some rollover protection. This felt like overkill, but also something that the tests need to ensure they avoid causing. 