### PR TITLE
Use clangd for IntelliSense in VSCode on Windows

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: "-*,bugprone-*,performance-*,modernize-*,-modernize-use-trailing-return-type"
+Checks: "-*,bugprone-*,performance-*,modernize-*,-modernize-use-trailing-return-type,-bugprone-easily-swappable-parameters,-bugprone-exception-escape"
 WarningsAsErrors: "*"
 FormatStyle: none

--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -10,7 +10,6 @@
     // See https://github.com/microsoft/vscode-cpptools/issues/5537
     "C_Cpp.autoAddFileAssociations": false,
     // Disable C/C++ extension IntelliSense since it conflicts with clangd
-    // and has trouble finding third party libraries
     "C_Cpp.intelliSenseEngine": "disabled",
     // Ignore submodules in git sidebar
     "git.detectSubmodules": false,

--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -9,6 +9,8 @@
     // being added to the file associations object.
     // See https://github.com/microsoft/vscode-cpptools/issues/5537
     "C_Cpp.autoAddFileAssociations": false,
+    // Disable C/C++ extension IntelliSense since it conflicts with clangd
+    "C_Cpp.intelliSenseEngine": "disabled",
     // Ignore submodules in git sidebar
     "git.detectSubmodules": false,
     "git.ignoreSubmodules": true,
