### PR TITLE
Performance testing app

### DIFF
--- a/apps/cesium.omniverse.dev.kit
+++ b/apps/cesium.omniverse.dev.kit
@@ -17,6 +17,7 @@ app.useFabricSceneDelegate = true
 app.usdrt.scene_delegate.enableProxyCubes = false
 app.usdrt.scene_delegate.geometryStreaming.enabled = false
 app.fastShutdown = true
+app.viewport.grid.enabled = false
 
 [settings.app.exts]
 folders.'++' = ["${app}/../exts"] # Make extensions from this repo available.

--- a/apps/cesium.omniverse.dev.kit
+++ b/apps/cesium.omniverse.dev.kit
@@ -17,7 +17,6 @@ app.useFabricSceneDelegate = true
 app.usdrt.scene_delegate.enableProxyCubes = false
 app.usdrt.scene_delegate.geometryStreaming.enabled = false
 app.fastShutdown = true
-app.viewport.grid.enabled = false
 
 [settings.app.exts]
 folders.'++' = ["${app}/../exts"] # Make extensions from this repo available.

--- a/apps/cesium.performance.kit
+++ b/apps/cesium.performance.kit
@@ -4,7 +4,6 @@ version = "0.0.0"
 app = true
 
 [dependencies]
-"cesium.omniverse.dev" = {}
 "cesium.omniverse.dev.trace" = {}
 "cesium.performance.app" = {}
 

--- a/apps/cesium.performance.kit
+++ b/apps/cesium.performance.kit
@@ -5,6 +5,7 @@ app = true
 
 [dependencies]
 "cesium.omniverse.dev" = {}
+"cesium.omniverse.dev.trace" = {}
 "cesium.performance.app" = {}
 
 [settings]

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -22,7 +22,7 @@ from cesium.usd.plugins.CesiumUsdSchemas import (
     Tokens as CesiumTokens,
 )
 
-ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyZTA0MDlmYi01Y2RhLTQ0MjQtYjBlOS1kMmZhMzQ0OWRkNGYiLCJpZCI6MjU5LCJpYXQiOjE2ODU2MzExMTF9.y2CrqatkaHKHcj6NIDJ8ioll-tnOi-2CblnzI6iUays"
+ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyZTA0MDlmYi01Y2RhLTQ0MjQtYjBlOS1kMmZhMzQ0OWRkNGYiLCJpZCI6MjU5LCJpYXQiOjE2ODU2MzExMTF9.y2CrqatkaHKHcj6NIDJ8ioll-tnOi-2CblnzI6iUays"  # noqa: E501
 GOOGLE_3D_TILES_URL = "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyC2PMYr_ZaMJT5DdZ8WJNYMwB0lDyvx5q8"
 
 CESIUM_DATA_PRIM_PATH = "/Cesium"
@@ -48,6 +48,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         self._view_tour_google_subscription: Optional[carb.events.ISubscription] = None
 
         self._stop_subscription: Optional[carb.events.ISubscription] = None
+        self._on_stage_subscription: Optional[carb.events.ISubscription] = None
         self._update_frame_subscription: Optional[carb.events.ISubscription] = None
 
         self._tileset_loaded_subscription: Optional[carb.events.ISubscription] = None
@@ -155,6 +156,10 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         if self._stop_subscription is not None:
             self._stop_subscription.unsubscribe()
             self._stop_subscription = None
+
+        if self._on_stage_subscription is not None:
+            self._on_stage_subscription.unsubscribe()
+            self._on_stage_subscription = None
 
         if self._update_frame_subscription is not None:
             self._update_frame_subscription.unsubscribe()

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -6,6 +6,7 @@ import omni.ext
 import omni.ui as ui
 import omni.kit.ui
 from .performance_window import CesiumPerformanceWindow
+from cesium.omniverse.bindings import acquire_cesium_omniverse_interface, release_cesium_omniverse_interface
 from cesium.omniverse.utils import wait_n_frames, dock_window_async
 
 
@@ -20,11 +21,16 @@ class CesiumPerformanceExtension(omni.ext.IExt):
     def on_startup(self):
         self._logger.info("Starting Cesium Performance Testing...")
 
+        global _cesium_omniverse_interface
+        _cesium_omniverse_interface = acquire_cesium_omniverse_interface()
+
         self._setup_menus()
         self._show_and_dock_startup_windows()
 
     def on_shutdown(self):
         self._destroy_performance_window()
