### PR TITLE
Fix advanced install instructions

### DIFF
--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -364,18 +364,20 @@ In some cases it's helpful to produce a self-contained build that can be tested 
 
 To install `CesiumOmniverse` onto the local system run:
 
+On Linux
+
 ```sh
 cmake -B build
-cmake --build build --target install --component library
+cmake --build build
+cmake --install build --component library --prefix $HOME/Desktop/CesiumOmniverse
 ```
 
-By default executables will be installed to `/usr/local/bin`, libraries will be installed to `/usr/local/lib`, and includes will be installed to `/usr/local/include`.
-
-To choose a custom install directory set `CMAKE_INSTALL_PREFIX`:
+On Windows
 
 ```sh
-cmake -B build -D CMAKE_INSTALL_PREFIX=$HOME/Desktop/CesiumOmniverse
-cmake --build build --target install --component library
+cmake -B build
+cmake --build build --config Release
+cmake --install build --config Release --component library --prefix $HOME/Desktop/CesiumOmniverse
 ```
 
 ## Tracing


### PR DESCRIPTION
Updated the instructions for installing cesium-omniverse to a standalone directory.

* Had to separate the build step from install step
* Remove `-D CMAKE_INSTALL_PREFIX` in favor of `--prefix`
* Window and Linux have slightly different instructions since Windows uses a multi-configuration generator.