### PR TITLE
Use Cesium USD python bindings instead of generic USD functions

### DIFF
--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -31,6 +31,7 @@
     // Python modules search paths:
     "python.analysis.extraPaths": [
       "${workspaceFolder}/exts/cesium.omniverse",
+      "${workspaceFolder}/exts/cesium.usd.plugins",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/extscore/omni.kit.pip_archive/pip_prebundle",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/plugins/bindings-python",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kernel/py",

--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -28,6 +28,7 @@
     // Python modules search paths:
     "python.analysis.extraPaths": [
       "${workspaceFolder}/exts/cesium.omniverse",
+      "${workspaceFolder}/exts/cesium.usd.plugins",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/extscore/omni.kit.pip_archive/pip_prebundle",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/plugins/bindings-python",
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kernel/py",

--- a/exts/cesium.omniverse/cesium/omniverse/ui/token_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/token_window.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import List, Optional
 from ..bindings import ICesiumOmniverseInterface, Token
 from .styles import CesiumOmniverseUiStyles
+from cesium.usd.plugins.CesiumUsdSchemas import Data as CesiumData
 
 SELECT_TOKEN_TEXT = (
     "Cesium for Omniverse embeds a Cesium ion token in your stage in order to allow it "
@@ -133,10 +134,10 @@ class CesiumOmniverseTokenWindow(ui.Window):
         self._create_new_field_model = ui.SimpleStringModel(DEFAULT_TOKEN_PLACEHOLDER_BASE.format(root_identifier))
         self._use_existing_combo_model = UseExistingComboModel([])
 
-        cesium_prim = stage.GetPrimAtPath("/Cesium")
+        cesium_prim = CesiumData.Get(stage, "/Cesium")
 
-        if cesium_prim.IsValid():
-            current_token = cesium_prim.GetAttribute("cesium:projectDefaultIonAccessToken").Get()
+        if cesium_prim.GetPrim().IsValid():
+            current_token = cesium_prim.GetProjectDefaultIonAccessTokenAttr().Get()
             self._specify_token_field_model = ui.SimpleStringModel(current_token if current_token is not None else "")
         else:
             self._specify_token_field_model = ui.SimpleStringModel()


### PR DESCRIPTION
For the performance testing app I'm doing a bunch of manipulation of the USD stage and have tried to use the Cesium USD python bindings instead of the generic USD functions.

In `cesium.omniverse` I noticed one area that could be switched to use the Cesium bindings.

I also added `cesium.usd.plugins` to the Pylance search paths for VSCode. @corybarr this should fix the IntelliSense errors you were seeing. Though it's limited because we don't have complete Python stubs yet (see [this TODO](https://github.com/CesiumGS/cesium-omniverse/blob/bcd70e23dd4052927a3911a9ab1d7cdc9a84aa34/exts/cesium.usd.plugins/cesium/usd/plugins/CesiumUsdSchemas/__init__.pyi#L12)).