+
+        release_cesium_omniverse_interface(_cesium_omniverse_interface)
 
     def _setup_menus(self):
         ui.Workspace.set_show_window_fn(
@@ -64,7 +70,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
 
     def _show_performance_window(self, _menu, value):
         if value:
-            self._performance_window = CesiumPerformanceWindow(width=300, height=400)
+            self._performance_window = CesiumPerformanceWindow(_cesium_omniverse_interface, width=300, height=400)
             self._performance_window.set_visibility_changed_fn(
                 partial(self._visibility_changed_fn, CesiumPerformanceWindow.MENU_PATH)
             )

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -9,7 +9,7 @@ import omni.ui as ui
 import omni.usd
 import omni.kit.app as app
 import omni.kit.ui
-from pxr import UsdGeom, Sdf
+from pxr import Sdf
 from .performance_window import CesiumPerformanceWindow
 from cesium.omniverse.bindings import acquire_cesium_omniverse_interface, release_cesium_omniverse_interface
 from cesium.omniverse.utils import wait_n_frames, dock_window_async
@@ -17,7 +17,7 @@ from cesium.usd.plugins.CesiumUsdSchemas import (
     Data as CesiumData,
     Georeference as CesiumGeoreference,
     Imagery as CesiumImagery,
-    TilesetAPI as CesiumTilesetAPI,
+    Tileset as CesiumTileset,
     Tokens as CesiumTokens,
 )
 
@@ -206,9 +206,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
     def _create_tileset_ion(self, path: str, asset_id: int, access_token: str) -> str:
         stage = omni.usd.get_context().get_stage()
         tileset_path = omni.usd.get_stage_next_free_path(stage, path, False)
-        xform = UsdGeom.Xform.Define(stage, tileset_path)
-        assert xform.GetPrim().IsValid()
-        tileset_prim = CesiumTilesetAPI.Apply(xform.GetPrim())
+        tileset_prim = CesiumTileset.Define(stage, tileset_path)
         assert tileset_prim.GetPrim().IsValid()
 
         tileset_prim.GetIonAssetIdAttr().Set(asset_id)
@@ -220,10 +218,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
     def _create_tileset_google(self) -> str:
         stage = omni.usd.get_context().get_stage()
         tileset_path = omni.usd.get_stage_next_free_path(stage, "/Google_3D_Tiles", False)
-        xform = UsdGeom.Xform.Define(stage, tileset_path)
-        assert xform.GetPrim().IsValid()
-        tileset_prim = CesiumTilesetAPI.Apply(xform.GetPrim())
-        assert tileset_prim.GetPrim().IsValid()
+        tileset_prim = CesiumTileset.Define(stage, tileset_path)
 
         tileset_prim.GetUrlAttr().Set(GOOGLE_3D_TILES_URL)
         tileset_prim.GetSourceTypeAttr().Set(CesiumTokens.url)
@@ -236,7 +231,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         imagery_prim = CesiumImagery.Define(stage, imagery_path)
         assert imagery_prim.GetPrim().IsValid()
         parent_prim = imagery_prim.GetPrim().GetParent()
-        assert parent_prim.HasAPI(CesiumTilesetAPI)
+        assert parent_prim.IsA(CesiumTileset)
 
         imagery_prim.GetIonAssetIdAttr().Set(asset_id)
         imagery_prim.GetIonAccessTokenAttr().Set(access_token)
@@ -255,9 +250,9 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         cesium_georeference_prim.GetGeoreferenceOriginLatitudeAttr().Set(latitude)
         cesium_georeference_prim.GetGeoreferenceOriginHeightAttr().Set(height)
 
-    def _get_tileset_prim(self, path: str) -> CesiumTilesetAPI:
+    def _get_tileset_prim(self, path: str) -> CesiumTileset:
         stage = omni.usd.get_context().get_stage()
-        tileset_prim = CesiumTilesetAPI.Get(stage, path)
+        tileset_prim = CesiumTileset.Get(stage, path)
         assert tileset_prim.GetPrim().IsValid()
         return tileset_prim
 

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -57,6 +57,9 @@ class CesiumPerformanceExtension(omni.ext.IExt):
             view_new_york_city_event, self._view_new_york_city
         )
 