@@ -334,6 +336,7 @@
   },
   "extensions": {
     "recommendations": [
+      "llvm-vs-code-extensions.vscode-clangd",
       "ms-python.python",
       "ms-python.vscode-pylance",
       "ms-vscode.cpptools",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ option(CESIUM_OMNI_ENABLE_TESTS "Unit tests" ON)
 option(CESIUM_OMNI_ENABLE_DOCUMENTATION "Generate HTML documentation with Doxygen" ON)
 option(CESIUM_OMNI_ENABLE_SANITIZERS "Check for undefined behavior at runtime" OFF)
 option(CESIUM_OMNI_ENABLE_LINTERS "Enable clang-format for code formatting and clang-tidy for static code analysis" ON)
-option(CESIUM_OMNI_ENABLE_TRACING "Whether to enable the Cesium performance tracing framework (CESIUM_TRACE_* macros)." OFF)
+option(CESIUM_OMNI_ENABLE_TRACING "Whether to enable the Cesium performance tracing framework" OFF)
 
 # Coverage can only be enabled if tests are also enabled
 cmake_dependent_option(
@@ -112,7 +112,12 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Source directories for formatting and linting
-set(LINT_SOURCE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/tests")
+set(LINT_SOURCE_DIRECTORIES
+    "${PROJECT_SOURCE_DIR}/include"
+    "${PROJECT_SOURCE_DIR}/src/bindings"
+    "${PROJECT_SOURCE_DIR}/src/core"
+    "${PROJECT_SOURCE_DIR}/src/public"
+    "${PROJECT_SOURCE_DIR}/tests")
 
 # Source directories for coverage
 set(COVERAGE_SOURCE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/src")
@@ -181,7 +186,7 @@ set(CESIUM_OMNI_CXX_DEFINES_DEBUG "")
 set(CESIUM_OMNI_LINKER_FLAGS "")
 set(CESIUM_OMNI_LINKER_FLAGS_DEBUG "")
 
-if (CESIUM_OMNI_ENABLE_TRACING)
+if(CESIUM_OMNI_ENABLE_TRACING)
     set(CESIUM_OMNI_CXX_DEFINES ${CESIUM_OMNI_CXX_DEFINES} "CESIUM_TRACING_ENABLED")
 endif()
 

--- a/cmake/Linters.cmake
+++ b/cmake/Linters.cmake
@@ -58,85 +58,82 @@ function(setup_linters)
         COMMAND "${Python3_EXECUTABLE}" "${_PROJECT_SCRIPTS_DIRECTORY}/clang_format.py" --fix --staged
                 --clang-format-executable "${CLANG_FORMAT_PATH}" --source-directories ${_PROJECT_SOURCE_DIRECTORIES})
 
-    # The clang-tidy target is disabled for MSVC.
-    if(NOT MSVC)
-        # Add clang-tidy
-        # our clang-tidy options are located in `.clang-tidy` in the root folder
-        # when clang-tidy runs it will look for this file
-        get_compiler_tool_with_correct_version(
-            TOOL_NAME
-            "clang-tidy"
-            TOOLCHAIN_NAME
-            "Clang"
-            RESULT_TOOL_PATH
-            CLANG_TIDY_PATH)
+    # Add clang-tidy
+    # our clang-tidy options are located in `.clang-tidy` in the root folder
+    # when clang-tidy runs it will look for this file
+    get_compiler_tool_with_correct_version(
+        TOOL_NAME
+        "clang-tidy"
+        TOOLCHAIN_NAME
+        "Clang"
+        RESULT_TOOL_PATH
+        CLANG_TIDY_PATH)
 
-        if(NOT CLANG_TIDY_PATH)
-            message(FATAL_ERROR "Could not find clang-tidy in your path.")
-        endif()
+    if(NOT CLANG_TIDY_PATH)
+        message(FATAL_ERROR "Could not find clang-tidy in your path.")
+    endif()
 
-        # CMake has built-in support for running clang-tidy during the build
-        if(_ENABLE_LINTERS_ON_BUILD)
-            set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
-            set(CMAKE_CXX_CLANG_TIDY
-                ${CMAKE_CXX_CLANG_TIDY}
-                PARENT_SCOPE)
-        endif()
+    # CMake has built-in support for running clang-tidy during the build
+    if(_ENABLE_LINTERS_ON_BUILD)
+        set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
+        set(CMAKE_CXX_CLANG_TIDY
+            ${CMAKE_CXX_CLANG_TIDY}
+            PARENT_SCOPE)
+    endif()
 
+    add_custom_target(
+        clang-tidy-staged
+        COMMAND "${Python3_EXECUTABLE}" "${_PROJECT_SCRIPTS_DIRECTORY}/clang_tidy.py" --clang-tidy-executable
+                "${CLANG_TIDY_PATH}" -p "${_PROJECT_BUILD_DIRECTORY}" # path that contains a compile_commands.json
+    )
+
+    # Generate a CMake target that runs clang-tidy by itself
+    # `run-clang-tidy` is a python script that comes with llvm that runs clang-tidy in parallel over a compile_commands.json
+    # See: https://clang.llvm.org/extra/doxygen/run-clang-tidy_8py_source.html
+    get_compiler_tool_with_correct_version(
+        TOOL_NAME
+        "run-clang-tidy"
+        TOOLCHAIN_NAME
+        "Clang"
+        RESULT_TOOL_PATH
+        CLANG_TIDY_RUNNER_PATH)
+
+    set(SOURCE_EXTENSIONS
+        "*.cpp"
+        "*.h"
+        "*.cxx"
+        "*.hxx"
+        "*.hpp"
+        "*.cc"
+        "*.inl")
+    foreach(source_directory ${_PROJECT_SOURCE_DIRECTORIES})
+        foreach(source_extension ${SOURCE_EXTENSIONS})
+            file(GLOB_RECURSE source_directory_files ${source_directory}/${source_extension})
+            list(APPEND all_source_files ${source_directory_files})
+        endforeach()
+    endforeach()
+
+    if(CLANG_TIDY_RUNNER_PATH)
         add_custom_target(
-            clang-tidy-staged
-            COMMAND "${Python3_EXECUTABLE}" "${_PROJECT_SCRIPTS_DIRECTORY}/clang_tidy.py" --clang-tidy-executable
-                    "${CLANG_TIDY_PATH}" -p "${_PROJECT_BUILD_DIRECTORY}" # path that contains a compile_commands.json
+            clang-tidy COMMAND ${Python3_EXECUTABLE} ${CLANG_TIDY_RUNNER_PATH} -clang-tidy-binary ${CLANG_TIDY_PATH} -p
+                               ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
         )
-
-        # Generate a CMake target that runs clang-tidy by itself
-        # `run-clang-tidy` is a python script that comes with llvm that runs clang-tidy in parallel over a compile_commands.json
-        # See: https://clang.llvm.org/extra/doxygen/run-clang-tidy_8py_source.html
-        get_compiler_tool_with_correct_version(
-            TOOL_NAME
-            "run-clang-tidy"
-            TOOLCHAIN_NAME
-            "Clang"
-            RESULT_TOOL_PATH
-            CLANG_TIDY_RUNNER_PATH)
-
-        if(CLANG_TIDY_RUNNER_PATH)
-            add_custom_target(
-                clang-tidy COMMAND ${CLANG_TIDY_RUNNER_PATH} -clang-tidy-binary ${CLANG_TIDY_PATH} -p
-                                   ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
-            )
-            add_custom_target(
-                clang-tidy-fix COMMAND ${CLANG_TIDY_RUNNER_PATH} -fix -clang-tidy-binary ${CLANG_TIDY_PATH} -p
-                                       ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
-            )
-        else()
-            # run-clang-tidy was not found, so call clang-tidy directly.
-            # this takes a lot longer because it's not parallelized.
-            set(SOURCE_EXTENSIONS
-                "*.cpp"
-                "*.h"
-                "*.cxx"
-                "*.hxx"
-                "*.hpp"
-                "*.cc"
-                "*.inl")
-            foreach(source_directory ${PROJECT_SOURCE_DIRECTORIES})
-                foreach(source_extension ${SOURCE_EXTENSIONS})
-                    file(GLOB_RECURSE source_directory_files ${source_directory}/${source_extension})
-                    list(APPEND all_source_files ${source_directory_files})
-                endforeach()
-            endforeach()
-
-            add_custom_target(
-                clang-tidy
-                COMMAND ${CLANG_TIDY_PATH} -p ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
-                        ${all_source_files})
-            add_custom_target(
-                clang-tidy-fix
-                COMMAND
-                    ${CLANG_TIDY_PATH} --fix -p
+        add_custom_target(
+            clang-tidy-fix
+            COMMAND ${Python3_EXECUTABLE} ${CLANG_TIDY_RUNNER_PATH} -fix -clang-tidy-binary ${CLANG_TIDY_PATH} -p
                     ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
+        )
+    else()
+        # run-clang-tidy was not found, so call clang-tidy directly.
+        # this takes a lot longer because it's not parallelized.
+        add_custom_target(
+            clang-tidy
+            COMMAND ${CLANG_TIDY_PATH} -p ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
                     ${all_source_files})
-        endif()
+        add_custom_target(
+            clang-tidy-fix
+            COMMAND
+                ${CLANG_TIDY_PATH} --fix -p ${_PROJECT_BUILD_DIRECTORY} # path that contains a compile_commands.json
+                ${all_source_files})
     endif()
 endfunction()

--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -454,8 +454,6 @@ cmake -B build
 cmake --build build --target clang-tidy
 ```
 
-Note that these targets are not available on Windows currently.
-
 ## Packaging
 
 ### Build Linux Package (Local)

--- a/scripts/vscode_build.py
+++ b/scripts/vscode_build.py
@@ -191,19 +191,11 @@ def format(args: Args):
 
 
 def lint(args: Args):
-    if is_windows():
-        print("Linters are not supported for Windows")
-        return
-
     clang_tidy_cmd = get_cmake_build_command(args, "clang-tidy")
     process(clang_tidy_cmd)
 
 
 def lint_fix(args: Args):
-    if is_windows():
-        print("Linters are not supported for Windows")
-        return
-
     clang_tidy_cmd = get_cmake_build_command(args, "clang-tidy-fix")
     process(clang_tidy_cmd)
 

--- a/src/bindings/PythonBindings.cpp
+++ b/src/bindings/PythonBindings.cpp
@@ -12,14 +12,13 @@
 // Needs to go after carb
 #include "pyboost11.h"
 
-namespace pybind11 {
-namespace detail {
+namespace pybind11::detail {
 
 PYBOOST11_TYPE_CASTER(pxr::GfMatrix4d, _("Matrix4d"));
 
-} // end namespace detail
-} // end namespace pybind11
+} // namespace pybind11::detail
 
+// NOLINTNEXTLINE
 CARB_BINDINGS("cesium.omniverse.python")
 DISABLE_PYBIND11_DYNAMIC_CAST(cesium::omniverse::ICesiumOmniverseInterface)
 

--- a/src/core/include/cesium/omniverse/AssetRegistry.h
+++ b/src/core/include/cesium/omniverse/AssetRegistry.h
@@ -30,18 +30,18 @@ class AssetRegistry {
 
     void addTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
     void removeTileset(const pxr::SdfPath& path);
-    std::optional<std::shared_ptr<OmniTileset>> getTilesetByPath(const pxr::SdfPath& path) const;
-    std::optional<std::shared_ptr<OmniTileset>> getTilesetByIonAssetId(int64_t ionAssetId) const;
-    const std::list<std::shared_ptr<OmniTileset>>& getAllTilesets() const;
-    std::vector<pxr::SdfPath> getAllTilesetPaths() const;
+    [[nodiscard]] std::optional<std::shared_ptr<OmniTileset>> getTilesetByPath(const pxr::SdfPath& path) const;
+    [[nodiscard]] std::optional<std::shared_ptr<OmniTileset>> getTilesetByIonAssetId(int64_t ionAssetId) const;
+    [[nodiscard]] const std::list<std::shared_ptr<OmniTileset>>& getAllTilesets() const;
+    [[nodiscard]] std::vector<pxr::SdfPath> getAllTilesetPaths() const;
 
     void addImagery(const pxr::SdfPath& path);
     void removeImagery(const pxr::SdfPath& path);
-    std::optional<std::shared_ptr<OmniImagery>> getImageryByPath(const pxr::SdfPath& path) const;
-    std::optional<std::shared_ptr<OmniImagery>> getImageryByIonAssetId(int64_t ionAssetId) const;
-    const std::list<std::shared_ptr<OmniImagery>>& getAllImageries() const;
+    [[nodiscard]] std::optional<std::shared_ptr<OmniImagery>> getImageryByPath(const pxr::SdfPath& path) const;
+    [[nodiscard]] std::optional<std::shared_ptr<OmniImagery>> getImageryByIonAssetId(int64_t ionAssetId) const;
+    [[nodiscard]] const std::list<std::shared_ptr<OmniImagery>>& getAllImageries() const;
 
-    AssetType getAssetType(const pxr::SdfPath& path) const;
+    [[nodiscard]] AssetType getAssetType(const pxr::SdfPath& path) const;
 
     void clear();
 

--- a/src/core/include/cesium/omniverse/CesiumIonSession.h
+++ b/src/core/include/cesium/omniverse/CesiumIonSession.h
@@ -16,46 +16,46 @@ class CesiumIonSession {
   public:
     CesiumIonSession(
         CesiumAsync::AsyncSystem& asyncSystem,
-        const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor);
+        std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor);
 
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor() const {
+    [[nodiscard]] const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor() const {
         return this->_pAssetAccessor;
     }
-    const CesiumAsync::AsyncSystem& getAsyncSystem() const {
+    [[nodiscard]] const CesiumAsync::AsyncSystem& getAsyncSystem() const {
         return this->_asyncSystem;
     }
     CesiumAsync::AsyncSystem& getAsyncSystem() {
         return this->_asyncSystem;
     }
 
-    bool isConnected() const {
+    [[nodiscard]] bool isConnected() const {
         return this->_connection.has_value();
     }
-    bool isConnecting() const {
+    [[nodiscard]] bool isConnecting() const {
         return this->_isConnecting;
     }
-    bool isResuming() const {
+    [[nodiscard]] bool isResuming() const {
         return this->_isResuming;
     }
 
-    bool isProfileLoaded() const {
+    [[nodiscard]] bool isProfileLoaded() const {
         return this->_profile.has_value();
     }
-    bool isLoadingProfile() const {
+    [[nodiscard]] bool isLoadingProfile() const {
         return this->_isLoadingProfile;
     }
 
-    bool isAssetListLoaded() const {
+    [[nodiscard]] bool isAssetListLoaded() const {
         return this->_assets.has_value();
     }
-    bool isLoadingAssetList() const {
+    [[nodiscard]] bool isLoadingAssetList() const {
         return this->_isLoadingAssets;
     }
 
-    bool isTokenListLoaded() const {
+    [[nodiscard]] bool isTokenListLoaded() const {
         return this->_tokens.has_value();
     }
-    bool isLoadingTokenList() const {
+    [[nodiscard]] bool isLoadingTokenList() const {
         return this->_isLoadingTokens;
     }
 
@@ -69,12 +69,12 @@ class CesiumIonSession {
     void refreshAssets();
     void refreshTokens();
 
-    const std::optional<CesiumIonClient::Connection>& getConnection() const;
+    [[nodiscard]] const std::optional<CesiumIonClient::Connection>& getConnection() const;
     const CesiumIonClient::Profile& getProfile();
     const CesiumIonClient::Assets& getAssets();
     const std::vector<CesiumIonClient::Token>& getTokens();
 
-    const std::string& getAuthorizeUrl() const {
+    [[nodiscard]] const std::string& getAuthorizeUrl() const {
         return this->_authorizeUrl;
     }
 
@@ -94,7 +94,8 @@ class CesiumIonSession {
      * @return The details of the token, or an error response if the token does
      * not exist in the signed-in user account.
      */
-    CesiumAsync::Future<CesiumIonClient::Response<CesiumIonClient::Token>> findToken(const std::string& token) const;
+    [[nodiscard]] CesiumAsync::Future<CesiumIonClient::Response<CesiumIonClient::Token>>
+    findToken(const std::string& token) const;
 
     /**
      * Gets the project default token.

--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -17,7 +17,10 @@ class FabricMaterial;
 
 class FabricGeometry {
   public:
-    FabricGeometry(pxr::SdfPath path, const FabricGeometryDefinition& geometryDefinition, bool debugRandomColors);
+    FabricGeometry(
+        const pxr::SdfPath& path,
+        const FabricGeometryDefinition& geometryDefinition,
+        bool debugRandomColors);
     ~FabricGeometry();
 
     void setTile(
@@ -37,10 +40,10 @@ class FabricGeometry {
     void setActive(bool active);
     void setVisibility(bool visible);
 
-    carb::flatcache::Path getPathFabric() const;
-    const FabricGeometryDefinition& getGeometryDefinition() const;
+    [[nodiscard]] carb::flatcache::Path getPathFabric() const;
+    [[nodiscard]] const FabricGeometryDefinition& getGeometryDefinition() const;
 
-    void assignMaterial(std::shared_ptr<FabricMaterial> material);
+    void assignMaterial(const std::shared_ptr<FabricMaterial>& material);
 
   private:
     void initialize();

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -19,11 +19,11 @@ class FabricGeometryDefinition {
         uint64_t imageryTexcoordSetIndex,
         bool disableMaterials);
 
-    bool hasMaterial() const;
-    bool hasTexcoords() const;
-    bool hasNormals() const;
-    bool hasVertexColors() const;
-    bool getDoubleSided() const;
+    [[nodiscard]] bool hasMaterial() const;
+    [[nodiscard]] bool hasTexcoords() const;
+    [[nodiscard]] bool hasNormals() const;
+    [[nodiscard]] bool hasVertexColors() const;
+    [[nodiscard]] bool getDoubleSided() const;
 
     bool operator==(const FabricGeometryDefinition& other) const;
 

--- a/src/core/include/cesium/omniverse/FabricGeometryPool.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryPool.h
@@ -14,7 +14,7 @@ class FabricGeometryPool final : public ObjectPool<FabricGeometry> {
         uint64_t initialCapacity,
         bool debugRandomColors);
 
-    const FabricGeometryDefinition& getGeometryDefinition() const;
+    [[nodiscard]] const FabricGeometryDefinition& getGeometryDefinition() const;
 
   protected:
     std::shared_ptr<FabricGeometry> createObject(uint64_t objectId) override;

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -31,8 +31,8 @@ class FabricMaterial {
 
     void setActive(bool active);
 
-    carb::flatcache::Path getPathFabric() const;
-    const FabricMaterialDefinition& getMaterialDefinition() const;
+    [[nodiscard]] carb::flatcache::Path getPathFabric() const;
+    [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
 
   private:
     void initialize(pxr::SdfPath path, const FabricMaterialDefinition& materialDefinition);

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -19,18 +19,18 @@ class FabricMaterialDefinition {
         bool hasImagery,
         bool disableTextures);
 
-    bool hasBaseColorTexture() const;
-    bool hasVertexColors() const;
+    [[nodiscard]] bool hasBaseColorTexture() const;
+    [[nodiscard]] bool hasVertexColors() const;
 
-    float getAlphaCutoff() const;
-    int getAlphaMode() const;
-    float getBaseAlpha() const;
-    pxr::GfVec3f getBaseColorFactor() const;
-    pxr::GfVec3f getEmissiveFactor() const;
-    float getMetallicFactor() const;
-    float getRoughnessFactor() const;
-    int getWrapS() const;
-    int getWrapT() const;
+    [[nodiscard]] float getAlphaCutoff() const;
+    [[nodiscard]] int getAlphaMode() const;
+    [[nodiscard]] float getBaseAlpha() const;
+    [[nodiscard]] pxr::GfVec3f getBaseColorFactor() const;
+    [[nodiscard]] pxr::GfVec3f getEmissiveFactor() const;
+    [[nodiscard]] float getMetallicFactor() const;
+    [[nodiscard]] float getRoughnessFactor() const;
+    [[nodiscard]] int getWrapS() const;
+    [[nodiscard]] int getWrapT() const;
 
     bool operator==(const FabricMaterialDefinition& other) const;
 

--- a/src/core/include/cesium/omniverse/FabricMaterialPool.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialPool.h
@@ -10,7 +10,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
   public:
     FabricMaterialPool(int64_t poolId, const FabricMaterialDefinition& materialDefinition, uint64_t initialCapacity);
 
-    const FabricMaterialDefinition& getMaterialDefinition() const;
+    [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
 
   protected:
     std::shared_ptr<FabricMaterial> createObject(uint64_t objectId) override;

--- a/src/core/include/cesium/omniverse/FabricMesh.h
+++ b/src/core/include/cesium/omniverse/FabricMesh.h
@@ -16,8 +16,8 @@ class FabricMesh {
   public:
     FabricMesh(std::shared_ptr<FabricGeometry> geometry, std::shared_ptr<FabricMaterial> material);
 
-    std::shared_ptr<FabricGeometry> getGeometry() const;
-    std::shared_ptr<FabricMaterial> getMaterial() const;
+    [[nodiscard]] std::shared_ptr<FabricGeometry> getGeometry() const;
+    [[nodiscard]] std::shared_ptr<FabricMaterial> getMaterial() const;
 
     void setVisibility(bool visible) const;
 

--- a/src/core/include/cesium/omniverse/FabricMeshManager.h
+++ b/src/core/include/cesium/omniverse/FabricMeshManager.h
@@ -36,7 +36,7 @@ class FabricMeshManager {
         const CesiumGltf::ImageCesium* imagery,
         uint64_t imageryTexcoordSetIndex);
 
-    void releaseMesh(std::shared_ptr<FabricMesh> mesh);
+    void releaseMesh(const std::shared_ptr<FabricMesh>& mesh);
 
     void setDisableMaterials(bool disableMaterials);
     void setDisableTextures(bool disableTextures);
@@ -65,8 +65,8 @@ class FabricMeshManager {
         const CesiumGltf::MeshPrimitive& primitive,
         const CesiumGltf::ImageCesium* imagery);
 
-    void releaseGeometry(std::shared_ptr<FabricGeometry> geometry);
-    void releaseMaterial(std::shared_ptr<FabricMaterial> material);
+    void releaseGeometry(const std::shared_ptr<FabricGeometry>& geometry);
+    void releaseMaterial(const std::shared_ptr<FabricMaterial>& material);
 
     std::shared_ptr<FabricGeometryPool> getGeometryPool(const FabricGeometryDefinition& geometryDefinition);
     std::shared_ptr<FabricMaterialPool> getMaterialPool(const FabricMaterialDefinition& materialDefinition);

--- a/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
+++ b/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
@@ -18,10 +18,10 @@ struct TileRenderResources {
     std::vector<std::shared_ptr<FabricMesh>> fabricMeshes;
 };
 
-class FabricPrepareRenderResources : public Cesium3DTilesSelection::IPrepareRendererResources {
+class FabricPrepareRenderResources final : public Cesium3DTilesSelection::IPrepareRendererResources {
   public:
     FabricPrepareRenderResources(const OmniTileset& tileset);
-    ~FabricPrepareRenderResources() = default;
+    ~FabricPrepareRenderResources() override = default;
 
     CesiumAsync::Future<Cesium3DTilesSelection::TileLoadResultAndRenderResources> prepareInLoadThread(
         const CesiumAsync::AsyncSystem& asyncSystem,

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -20,8 +20,8 @@ class PositionsAccessor {
     PositionsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view);
 
     void fill(const gsl::span<pxr::GfVec3f>& values) const;
-    const glm::fvec3& get(uint64_t index) const;
-    uint64_t size() const;
+    [[nodiscard]] const glm::fvec3& get(uint64_t index) const;
+    [[nodiscard]] uint64_t size() const;
 
   private:
     CesiumGltf::AccessorView<glm::fvec3> _view;
@@ -40,8 +40,8 @@ class IndicesAccessor {
     template <typename T> static IndicesAccessor FromTriangleFans(const CesiumGltf::AccessorView<T>& view);
 
     void fill(const gsl::span<int>& values) const;
-    uint32_t get(uint64_t index) const;
-    uint64_t size() const;
+    [[nodiscard]] uint32_t get(uint64_t index) const;
+    [[nodiscard]] uint64_t size() const;
 
   private:
     std::vector<uint32_t> _computed;

--- a/src/core/include/cesium/omniverse/HttpAssetAccessor.h
+++ b/src/core/include/cesium/omniverse/HttpAssetAccessor.h
@@ -6,9 +6,10 @@
 #include <cpr/cpr.h>
 
 #include <filesystem>
+#include <utility>
 
 namespace cesium::omniverse {
-class HttpAssetResponse : public CesiumAsync::IAssetResponse {
+class HttpAssetResponse final : public CesiumAsync::IAssetResponse {
   public:
     HttpAssetResponse(cpr::Response&& response)
         : _response{std::move(response)} {
@@ -17,11 +18,11 @@ class HttpAssetResponse : public CesiumAsync::IAssetResponse {
         }
     }
 
-    uint16_t statusCode() const override {
+    [[nodiscard]] uint16_t statusCode() const override {
         return uint16_t(_response.status_code);
     }
 
-    std::string contentType() const override {
+    [[nodiscard]] std::string contentType() const override {
         auto it = _response.header.find("content-type");
         if (it != _response.header.end()) {
             return it->second;
@@ -30,11 +31,11 @@ class HttpAssetResponse : public CesiumAsync::IAssetResponse {
         return "";
     }
 
-    const CesiumAsync::HttpHeaders& headers() const override {
+    [[nodiscard]] const CesiumAsync::HttpHeaders& headers() const override {
         return _headers;
     }
 
-    gsl::span<const std::byte> data() const override {
+    [[nodiscard]] gsl::span<const std::byte> data() const override {
         return {reinterpret_cast<const std::byte*>(_response.text.data()), _response.text.size()};
     }
 
@@ -43,31 +44,31 @@ class HttpAssetResponse : public CesiumAsync::IAssetResponse {
     cpr::Response _response;
 };
 
-class HttpAssetRequest : public CesiumAsync::IAssetRequest {
+class HttpAssetRequest final : public CesiumAsync::IAssetRequest {
   public:
     HttpAssetRequest(
         std::string&& method,
-        const std::string& url,
+        std::string url,
         const std::vector<CesiumAsync::IAssetAccessor::THeader>& headers,
         cpr::Response&& response)
         : _method{std::move(method)}
-        , _url{url}
+        , _url{std::move(url)}
         , _headers{headers.begin(), headers.end()}
         , _response{std::move(response)} {}
 
-    const std::string& method() const override {
+    [[nodiscard]] const std::string& method() const override {
         return _method;
     }
 
-    const std::string& url() const override {
+    [[nodiscard]] const std::string& url() const override {
         return _url;
     }
 
-    const CesiumAsync::HttpHeaders& headers() const override {
+    [[nodiscard]] const CesiumAsync::HttpHeaders& headers() const override {
         return _headers;
     }
 
-    const CesiumAsync::IAssetResponse* response() const override {
+    [[nodiscard]] const CesiumAsync::IAssetResponse* response() const override {
         return &_response;
     }
 
@@ -78,7 +79,7 @@ class HttpAssetRequest : public CesiumAsync::IAssetRequest {
     HttpAssetResponse _response;
 };
 
-class HttpAssetAccessor : public CesiumAsync::IAssetAccessor {
+class HttpAssetAccessor final : public CesiumAsync::IAssetAccessor {
   public:
     HttpAssetAccessor(const std::filesystem::path& certificatePath);
 

--- a/src/core/include/cesium/omniverse/LoggerSink.h
+++ b/src/core/include/cesium/omniverse/LoggerSink.h
@@ -18,7 +18,7 @@ namespace cesium::omniverse {
 #define CESIUM_LOG_ERROR(...) Context::instance().getLogger()->error(__VA_ARGS__)
 #define CESIUM_LOG_FATAL(...) Context::instance().getLogger()->fatal(__VA_ARGS__)
 
-class LoggerSink : public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
+class LoggerSink final : public spdlog::sinks::base_sink<spdlog::details::null_mutex> {
   public:
     LoggerSink(omni::log::Level logLevel);
 

--- a/src/core/include/cesium/omniverse/ObjectPool.h
+++ b/src/core/include/cesium/omniverse/ObjectPool.h
@@ -34,19 +34,19 @@ template <typename T> class ObjectPool {
         setActive(object, false);
     }
 
-    uint64_t getCapacity() const {
+    [[nodiscard]] uint64_t getCapacity() const {
         return _capacity;
     }
 
-    uint64_t getNumberActive() const {
+    [[nodiscard]] uint64_t getNumberActive() const {
         return getCapacity() - getNumberInactive();
     }
 
-    uint64_t getNumberInactive() const {
+    [[nodiscard]] uint64_t getNumberInactive() const {
         return _queue.size();
     }
 
-    double computePercentActive() const {
+    [[nodiscard]] double computePercentActive() const {
         const auto numberActive = static_cast<double>(getNumberActive());
         const auto capacity = static_cast<double>(getCapacity());
 

--- a/src/core/include/cesium/omniverse/OmniImagery.h
+++ b/src/core/include/cesium/omniverse/OmniImagery.h
@@ -6,13 +6,13 @@
 namespace cesium::omniverse {
 class OmniImagery {
   public:
-    OmniImagery(const pxr::SdfPath& path);
+    OmniImagery(pxr::SdfPath path);
 
-    pxr::SdfPath getPath() const;
-    std::string getName() const;
-    int64_t getIonAssetId() const;
-    std::optional<CesiumIonClient::Token> getIonAccessToken() const;
-    bool getShowCreditsOnScreen() const;
+    [[nodiscard]] pxr::SdfPath getPath() const;
+    [[nodiscard]] std::string getName() const;
+    [[nodiscard]] int64_t getIonAssetId() const;
+    [[nodiscard]] std::optional<CesiumIonClient::Token> getIonAccessToken() const;
+    [[nodiscard]] bool getShowCreditsOnScreen() const;
 
   private:
     pxr::SdfPath _path;

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -11,14 +11,12 @@
 #include <vector>
 
 namespace Cesium3DTilesSelection {
-struct ImageCesium;
 class Tileset;
 class ViewState;
 class ViewUpdateResult;
 } // namespace Cesium3DTilesSelection
 
 namespace CesiumGltf {
-struct ImageCesium;
 struct Model;
 } // namespace CesiumGltf
 
@@ -45,30 +43,30 @@ class OmniTileset {
     OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& georeferencePath);
     ~OmniTileset();
 
-    pxr::SdfPath getPath() const;
-    std::string getName() const;
-    TilesetSourceType getSourceType() const;
-    std::string getUrl() const;
-    int64_t getIonAssetId() const;
-    std::optional<CesiumIonClient::Token> getIonAccessToken() const;
-    float getMaximumScreenSpaceError() const;
-    bool getPreloadAncestors() const;
-    bool getPreloadSiblings() const;
-    bool getForbidHoles() const;
-    uint32_t getMaximumSimultaneousTileLoads() const;
-    uint64_t getMaximumCachedBytes() const;
-    uint32_t getLoadingDescendantLimit() const;
-    bool getEnableFrustumCulling() const;
-    bool getEnableFogCulling() const;
-    bool getEnforceCulledScreenSpaceError() const;
-    float getCulledScreenSpaceError() const;
-    bool getSuspendUpdate() const;
-    bool getSmoothNormals() const;
-    bool getShowCreditsOnScreen() const;
-    pxr::CesiumGeoreference getGeoreference() const;
+    [[nodiscard]] pxr::SdfPath getPath() const;
+    [[nodiscard]] std::string getName() const;
+    [[nodiscard]] TilesetSourceType getSourceType() const;
+    [[nodiscard]] std::string getUrl() const;
+    [[nodiscard]] int64_t getIonAssetId() const;
+    [[nodiscard]] std::optional<CesiumIonClient::Token> getIonAccessToken() const;
+    [[nodiscard]] float getMaximumScreenSpaceError() const;
+    [[nodiscard]] bool getPreloadAncestors() const;
+    [[nodiscard]] bool getPreloadSiblings() const;
+    [[nodiscard]] bool getForbidHoles() const;
+    [[nodiscard]] uint32_t getMaximumSimultaneousTileLoads() const;
+    [[nodiscard]] uint64_t getMaximumCachedBytes() const;
+    [[nodiscard]] uint32_t getLoadingDescendantLimit() const;
+    [[nodiscard]] bool getEnableFrustumCulling() const;
+    [[nodiscard]] bool getEnableFogCulling() const;
+    [[nodiscard]] bool getEnforceCulledScreenSpaceError() const;
+    [[nodiscard]] float getCulledScreenSpaceError() const;
+    [[nodiscard]] bool getSuspendUpdate() const;
+    [[nodiscard]] bool getSmoothNormals() const;
+    [[nodiscard]] bool getShowCreditsOnScreen() const;
+    [[nodiscard]] pxr::CesiumGeoreference getGeoreference() const;
 
-    int64_t getTilesetId() const;
-    TilesetStatistics getStatistics() const;
+    [[nodiscard]] int64_t getTilesetId() const;
+    [[nodiscard]] TilesetStatistics getStatistics() const;
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);

--- a/src/core/include/cesium/omniverse/TaskProcessor.h
+++ b/src/core/include/cesium/omniverse/TaskProcessor.h
@@ -4,7 +4,7 @@
 #include <pxr/base/work/dispatcher.h>
 
 namespace cesium::omniverse {
-class TaskProcessor : public CesiumAsync::ITaskProcessor {
+class TaskProcessor final : public CesiumAsync::ITaskProcessor {
   public:
     void startTask(std::function<void()> f) override;
 

--- a/src/core/include/cesium/omniverse/UsdNotificationHandler.h
+++ b/src/core/include/cesium/omniverse/UsdNotificationHandler.h
@@ -26,7 +26,7 @@ struct ChangedPrim {
     ChangeType changeType;
 };
 
-class UsdNotificationHandler : public pxr::TfWeakBase {
+class UsdNotificationHandler final : public pxr::TfWeakBase {
   public:
     UsdNotificationHandler();
     ~UsdNotificationHandler();

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -34,7 +34,7 @@ struct Decomposed {
 class ScopedEdit {
   public:
     ScopedEdit(pxr::UsdStageRefPtr stage)
-        : _stage(stage)
+        : _stage(std::move(stage))
         , _sessionLayer(_stage->GetSessionLayer())
         , _sessionLayerWasEditable(_sessionLayer->PermissionToEdit())
         , _originalEditTarget(_stage->GetEditTarget()) {

--- a/src/core/src/CesiumIonSession.cpp
+++ b/src/core/src/CesiumIonSession.cpp
@@ -18,9 +18,9 @@ const char* browserCommandBase = "xdg-open";
 
 CesiumIonSession::CesiumIonSession(
     CesiumAsync::AsyncSystem& asyncSystem,
-    const std::shared_ptr<CesiumAsync::IAssetAccessor>& pAssetAccessor)
+    std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor)
     : _asyncSystem(asyncSystem)
-    , _pAssetAccessor(pAssetAccessor)
+    , _pAssetAccessor(std::move(pAssetAccessor))
     , _connection(std::nullopt)
     , _profile(std::nullopt)
     , _assets(std::nullopt)
@@ -272,7 +272,8 @@ Future<Token> getTokenFuture(const CesiumIonSession& session) {
     std::string defaultIonAccessToken = Settings::getDefaultAccessToken();
 
     if (!defaultIonAccessToken.empty()) {
-        return session.getConnection()
+        return session // NOLINT(bugprone-unchecked-optional-access)
+            .getConnection()
             ->token(defaultIonAccessToken)
             .thenImmediately([](Response<Token>&& tokenResponse) {
                 if (tokenResponse.value) {

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -139,8 +139,8 @@ void Context::setProjectDefaultToken(const CesiumIonClient::Token& token) {
 
 pxr::SdfPath Context::addTilesetUrl(const std::string& name, const std::string& url) {
     const auto tilesetName = UsdUtil::getSafeName(name);
-    const auto tilesetPath = UsdUtil::getPathUnique(UsdUtil::getRootPath(), tilesetName);
-    const auto tilesetUsd = UsdUtil::defineCesiumTileset(tilesetPath);
+    auto tilesetPath = UsdUtil::getPathUnique(UsdUtil::getRootPath(), tilesetName);
+    auto tilesetUsd = UsdUtil::defineCesiumTileset(tilesetPath);
 
     tilesetUsd.GetUrlAttr().Set<std::string>(url);
 
@@ -149,8 +149,8 @@ pxr::SdfPath Context::addTilesetUrl(const std::string& name, const std::string& 
 
 pxr::SdfPath Context::addTilesetIon(const std::string& name, int64_t ionAssetId, const std::string& ionAccessToken) {
     const auto tilesetName = UsdUtil::getSafeName(name);
-    const auto tilesetPath = UsdUtil::getPathUnique(UsdUtil::getRootPath(), tilesetName);
-    const auto tilesetUsd = UsdUtil::defineCesiumTileset(tilesetPath);
+    auto tilesetPath = UsdUtil::getPathUnique(UsdUtil::getRootPath(), tilesetName);
+    auto tilesetUsd = UsdUtil::defineCesiumTileset(tilesetPath);
 
     tilesetUsd.GetIonAssetIdAttr().Set<int64_t>(ionAssetId);
     tilesetUsd.GetIonAccessTokenAttr().Set<std::string>(ionAccessToken);
@@ -164,8 +164,8 @@ pxr::SdfPath Context::addImageryIon(
     int64_t ionAssetId,
     const std::string& ionAccessToken) {
     const auto imageryName = UsdUtil::getSafeName(name);
-    const auto imageryPath = UsdUtil::getPathUnique(tilesetPath, imageryName);
-    const auto imageryUsd = UsdUtil::defineCesiumImagery(imageryPath);
+    auto imageryPath = UsdUtil::getPathUnique(tilesetPath, imageryName);
+    auto imageryUsd = UsdUtil::defineCesiumImagery(imageryPath);
 
     imageryUsd.GetIonAssetIdAttr().Set<int64_t>(ionAssetId);
     imageryUsd.GetIonAccessTokenAttr().Set<std::string>(ionAccessToken);
@@ -271,7 +271,8 @@ void Context::processCesiumDataChanged(const ChangedPrim& changedPrim) {
         for (const auto& tileset : tilesets) {
             const auto tilesetToken = tileset->getIonAccessToken();
             const auto defaultToken = Context::instance().getDefaultToken();
-            if (!tilesetToken.has_value() || tilesetToken.value().token == defaultToken.value().token) {
+            if (!tilesetToken.has_value() ||
+                (defaultToken.has_value() && tilesetToken.value().token == defaultToken.value().token)) {
                 tileset->reload();
             }
         }
@@ -399,7 +400,7 @@ pxr::UsdStageRefPtr Context::getStage() const {
 
 carb::flatcache::StageInProgress Context::getFabricStageInProgress() const {
     assert(_fabricStageInProgress.has_value());
-    return _fabricStageInProgress.value();
+    return _fabricStageInProgress.value(); // NOLINT(bugprone-unchecked-optional-access)
 }
 
 long Context::getStageId() const {
@@ -605,10 +606,11 @@ void Context::updateTroubleshootingDetails(
 
     _defaultTokenTroubleshootingDetails = TokenTroubleshootingDetails();
 
-    if (isDefaultTokenSet()) {
-        auto defaultToken = getDefaultToken().value().token;
+    const auto& defaultToken = getDefaultToken();
+    if (defaultToken.has_value()) {
+        const auto& token = defaultToken.value().token;
         troubleshooter.updateTokenTroubleshootingDetails(
-            tilesetIonAssetId, defaultToken, tokenEventId, _defaultTokenTroubleshootingDetails.value());
+            tilesetIonAssetId, token, tokenEventId, _defaultTokenTroubleshootingDetails.value());
     }
 
     _assetTokenTroubleshootingDetails = TokenTroubleshootingDetails();
@@ -647,8 +649,9 @@ void Context::updateTroubleshootingDetails(
 
     _defaultTokenTroubleshootingDetails = TokenTroubleshootingDetails();
 
-    if (isDefaultTokenSet()) {
-        auto token = getDefaultToken().value().token;
+    const auto& defaultToken = getDefaultToken();
+    if (defaultToken.has_value()) {
+        const auto& token = defaultToken.value().token;
         troubleshooter.updateTokenTroubleshootingDetails(
             imageryIonAssetId, token, tokenEventId, _defaultTokenTroubleshootingDetails.value());
     }

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -32,7 +32,7 @@ const auto DEFAULT_MATRIX = pxr::GfMatrix4d(1.0);
 } // namespace
 
 FabricGeometry::FabricGeometry(
-    pxr::SdfPath path,
+    const pxr::SdfPath& path,
     const FabricGeometryDefinition& geometryDefinition,
     bool debugRandomColors)
     : _pathFabric(path.GetText())
@@ -66,7 +66,7 @@ const FabricGeometryDefinition& FabricGeometry::getGeometryDefinition() const {
     return _geometryDefinition;
 }
 
-void FabricGeometry::assignMaterial(std::shared_ptr<FabricMaterial> material) {
+void FabricGeometry::assignMaterial(const std::shared_ptr<FabricMaterial>& material) {
     auto sip = UsdUtil::getFabricStageInProgress();
     auto materialIdFabric = sip.getAttributeWr<uint64_t>(_pathFabric, FabricTokens::materialId);
     *materialIdFabric = carb::flatcache::PathC(material->getPathFabric()).path;

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -25,7 +25,7 @@ namespace cesium::omniverse {
 FabricMaterial::FabricMaterial(pxr::SdfPath path, const FabricMaterialDefinition& materialDefinition)
     : _materialDefinition(materialDefinition) {
 
-    initialize(path, materialDefinition);
+    initialize(std::move(path), materialDefinition);
 
     // Remove this function once dynamic material values are supported in Kit 105
     setInitialValues(materialDefinition);
@@ -64,7 +64,7 @@ void FabricMaterial::initialize(pxr::SdfPath path, const FabricMaterialDefinitio
 
     auto sip = UsdUtil::getFabricStageInProgress();
 
-    const auto materialPath = path;
+    const auto materialPath = std::move(path);
     const auto shaderPath = materialPath.AppendChild(UsdTokens::Shader);
     const auto displacementPath = materialPath.AppendChild(UsdTokens::displacement);
     const auto surfacePath = materialPath.AppendChild(UsdTokens::surface);

--- a/src/core/src/FabricMesh.cpp
+++ b/src/core/src/FabricMesh.cpp
@@ -4,8 +4,8 @@
 
 namespace cesium::omniverse {
 FabricMesh::FabricMesh(std::shared_ptr<FabricGeometry> geometry, std::shared_ptr<FabricMaterial> material)
-    : _geometry(geometry)
-    , _material(material) {}
+    : _geometry(std::move(geometry))
+    , _material(std::move(material)) {}
 
 std::shared_ptr<FabricGeometry> FabricMesh::getGeometry() const {
     return _geometry;

--- a/src/core/src/FabricMeshManager.cpp
+++ b/src/core/src/FabricMeshManager.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<FabricMesh> FabricMeshManager::acquireMesh(
     return std::make_shared<FabricMesh>(geometry, material);
 }
 
-void FabricMeshManager::releaseMesh(std::shared_ptr<FabricMesh> mesh) {
+void FabricMeshManager::releaseMesh(const std::shared_ptr<FabricMesh>& mesh) {
     const auto geometry = mesh->getGeometry();
     const auto material = mesh->getMaterial();
 
@@ -100,7 +100,7 @@ std::shared_ptr<FabricGeometry> FabricMeshManager::acquireGeometry(
     std::scoped_lock<std::mutex> lock(_poolMutex);
 
     const auto geometryPool = getGeometryPool(geometryDefinition);
-    const auto geometry = geometryPool->acquire();
+    auto geometry = geometryPool->acquire();
 
     return geometry;
 }
@@ -120,12 +120,12 @@ std::shared_ptr<FabricMaterial> FabricMeshManager::acquireMaterial(
     std::scoped_lock<std::mutex> lock(_poolMutex);
 
     const auto materialPool = getMaterialPool(materialDefinition);
-    const auto material = materialPool->acquire();
+    auto material = materialPool->acquire();
 
     return material;
 }
 
-void FabricMeshManager::releaseGeometry(std::shared_ptr<FabricGeometry> geometry) {
+void FabricMeshManager::releaseGeometry(const std::shared_ptr<FabricGeometry>& geometry) {
     if (_disableGeometryPool) {
         return;
     }
@@ -136,7 +136,7 @@ void FabricMeshManager::releaseGeometry(std::shared_ptr<FabricGeometry> geometry
     geometryPool->release(geometry);
 }
 
-void FabricMeshManager::releaseMaterial(std::shared_ptr<FabricMaterial> material) {
+void FabricMeshManager::releaseMaterial(const std::shared_ptr<FabricMaterial>& material) {
     if (_disableMaterialPool) {
         return;
     }

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -172,7 +172,7 @@ FabricPrepareRenderResources::prepareInLoadThread(
     if (!tileLoadResult.rasterOverlayDetails.has_value()) {
         auto meshes = gatherMeshes(_tileset, transform, *pModel);
         return asyncSystem.runInMainThread(
-            [transform, meshes = std::move(meshes), tileLoadResult = std::move(tileLoadResult)]() {
+            [transform, meshes = std::move(meshes), tileLoadResult = std::move(tileLoadResult)]() mutable {
                 const auto& model = *std::get_if<CesiumGltf::Model>(&tileLoadResult.contentKind);
                 auto fabricMeshes = acquireFabricMeshes(model, meshes);
                 setFabricMeshes(model, meshes, fabricMeshes);

--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -10,7 +10,7 @@ CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::Cesi
     georeference.GetGeoreferenceOriginLatitudeAttr().Get<double>(&latitude);
     georeference.GetGeoreferenceOriginHeightAttr().Get<double>(&height);
 
-    return CesiumGeospatial::Cartographic(glm::radians(longitude), glm::radians(latitude), height);
+    return {glm::radians(longitude), glm::radians(latitude), height};
 }
 
 } // namespace cesium::omniverse::GeospatialUtil

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -10,12 +10,12 @@ PositionsAccessor::PositionsAccessor(const CesiumGltf::AccessorView<glm::fvec3>&
 
 void PositionsAccessor::fill(const gsl::span<pxr::GfVec3f>& values) const {
     for (uint64_t i = 0; i < _size; i++) {
-        values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[i]);
+        values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[static_cast<int64_t>(i)]);
     }
 }
 
 const glm::fvec3& PositionsAccessor::get(uint64_t index) const {
-    return _view[index];
+    return _view[static_cast<int64_t>(index)];
 }
 
 uint64_t PositionsAccessor::size() const {
@@ -57,8 +57,8 @@ template <typename T> IndicesAccessor IndicesAccessor::FromTriangleStrips(const 
     }
 
     auto accessor = IndicesAccessor();
-    accessor._computed = std::move(indices);
     accessor._size = indices.size();
+    accessor._computed = std::move(indices);
     return accessor;
 }
 
@@ -78,8 +78,8 @@ template <typename T> IndicesAccessor IndicesAccessor::FromTriangleFans(const Ce
     }
 
     auto accessor = IndicesAccessor();
-    accessor._computed = std::move(indices);
     accessor._size = indices.size();
+    accessor._computed = std::move(indices);
     return accessor;
 }
 
@@ -95,15 +95,15 @@ void IndicesAccessor::fill(const gsl::span<int>& values) const {
         }
     } else if (_uint8View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = static_cast<int>(_uint8View[i]);
+            values[i] = static_cast<int>(_uint8View[static_cast<int64_t>(i)]);
         }
     } else if (_uint16View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = static_cast<int>(_uint16View[i]);
+            values[i] = static_cast<int>(_uint16View[static_cast<int64_t>(i)]);
         }
     } else if (_uint32View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = static_cast<int>(_uint32View[i]);
+            values[i] = static_cast<int>(_uint32View[static_cast<int64_t>(i)]);
         }
     } else {
         for (uint64_t i = 0; i < _size; i++) {
@@ -116,11 +116,11 @@ uint32_t IndicesAccessor::get(uint64_t index) const {
     if (!_computed.empty()) {
         return _computed[index];
     } else if (_uint8View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        return static_cast<uint32_t>(_uint8View[index]);
+        return static_cast<uint32_t>(_uint8View[static_cast<int64_t>(index)]);
     } else if (_uint16View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        return static_cast<uint32_t>(_uint16View[index]);
+        return static_cast<uint32_t>(_uint16View[static_cast<int64_t>(index)]);
     } else if (_uint32View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        return static_cast<uint32_t>(_uint32View[index]);
+        return static_cast<uint32_t>(_uint32View[static_cast<int64_t>(index)]);
     } else {
         return static_cast<uint32_t>(index);
     }
@@ -172,7 +172,7 @@ void NormalsAccessor::fill(const gsl::span<pxr::GfVec3f>& values) const {
         }
     } else {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[i]);
+            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_view[static_cast<int64_t>(i)]);
         }
     }
 }
@@ -198,7 +198,7 @@ TexcoordsAccessor::TexcoordsAccessor(
 
 void TexcoordsAccessor::fill(const gsl::span<pxr::GfVec2f>& values) const {
     for (uint64_t i = 0; i < _size; i++) {
-        values[i] = *reinterpret_cast<const pxr::GfVec2f*>(&_view[i]);
+        values[i] = *reinterpret_cast<const pxr::GfVec2f*>(&_view[static_cast<int64_t>(i)]);
     }
 
     if (_flipVertical) {
@@ -253,38 +253,38 @@ void VertexColorsAccessor::fill(const gsl::span<pxr::GfVec3f>& values) const {
     if (_uint8Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
             values[i] = pxr::GfVec3f(
-                static_cast<float>(_uint8Vec3View[i].x) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec3View[i].y) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec3View[i].z) / static_cast<float>(MAX_UINT8));
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT8),
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT8),
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT8));
         }
     } else if (_uint8Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
             values[i] = pxr::GfVec3f(
-                static_cast<float>(_uint8Vec4View[i].x) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec4View[i].y) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec4View[i].z) / static_cast<float>(MAX_UINT8));
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT8),
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT8),
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT8));
         }
     } else if (_uint16Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
             values[i] = pxr::GfVec3f(
-                static_cast<float>(_uint16Vec3View[i].x) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec3View[i].y) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec3View[i].z) / static_cast<float>(MAX_UINT16));
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT16),
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT16),
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT16));
         }
     } else if (_uint16Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
             values[i] = pxr::GfVec3f(
-                static_cast<float>(_uint16Vec4View[i].x) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec4View[i].y) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec4View[i].z) / static_cast<float>(MAX_UINT16));
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT16),
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT16),
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT16));
         }
     } else if (_float32Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_float32Vec3View[i]);
+            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_float32Vec3View[static_cast<int64_t>(i)]);
         }
     } else if (_float32Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
         for (uint64_t i = 0; i < _size; i++) {
-            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_float32Vec4View[i]);
+            values[i] = *reinterpret_cast<const pxr::GfVec3f*>(&_float32Vec4View[static_cast<int64_t>(i)]);
         }
     }
 }

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -137,7 +137,7 @@ TexcoordsAccessor getTexcoords(
         return {};
     }
 
-    return TexcoordsAccessor(texcoordsView, translation, scale, flipVertical);
+    return {texcoordsView, translation, scale, flipVertical};
 }
 
 template <typename VertexColorType>
@@ -154,10 +154,10 @@ float getBaseAlpha(const CesiumGltf::MaterialPBRMetallicRoughness& pbrMetallicRo
 }
 
 pxr::GfVec3f getBaseColorFactor(const CesiumGltf::MaterialPBRMetallicRoughness& pbrMetallicRoughness) {
-    return pxr::GfVec3f(
+    return {
         static_cast<float>(pbrMetallicRoughness.baseColorFactor[0]),
         static_cast<float>(pbrMetallicRoughness.baseColorFactor[1]),
-        static_cast<float>(pbrMetallicRoughness.baseColorFactor[2]));
+        static_cast<float>(pbrMetallicRoughness.baseColorFactor[2])};
 }
 
 float getMetallicFactor(const CesiumGltf::MaterialPBRMetallicRoughness& pbrMetallicRoughness) {
@@ -185,7 +185,7 @@ PositionsAccessor getPositions(const CesiumGltf::Model& model, const CesiumGltf:
         return {};
     }
 
-    return PositionsAccessor(positionsView);
+    return {positionsView};
 }
 
 std::optional<pxr::GfRange3d> getExtent(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive) {
@@ -215,7 +215,7 @@ IndicesAccessor getIndices(
     const PositionsAccessor& positions) {
     const auto indicesAccessor = model.getSafe<CesiumGltf::Accessor>(&model.accessors, primitive.indices);
     if (!indicesAccessor) {
-        return IndicesAccessor(positions.size());
+        return {positions.size()};
     }
 
     if (indicesAccessor->componentType == CesiumGltf::AccessorSpec::ComponentType::UNSIGNED_BYTE) {
@@ -242,7 +242,7 @@ NormalsAccessor getNormals(
     const auto normalsView = getNormalsView(model, primitive);
 
     if (normalsView.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        return NormalsAccessor(normalsView);
+        return {normalsView};
     }
 
     if (smoothNormals) {
@@ -298,7 +298,7 @@ getVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive&
 }
 
 FaceVertexCountsAccessor getFaceVertexCounts(const IndicesAccessor& indices) {
-    return FaceVertexCountsAccessor(indices.size() / 3);
+    return {indices.size() / 3};
 }
 
 float getAlphaCutoff(const CesiumGltf::Material& material) {
@@ -336,10 +336,10 @@ pxr::GfVec3f getBaseColorFactor(const CesiumGltf::Material& material) {
 }
 
 pxr::GfVec3f getEmissiveFactor(const CesiumGltf::Material& material) {
-    return pxr::GfVec3f(
+    return {
         static_cast<float>(material.emissiveFactor[0]),
         static_cast<float>(material.emissiveFactor[1]),
-        static_cast<float>(material.emissiveFactor[2]));
+        static_cast<float>(material.emissiveFactor[2])};
 }
 
 float getMetallicFactor(const CesiumGltf::Material& material) {

--- a/src/core/src/OmniImagery.cpp
+++ b/src/core/src/OmniImagery.cpp
@@ -7,8 +7,8 @@
 
 namespace cesium::omniverse {
 
-OmniImagery::OmniImagery(const pxr::SdfPath& path)
-    : _path(path) {}
+OmniImagery::OmniImagery(pxr::SdfPath path)
+    : _path(std::move(path)) {}
 
 pxr::SdfPath OmniImagery::getPath() const {
     return _path;

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -38,7 +38,7 @@ OmniTileset::OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& ge
     UsdUtil::setGeoreferenceForTileset(tilesetPath, georeferencePath);
 }
 
-OmniTileset::~OmniTileset() {}
+OmniTileset::~OmniTileset() = default;
 
 pxr::SdfPath OmniTileset::getPath() const {
     return _tilesetPath;
@@ -260,7 +260,7 @@ TilesetStatistics OmniTileset::getStatistics() const {
 void OmniTileset::reload() {
     _renderResourcesPreparer = std::make_shared<FabricPrepareRenderResources>(*this);
     auto& context = Context::instance();
-    const auto asyncSystem = CesiumAsync::AsyncSystem(context.getTaskProcessor());
+    auto asyncSystem = CesiumAsync::AsyncSystem(context.getTaskProcessor());
     const auto externals = Cesium3DTilesSelection::TilesetExternals{
         context.getHttpAssetAccessor(),
         _renderResourcesPreparer,

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -61,12 +61,12 @@ bool hasStage() {
 }
 
 glm::dvec3 usdToGlmVector(const pxr::GfVec3d& vector) {
-    return glm::dvec3(vector[0], vector[1], vector[2]);
+    return {vector[0], vector[1], vector[2]};
 }
 
 glm::dmat4 usdToGlmMatrix(const pxr::GfMatrix4d& matrix) {
     // Row-major to column-major
-    return glm::dmat4{
+    return {
         matrix[0][0],
         matrix[1][0],
         matrix[2][0],
@@ -87,7 +87,7 @@ glm::dmat4 usdToGlmMatrix(const pxr::GfMatrix4d& matrix) {
 }
 
 pxr::GfVec3d glmToUsdVector(const glm::dvec3& vector) {
-    return pxr::GfVec3d(vector.x, vector.y, vector.z);
+    return {vector.x, vector.y, vector.z};
 }
 
 pxr::GfMatrix4d glmToUsdMatrix(const glm::dmat4& matrix) {
@@ -158,7 +158,7 @@ bool isPrimVisible(const pxr::SdfPath& path) {
 
 pxr::TfToken getUsdUpAxis() {
     const auto stage = getUsdStage();
-    const auto upAxis = pxr::UsdGeomGetStageUpAxis(stage);
+    auto upAxis = pxr::UsdGeomGetStageUpAxis(stage);
     return upAxis;
 }
 
@@ -256,7 +256,7 @@ pxr::GfRange3d computeWorldExtent(const pxr::GfRange3d& localExtent, const glm::
         worldMax = glm::max(worldMax, worldPosition);
     }
 
-    return pxr::GfRange3d(glmToUsdVector(worldMin), glmToUsdVector(worldMax));
+    return {glmToUsdVector(worldMin), glmToUsdVector(worldMax)};
 }
 
 pxr::CesiumData defineCesiumData(const pxr::SdfPath& path) {

--- a/src/public/CesiumOmniverse.cpp
+++ b/src/public/CesiumOmniverse.cpp
@@ -17,13 +17,13 @@
 
 namespace cesium::omniverse {
 
-class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
+class CesiumOmniversePlugin final : public ICesiumOmniverseInterface {
   protected:
     void onStartup(const char* cesiumExtensionLocation) noexcept override {
         Context::onStartup(cesiumExtensionLocation);
     }
 
-    void onShutdown() noexcept {
+    void onShutdown() noexcept override {
         Context::onShutdown();
     }
 
@@ -56,7 +56,7 @@ class CesiumOmniversePlugin : public ICesiumOmniverseInterface {
         int64_t tilesetIonAssetId,
         const char* imageryName,
         int64_t imageryIonAssetId) noexcept override {
-        const auto tilesetPath = addTilesetIon(tilesetName, tilesetIonAssetId, "");
+        auto tilesetPath = addTilesetIon(tilesetName, tilesetIonAssetId, "");
         addImageryIon(tilesetPath.c_str(), imageryName, imageryIonAssetId, "");
 
         return tilesetPath;
@@ -200,7 +200,9 @@ const struct carb::PluginImplDesc pluginImplDesc = {
     carb::PluginHotReload::eDisabled,
     "dev"};
 
+// NOLINTBEGIN
 CARB_PLUGIN_IMPL(pluginImplDesc, cesium::omniverse::CesiumOmniversePlugin)
 CARB_PLUGIN_IMPL_DEPS(carb::flatcache::FlatCache, carb::flatcache::IStageInProgress)
+// NOLINTEND
 
 void fillInterface([[maybe_unused]] cesium::omniverse::CesiumOmniversePlugin& iface) {}

--- a/tests/ObjectPoolTests.cpp
+++ b/tests/ObjectPoolTests.cpp
@@ -13,7 +13,7 @@
 constexpr int MAX_TESTED_POOL_SIZE = 1024; // The max size pool to randomly generate
 
 // ObjectPool is a virtual class so we cannot directly instantiate it for
-// testing, and instatiating the classes that implement it (FabricGeometryPool
+// testing, and instantiating the classes that implement it (FabricGeometryPool
 // and FabricMaterialPool) requires mocking more complicated classes, so we
 // create a bare-bones class here.
 


### PR DESCRIPTION
`ms-vscode.cpptools` IntelliSense is too slow, switching to clangd instead. We've been using clangd on Linux for a while now without any trouble.