### PR TITLE
Add tileset loaded event

### DIFF
--- a/src/core/include/cesium/omniverse/Broadcast.h
+++ b/src/core/include/cesium/omniverse/Broadcast.h
@@ -18,6 +18,7 @@ void showTroubleshooter(
     const std::string& imageryName,
     const std::string& message);
 void setDefaultTokenComplete();
+void tilesetLoaded(const pxr::SdfPath& tilesetPath);
 void sendMessageToBus(carb::events::EventType eventType);
 void sendMessageToBus(const char* eventKey);
 } // namespace cesium::omniverse::Broadcast

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -77,6 +77,7 @@ class OmniTileset {
   private:
     void updateTransform();
     void updateView(const std::vector<Viewport>& viewports);
+    void updateLoadStatus();
 
     std::unique_ptr<Cesium3DTilesSelection::Tileset> _tileset;
     std::shared_ptr<FabricPrepareRenderResources> _renderResourcesPreparer;
@@ -86,5 +87,6 @@ class OmniTileset {
     int64_t _tilesetId;
     glm::dmat4 _ecefToUsdTransform;
     std::vector<Cesium3DTilesSelection::ViewState> _viewStates;
+    bool _activeLoading{false};
 };
 } // namespace cesium::omniverse

--- a/src/core/src/Broadcast.cpp
+++ b/src/core/src/Broadcast.cpp
@@ -7,6 +7,7 @@ const char* PROFILE_UPDATED_EVENT_KEY = "cesium.omniverse.PROFILE_UPDATED";
 const char* TOKENS_UPDATED_EVENT_KEY = "cesium.omniverse.TOKENS_UPDATED";
 const char* SHOW_TROUBLESHOOTER_EVENT_KEY = "cesium.omniverse.SHOW_TROUBLESHOOTER";
 const char* SET_DEFAULT_PROJECT_TOKEN_COMPLETE_KEY = "cesium.omniverse.SET_DEFAULT_PROJECT_TOKEN_COMPLETE";
+const char* TILESET_LOADED_KEY = "cesium.omniverse.TILESET_LOADED";
 
 template <typename... ValuesT>
 void sendMessageToBusWithPayload(carb::events::EventType eventType, ValuesT&&... payload) {
@@ -57,6 +58,10 @@ void showTroubleshooter(
 
 void setDefaultTokenComplete() {
     sendMessageToBus(SET_DEFAULT_PROJECT_TOKEN_COMPLETE_KEY);
+}
+
+void tilesetLoaded(const pxr::SdfPath& tilesetPath) {
+    sendMessageToBusWithPayload(TILESET_LOADED_KEY, std::make_pair("tilesetPath", tilesetPath.GetText()));
 }
 
 void sendMessageToBus(carb::events::EventType eventType) {

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -370,6 +370,7 @@ void OmniTileset::onUpdateFrame(const std::vector<Viewport>& viewports) {
 
     updateTransform();
     updateView(viewports);
+    updateLoadStatus();
 }
 
 void OmniTileset::updateTransform() {
@@ -443,6 +444,17 @@ void OmniTileset::updateView(const std::vector<Viewport>& viewports) {
                 }
             }
         }
+    }
+}
+
+void OmniTileset::updateLoadStatus() {
+    const auto loadProgress = _tileset->computeLoadProgress();
+
+    if (loadProgress < 100.0f) {
+        _activeLoading = true;
+    } else if (_activeLoading) {
+        Broadcast::tilesetLoaded(_tilesetPath);
+        _activeLoading = false;
     }
 }
 


### PR DESCRIPTION
Adds a tileset loaded event that's broadcasted when the all tiles are loaded for the current view. This will be helpful for #261. Inspired by the implementation in Unreal: https://github.com/CesiumGS/cesium-unreal/pull/906.

To test, add this code to `_setup_subscriptions` in `main_window.py`:

```python
        tileset_loaded_event = carb.events.type_from_string("cesium.omniverse.TILESET_LOADED")
        self._subscriptions.append(
            bus.create_subscription_to_pop_by_type(
                tileset_loaded_event,
                lambda _e: self._logger.warn("Cesium tileset loaded {}".format(_e.payload["tilesetPath"])),
                name="cesium.omniverse.TILESET_LOADED",
            )
        )
```

You'll see "Cesium tileset loaded" messages printed in the console.

https://github.com/CesiumGS/cesium-omniverse/assets/915398/399ab674-6991-45f8-957a-44635fdcd20c