+        view_paris_event = carb.events.type_from_string("cesium.performance.VIEW_PARIS")
+        self._view_paris_subscription = bus.create_subscription_to_pop_by_type(view_paris_event, self._view_paris)
+
         view_grand_canyon_event = carb.events.type_from_string("cesium.performance.VIEW_GRAND_CANYON")
         self._view_grand_canyon_subscription = bus.create_subscription_to_pop_by_type(
             view_grand_canyon_event, self._view_grand_canyon
@@ -79,6 +82,10 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         if self._view_new_york_city_subscription is not None:
             self._view_new_york_city_subscription.unsubscribe()
             self._view_new_york_city_subscription = None
+
+        if self._view_paris_subscription is not None:
+            self._view_paris_subscription.unsubscribe()
+            self._view_paris_subscription = None
 
         if self._view_grand_canyon_subscription is not None:
             self._view_grand_canyon_subscription.unsubscribe()
@@ -215,11 +222,34 @@ class CesiumPerformanceExtension(omni.ext.IExt):
             ION_ACCESS_TOKEN,
         )
 
-        self._set_georeference(-74.0, 40.69, 50)
+        self._set_georeference(-74.0060, 40.7128, 50.0)
+        self._load_tileset(tileset_path, self._tileset_loaded)
+
+    def _view_paris(self, _e: carb.events.IEvent):
+        self._logger.warning("View Paris")
+        self._clear_scene()
+        tileset_path = self._create_tileset_ion("/Cesium_World_Terrain", 1, ION_ACCESS_TOKEN)
+        self._create_imagery_ion(
+            CesiumPerformanceExtension._get_imagery_path(tileset_path, "Bing_Maps_Aerial_Imagery"),
+            2,
+            ION_ACCESS_TOKEN,
+        )
+
+        self._set_georeference(2.3522, 48.8566, 100.0)
         self._load_tileset(tileset_path, self._tileset_loaded)
 
     def _view_grand_canyon(self, _e: carb.events.IEvent):
         self._logger.warning("View Grand Canyon")
+        self._clear_scene()
+        tileset_path = self._create_tileset_ion("/Cesium_World_Terrain", 1, ION_ACCESS_TOKEN)
+        self._create_imagery_ion(
+            CesiumPerformanceExtension._get_imagery_path(tileset_path, "Bing_Maps_Aerial_Imagery"),
+            2,
+            ION_ACCESS_TOKEN,
+        )
+
+        self._set_georeference(-112.3535, 36.2679, 2100.0)
+        self._load_tileset(tileset_path, self._tileset_loaded)
 
     def _view_tour(self, _e: carb.events.IEvent):
         self._logger.warning("View Tour")
@@ -232,13 +262,13 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         )
 
         def tour_stop_0():
-            self._set_georeference(-74.0, 40.69, 50)
+            self._set_georeference(-74.0060, 40.7128, 50.0)
 
         def tour_stop_1():
-            self._set_georeference(2.349, 48.86, 100)
+            self._set_georeference(2.3522, 48.8566, 100.0)
 
         def tour_stop_2():
-            self._set_georeference(-157.86, 21.31, 10)
+            self._set_georeference(-112.3535, 36.2679, 2100.0)
 
         tour = Tour(self, [tour_stop_0, tour_stop_1, tour_stop_2], self._tileset_loaded)
 

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -15,8 +15,6 @@ GRAND_CANYON_TEXT = "Grand Canyon"
 TOUR_TEXT = "Tour"
 
 DURATION_TEXT = "Duration (seconds)"
-FPS_TEXT = "Frames Per Second"
-TILES_LOADED_TEXT = "Tiles Loaded"
 
 
 class CesiumPerformanceWindow(ui.Window):
@@ -81,12 +79,13 @@ class CesiumPerformanceWindow(ui.Window):
 
                 for label, model in [
                     (DURATION_TEXT, self._duration_model),
-                    (FPS_TEXT, self._duration_model),
-                    (TILES_LOADED_TEXT, self._duration_model),
                 ]:
                     with ui.HStack(height=0):
                         ui.Label(label, height=0)
                         ui.StringField(model=model, height=0, read_only=True)
+
+            with ui.VStack(spacing=0):
+                ui.Button("Stop", height=16, clicked_fn=self._stop)
 
     def _view_new_york_city(self):
         bus = app.get_app().get_message_bus_event_stream()
