### PR TITLE
Capitalize CesiumUsdSchemas in more places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,21 +475,21 @@ set(PLUG_INFO_LIBRARY_PATH_KIT "../../bin/${PLUG_INFO_LIBRARY_FILE_NAME}")
 
 set(PLUG_INFO_LIBRARY_PATH ${PLUG_INFO_LIBRARY_PATH_BUILD})
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/plugInfo.json.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.build")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.build")
 set(PLUG_INFO_LIBRARY_PATH ${PLUG_INFO_LIBRARY_PATH_INSTALL})
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/plugInfo.json.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.install")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.install")
 set(PLUG_INFO_LIBRARY_PATH ${PLUG_INFO_LIBRARY_PATH_KIT})
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/plugInfo.json.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.kit")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.kit")
 
 # Configure generatedSchema.usda for CesiumUsdSchemas
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.build")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.build")
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.install")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.install")
 configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/generatedSchema.usda.in"
-               "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.kit")
+               "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.kit")
 
 set(KIT_EXTENSION_BIN_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.omniverse/bin")
 set(KIT_EXTENSION_CERTS_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.omniverse/certs/cacert.pem")
@@ -630,26 +630,26 @@ install(
     EXCLUDE_FROM_ALL)
 
 install(
-    FILES "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.kit"
+    FILES "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.kit"
     DESTINATION "${KIT_EXTENSION_PLUGINS_PATH}/CesiumUsdSchemas/resources/"
     RENAME "plugInfo.json"
     COMPONENT install)
 
 install(
-    FILES "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.install"
+    FILES "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.install"
     DESTINATION "plugins/CesiumUsdSchemas/resources/"
     RENAME "plugInfo.json"
     COMPONENT library
     EXCLUDE_FROM_ALL)
 
 install(
-    FILES "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.kit"
+    FILES "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.kit"
     DESTINATION "${KIT_EXTENSION_PLUGINS_PATH}/CesiumUsdSchemas/resources/"
     RENAME "generatedSchema.usda"
     COMPONENT install)
 
 install(
-    FILES "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.install"
+    FILES "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.install"
     DESTINATION "plugins/CesiumUsdSchemas/resources/"
     RENAME "generatedSchema.usda"
     COMPONENT library

--- a/genStubs.bat
+++ b/genStubs.bat
@@ -35,11 +35,11 @@ cd %FLAT_LIBRARIES_DIR%\lib
 :: We call mypy in this strange way to ensure the correct nvidia python executable is used
 echo "Generating stubs"
 %NVIDIA_PYTHON_EXECUTABLE% -c "from mypy import stubgen; stubgen.main()" -m CesiumOmniversePythonBindings -v
-%NVIDIA_PYTHON_EXECUTABLE% -c "from mypy import stubgen; stubgen.main()" -m _cesiumUsdSchemas -v
+%NVIDIA_PYTHON_EXECUTABLE% -c "from mypy import stubgen; stubgen.main()" -m _CesiumUsdSchemas -v
 
 echo "Copying stubs"
 copy out\CesiumOmniversePythonBindings.pyi %CESIUM_OMNI_STUB_PATH%
-copy out\_cesiumUsdSchemas.pyi %CESIUM_USD_STUB_PATH%
+copy out\_CesiumUsdSchemas.pyi %CESIUM_USD_STUB_PATH%
 
 echo "Formatting stubs"
 black %CESIUM_OMNI_STUB_PATH%

--- a/genStubs.sh
+++ b/genStubs.sh
@@ -35,11 +35,11 @@ cd "$FLAT_LIBRARIES_DIR/lib"
 # We call mypy in this strange way to ensure the correct nvidia python executable is used
 echo "Generating stubs"
 $NVIDIA_PYTHON_EXECUTABLE -c 'from mypy import stubgen; stubgen.main()' -m CesiumOmniversePythonBindings -v
-$NVIDIA_PYTHON_EXECUTABLE -c 'from mypy import stubgen; stubgen.main()' -m _cesiumUsdSchemas -v
+$NVIDIA_PYTHON_EXECUTABLE -c 'from mypy import stubgen; stubgen.main()' -m _CesiumUsdSchemas -v
 
 echo "Copying stubs"
 cp "out/CesiumOmniversePythonBindings.pyi" $CESIUM_OMNI_STUB_PATH
-cp "out/_cesiumUsdSchemas.pyi" $CESIUM_USD_STUB_PATH
+cp "out/_CesiumUsdSchemas.pyi" $CESIUM_USD_STUB_PATH
 
 echo "Formatting stubs"
 black $CESIUM_OMNI_STUB_PATH

--- a/src/plugins/CesiumUsdSchemas/CMakeLists.txt
+++ b/src/plugins/CesiumUsdSchemas/CMakeLists.txt
@@ -103,7 +103,7 @@ setup_usd_python_lib(
 add_custom_command(
     TARGET CesiumUsdSchemas
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.plugInfo.json.build"
+    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.plugInfo.json.build"
             "$<TARGET_FILE_DIR:CesiumUsdSchemas>/plugins/CesiumUsdSchemas/resources/plugInfo.json"
-    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/cesiumUsdSchemas.generatedSchema.usda.build"
+    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.build"
             "$<TARGET_FILE_DIR:CesiumUsdSchemas>/plugins/CesiumUsdSchemas/resources/generatedSchema.usda")


### PR DESCRIPTION
Missed a few `cesiumUsdSchemas` -> `CesiumUsdSchemas` changes in https://github.com/CesiumGS/cesium-omniverse/pull/369, in particular in `genStubs`.

https://github.com/CesiumGS/cesium-omniverse/pull/360 and https://github.com/CesiumGS/cesium-omniverse/pull/369 got merged around the same time which is probably why some of these got overlooked.