@@ -103,6 +102,11 @@ class CesiumPerformanceWindow(ui.Window):
         view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR")
         bus.push(view_new_york_city_event)
 
+    def _stop(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        stop_event = carb.events.type_from_string("cesium.performance.STOP")
+        bus.push(stop_event)
+
     def get_random_colors(self) -> bool:
         return self._random_colors_checkbox_model.get_value_as_bool()
 
@@ -111,3 +115,6 @@ class CesiumPerformanceWindow(ui.Window):
 
     def get_frustum_culling(self) -> bool:
         return self._frustum_culling_checkbox_model.get_value_as_bool()
+
+    def set_duration(self, duration: float):
+        self._duration_model.set_value(duration)

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -11,6 +11,7 @@ FRUSTUM_CULLING_TEXT = "Frustum culling"
 TRACING_ENABLED_TEXT = "Tracing enabled"
 
 NEW_YORK_CITY_TEXT = "New York City"
+PARIS_TEXT = "Paris"
 GRAND_CANYON_TEXT = "Grand Canyon"
 TOUR_TEXT = "Tour"
 
@@ -67,6 +68,7 @@ class CesiumPerformanceWindow(ui.Window):
 
                 for label, callback in [
                     (NEW_YORK_CITY_TEXT, self._view_new_york_city),
+                    (PARIS_TEXT, self._view_paris),
                     (GRAND_CANYON_TEXT, self._view_grand_canyon),
                     (TOUR_TEXT, self._view_tour),
                 ]:
@@ -91,6 +93,11 @@ class CesiumPerformanceWindow(ui.Window):
         bus = app.get_app().get_message_bus_event_stream()
         view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_NEW_YORK_CITY")
         bus.push(view_new_york_city_event)
+
+    def _view_paris(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        view_paris_event = carb.events.type_from_string("cesium.performance.VIEW_PARIS")
+        bus.push(view_paris_event)
 
     def _view_grand_canyon(self):
         bus = app.get_app().get_message_bus_event_stream()

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -102,3 +102,12 @@ class CesiumPerformanceWindow(ui.Window):
         bus = app.get_app().get_message_bus_event_stream()
         view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR")
         bus.push(view_new_york_city_event)
+
+    def get_random_colors(self) -> bool:
+        return self._random_colors_checkbox_model.get_value_as_bool()
+
+    def get_forbid_holes(self) -> bool:
+        return self._forbid_holes_checkbox_model.get_value_as_bool()
+
+    def get_frustum_culling(self) -> bool:
+        return self._frustum_culling_checkbox_model.get_value_as_bool()

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -1,10 +1,12 @@
 import logging
 import omni.ui as ui
+from cesium.omniverse.bindings import ICesiumOmniverseInterface
 from cesium.omniverse.ui.models.space_delimited_number_model import SpaceDelimitedNumberModel
 
 RANDOM_COLORS_TEXT = "Random colors"
 FORBID_HOLES_TEXT = "Forbid holes"
 FRUSTUM_CULLING_TEXT = "Frustum culling"
+TRACING_ENABLED_TEXT = "Tracing enabled"
 
 NEW_YORK_CITY_TEXT = "New York City"
 GRAND_CANYON_TEXT = "Grand Canyon"
@@ -14,13 +16,15 @@ DURATION_TEXT = "Duration (seconds)"
 FPS_TEXT = "Frames Per Second"
 TILES_LOADED_TEXT = "Tiles Loaded"
 
+
 class CesiumPerformanceWindow(ui.Window):
     WINDOW_NAME = "Cesium Performance Testing"
     MENU_PATH = f"Window/Cesium/{WINDOW_NAME}"
 
-    def __init__(self, **kwargs):
+    def __init__(self, cesium_omniverse_interface: ICesiumOmniverseInterface, **kwargs):
         super().__init__(CesiumPerformanceWindow.WINDOW_NAME, **kwargs)
 
+        self._cesium_omniverse_interface = cesium_omniverse_interface
         self._logger = logging.getLogger(__name__)
 
         self._random_colors_checkbox_model = ui.SimpleBoolModel(False)
@@ -28,7 +32,6 @@ class CesiumPerformanceWindow(ui.Window):
         self._frustum_culling_checkbox_model = ui.SimpleBoolModel(False)
 
         self._duration_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
-
 
         self.frame.set_build_fn(self._build_fn)
 
@@ -50,6 +53,14 @@ class CesiumPerformanceWindow(ui.Window):
                     with ui.HStack(height=0):
                         ui.Label(label, height=0)
                         ui.CheckBox(model)
+
+                with ui.HStack(height=16):
+                    tracing_label = ui.Label(TRACING_ENABLED_TEXT, height=0)
+                    tracing_label.set_tooltip(
+                        "Enabled when the project is configured with -D CESIUM_OMNI_ENABLE_TRACING"
+                    )
+                    enabled_string = "ON" if self._cesium_omniverse_interface.is_tracing_enabled() else "OFF"
+                    ui.Label(enabled_string, height=0)
 
             with ui.VStack(spacing=0):
                 ui.Label("Scenarios", height=16)

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -15,6 +15,11 @@ PARIS_TEXT = "Paris"
 GRAND_CANYON_TEXT = "Grand Canyon"
 TOUR_TEXT = "Tour"
 
+NEW_YORK_CITY_GOOGLE_TEXT = "New York City (Google)"
+PARIS_GOOGLE_TEXT = "Paris (Google)"
+GRAND_CANYON_GOOGLE_TEXT = "Grand Canyon (Google)"
+TOUR_GOOGLE_TEXT = "Tour (Google)"
+
 DURATION_TEXT = "Duration (seconds)"
 
 
@@ -71,6 +76,10 @@ class CesiumPerformanceWindow(ui.Window):
                     (PARIS_TEXT, self._view_paris),
                     (GRAND_CANYON_TEXT, self._view_grand_canyon),
                     (TOUR_TEXT, self._view_tour),
+                    (NEW_YORK_CITY_GOOGLE_TEXT, self._view_new_york_city_google),
+                    (PARIS_GOOGLE_TEXT, self._view_paris_google),
+                    (GRAND_CANYON_GOOGLE_TEXT, self._view_grand_canyon_google),
+                    (TOUR_GOOGLE_TEXT, self._view_tour_google),
                 ]:
                     ui.Button(label, height=20, clicked_fn=callback)
 
@@ -101,13 +110,33 @@ class CesiumPerformanceWindow(ui.Window):
 
     def _view_grand_canyon(self):
         bus = app.get_app().get_message_bus_event_stream()
-        view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_GRAND_CANYON")
-        bus.push(view_new_york_city_event)
+        view_grand_canyon_event = carb.events.type_from_string("cesium.performance.VIEW_GRAND_CANYON")
+        bus.push(view_grand_canyon_event)
 
     def _view_tour(self):
         bus = app.get_app().get_message_bus_event_stream()
-        view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR")
-        bus.push(view_new_york_city_event)
+        view_tour_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR")
+        bus.push(view_tour_event)
+
+    def _view_new_york_city_google(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        view_new_york_city_google_event = carb.events.type_from_string("cesium.performance.VIEW_NEW_YORK_CITY_GOOGLE")
+        bus.push(view_new_york_city_google_event)
+
+    def _view_paris_google(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        view_paris_google_event = carb.events.type_from_string("cesium.performance.VIEW_PARIS_GOOGLE")
+        bus.push(view_paris_google_event)
+
+    def _view_grand_canyon_google(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        view_grand_canyon_google_event = carb.events.type_from_string("cesium.performance.VIEW_GRAND_CANYON_GOOGLE")
+        bus.push(view_grand_canyon_google_event)
+
+    def _view_tour_google(self):
+        bus = app.get_app().get_message_bus_event_stream()
+        view_tour_google_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR_GOOGLE")
+        bus.push(view_tour_google_event)
 
     def _stop(self):
         bus = app.get_app().get_message_bus_event_stream()

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -35,7 +35,7 @@ class CesiumPerformanceWindow(ui.Window):
 
         self._random_colors_checkbox_model = ui.SimpleBoolModel(False)
         self._forbid_holes_checkbox_model = ui.SimpleBoolModel(False)
-        self._frustum_culling_checkbox_model = ui.SimpleBoolModel(False)
+        self._frustum_culling_checkbox_model = ui.SimpleBoolModel(True)
 
         self._duration_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
 

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -1,4 +1,6 @@
 import logging
+import carb.events
+import omni.kit.app as app
 import omni.ui as ui
 from cesium.omniverse.bindings import ICesiumOmniverseInterface
 from cesium.omniverse.ui.models.space_delimited_number_model import SpaceDelimitedNumberModel
@@ -87,10 +89,16 @@ class CesiumPerformanceWindow(ui.Window):
                         ui.StringField(model=model, height=0, read_only=True)
 
     def _view_new_york_city(self):
-        print("View New York City")
+        bus = app.get_app().get_message_bus_event_stream()
+        view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_NEW_YORK_CITY")
+        bus.push(view_new_york_city_event)
 
     def _view_grand_canyon(self):
-        print("View Grand Canyon")
+        bus = app.get_app().get_message_bus_event_stream()
+        view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_GRAND_CANYON")
+        bus.push(view_new_york_city_event)
 
     def _view_tour(self):
-        print("Tour")
+        bus = app.get_app().get_message_bus_event_stream()
+        view_new_york_city_event = carb.events.type_from_string("cesium.performance.VIEW_TOUR")
+        bus.push(view_new_york_city_event)

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -1,6 +1,18 @@
 import logging
 import omni.ui as ui
+from cesium.omniverse.ui.models.space_delimited_number_model import SpaceDelimitedNumberModel
 
+RANDOM_COLORS_TEXT = "Random colors"
+FORBID_HOLES_TEXT = "Forbid holes"
+FRUSTUM_CULLING_TEXT = "Frustum culling"
+
+NEW_YORK_CITY_TEXT = "New York City"
+GRAND_CANYON_TEXT = "Grand Canyon"
+TOUR_TEXT = "Tour"
+
+DURATION_TEXT = "Duration (seconds)"
+FPS_TEXT = "Frames Per Second"
+TILES_LOADED_TEXT = "Tiles Loaded"
 
 class CesiumPerformanceWindow(ui.Window):
     WINDOW_NAME = "Cesium Performance Testing"
@@ -11,10 +23,63 @@ class CesiumPerformanceWindow(ui.Window):
 
         self._logger = logging.getLogger(__name__)
 
+        self._random_colors_checkbox_model = ui.SimpleBoolModel(False)
+        self._forbid_holes_checkbox_model = ui.SimpleBoolModel(False)
+        self._frustum_culling_checkbox_model = ui.SimpleBoolModel(False)
+
+        self._duration_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+
+
         self.frame.set_build_fn(self._build_fn)
 
     def destroy(self) -> None:
         super().destroy()
 
     def _build_fn(self):
-        ui.Label("Performance Testing UI")
+        with ui.VStack(spacing=10):
+            with ui.VStack(spacing=4):
+                with ui.HStack(height=16):
+                    ui.Label("Options", height=0)
+                    ui.Spacer()
+
+                for label, model in [
+                    (RANDOM_COLORS_TEXT, self._random_colors_checkbox_model),
+                    (FORBID_HOLES_TEXT, self._forbid_holes_checkbox_model),
+                    (FRUSTUM_CULLING_TEXT, self._frustum_culling_checkbox_model),
+                ]:
+                    with ui.HStack(height=0):
+                        ui.Label(label, height=0)
+                        ui.CheckBox(model)
+
+            with ui.VStack(spacing=0):
+                ui.Label("Scenarios", height=16)
+
+                for label, callback in [
+                    (NEW_YORK_CITY_TEXT, self._view_new_york_city),
+                    (GRAND_CANYON_TEXT, self._view_grand_canyon),
+                    (TOUR_TEXT, self._view_tour),
+                ]:
+                    ui.Button(label, height=20, clicked_fn=callback)
+
+            with ui.VStack(spacing=4):
+                with ui.HStack(height=16):
+                    ui.Label("Stats", height=0)
+                    ui.Spacer()
+
+                for label, model in [
+                    (DURATION_TEXT, self._duration_model),
+                    (FPS_TEXT, self._duration_model),
+                    (TILES_LOADED_TEXT, self._duration_model),
+                ]:
+                    with ui.HStack(height=0):
+                        ui.Label(label, height=0)
+                        ui.StringField(model=model, height=0, read_only=True)
+
+    def _view_new_york_city(self):
+        print("View New York City")
+
+    def _view_grand_canyon(self):
+        print("View Grand Canyon")
+
+    def _view_tour(self):
+        print("Tour")

--- a/include/cesium/omniverse/CesiumOmniverse.h
+++ b/include/cesium/omniverse/CesiumOmniverse.h
@@ -243,6 +243,7 @@ class ICesiumOmniverseInterface {
     virtual bool creditsAvailable() noexcept = 0;
     virtual std::vector<std::pair<std::string, bool>> getCredits() noexcept = 0;
     virtual void creditsStartNextFrame() noexcept = 0;
+    virtual bool isTracingEnabled() noexcept = 0;
 };
 
 } // namespace cesium::omniverse

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -63,7 +63,8 @@ PYBIND11_MODULE(CesiumOmniversePythonBindings, m) {
         .def("get_render_statistics", &ICesiumOmniverseInterface::getRenderStatistics)
         .def("credits_available", &ICesiumOmniverseInterface::creditsAvailable)
         .def("get_credits", &ICesiumOmniverseInterface::getCredits)
-        .def("credits_start_next_frame", &ICesiumOmniverseInterface::creditsStartNextFrame);
+        .def("credits_start_next_frame", &ICesiumOmniverseInterface::creditsStartNextFrame)
+        .def("is_tracing_enabled", &ICesiumOmniverseInterface::isTracingEnabled);
     // clang-format on
 
     py::class_<CesiumIonSession, std::shared_ptr<CesiumIonSession>>(m, "CesiumIonSession")

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -30,7 +30,7 @@
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdUtils/stageCache.h>
 
-#ifdef CESIUM_TRACING_ENABLED
+#if CESIUM_TRACING_ENABLED
 #include <chrono>
 #endif
 
@@ -96,7 +96,7 @@ void Context::initialize(int64_t contextId, const std::filesystem::path& cesiumE
 
     Cesium3DTilesSelection::registerAllTileContentTypes();
 
-#ifdef CESIUM_TRACING_ENABLED
+#if CESIUM_TRACING_ENABLED
     const auto timeNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
     const auto timeSinceEpoch = timeNow.time_since_epoch().count();
     const auto path = cesiumExtensionLocation / fmt::format("cesium-trace-{}.json", timeSinceEpoch);

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -182,6 +182,14 @@ class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
     void creditsStartNextFrame() noexcept override {
         return Context::instance().creditsStartNextFrame();
     }
+
+    bool isTracingEnabled() noexcept override {
+#if CESIUM_TRACING_ENABLED
+        return true;
+#else
+        return false;
+#endif
+    }
 };
 } // namespace cesium::omniverse
 


### PR DESCRIPTION
Fixes #261 

Follow up to https://github.com/CesiumGS/cesium-omniverse/pull/347 that fills out the performance testing application.

The UI is split into three categories:

* **Options** - Different options to test with. More options could be added here in the future. These only apply when you click a new scenario. The `Tracing Enabled` option is there to remind you if you have tracing enabled. I would have preferred using a read-only checkbox but didn't see an option in `omni.ui`.
* **Scenarios** - a list of scenarios to test. Most scenarios load a single tileset, set the camera at a specific location, and wait for the tileset to load (waiting for the `cesium.omniverse.TILESET_LOADED` event to fire). The "Tour" scenario loads a single tileset and jumps between different locations. You can click `Stop` to stop the current scenario. This is useful for stopping tours early.
* **Stats** - stats measured during a run. For now only the duration is measured, but in the future we should add memory usage, number of tile requests, average FPS, etc.

Other notes:

* The ion access token and google access token are hardcoded in the .py file. These are the same keys used in `cesium-omniverse-samples` and will need to be rotated monthly.

Known issues:

* Sometimes the timer stops early. In some cases this is because Fabric materials are still loading even after cesium-native thinks it's done, but other times it seems like a bug in cesium-native `computeLoadProgress`.
* Clicking a scenario while it's currently running often causes a crash, which is a bug in cesium-omniverse.
* The code is in a workable state but I think it could be cleaned up and organized better

Future work:

* Scenarios that follow camera paths
* Option to disable cesium-native cache
* Multiple trials per-scenario
* More options and stats

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/95f572bd-bf74-45d1-9c77-a84932233b74)


And a video of it in action. I accidentally took this video in Debug mode so it's a bit slow.

https://github.com/CesiumGS/cesium-omniverse/assets/915398/dee7bf76-c930-4b50-b175-2e7418ef2cbc
