### PR TITLE
Add FPS stats to performance testing window

### DIFF
--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -12,6 +12,7 @@ import omni.kit.ui
 from omni.kit.viewport.utility import get_active_viewport
 from pxr import Gf, Sdf, UsdGeom
 from .performance_window import CesiumPerformanceWindow
+from .fps_sampler import FpsSampler
 from cesium.omniverse.bindings import acquire_cesium_omniverse_interface, release_cesium_omniverse_interface
 from cesium.omniverse.utils import wait_n_frames, dock_window_async
 from cesium.usd.plugins.CesiumUsdSchemas import (
@@ -57,6 +58,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         self._tileset_path: Optional[str] = None
         self._active: bool = False
         self._start_time: float = 0.0
+        self._fps_sampler: FpsSampler = FpsSampler()
 
     def on_startup(self):
         global _cesium_omniverse_interface
@@ -165,6 +167,8 @@ class CesiumPerformanceExtension(omni.ext.IExt):
             self._update_frame_subscription.unsubscribe()
             self._update_frame_subscription = None
 
+        self._fps_sampler.destroy()
+
         self._destroy_performance_window()
 
         release_cesium_omniverse_interface(_cesium_omniverse_interface)
@@ -218,6 +222,7 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         if self._active is True:
             duration = self._get_duration()
             self._update_duration_ui(duration)
+            self._update_fps_ui(self._fps_sampler.get_fps())
 
     def _on_stage_event(self, _e: carb.events.IEvent):
         usd_context = omni.usd.get_context()
@@ -482,11 +487,16 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         self._tileset_path = tileset_path
         self._active = True
         self._start_time = time.time()
+        self._fps_sampler.start()
 
     def _tileset_loaded(self, _e: carb.events.IEvent):
         self._stop()
         duration = self._get_duration()
         self._update_duration_ui(duration)
+        self._update_fps_mean_ui(self._fps_sampler.get_mean())
+        self._update_fps_median_ui(self._fps_sampler.get_median())
+        self._update_fps_low_ui(self._fps_sampler.get_low())
+        self._update_fps_high_ui(self._fps_sampler.get_high())
         self._logger.warning("Loaded in {} seconds".format(duration))
 
     def _get_duration(self) -> float:
@@ -494,13 +504,38 @@ class CesiumPerformanceExtension(omni.ext.IExt):
         duration = current_time - self._start_time
         return duration
 
-    def _update_duration_ui(self, duration: float):
+    def _update_duration_ui(self, value: float):
         if self._performance_window is not None:
-            self._performance_window.set_duration(duration)
+            self._performance_window.set_duration(value)
+
+    def _update_fps_ui(self, value: float):
+        if self._performance_window is not None:
+            self._performance_window.set_fps(value)
+
+    def _update_fps_mean_ui(self, value: float):
+        if self._performance_window is not None:
+            self._performance_window.set_fps_mean(value)
+
+    def _update_fps_median_ui(self, value: float):
+        if self._performance_window is not None:
+            self._performance_window.set_fps_median(value)
+
+    def _update_fps_low_ui(self, value: float):
+        if self._performance_window is not None:
+            self._performance_window.set_fps_low(value)
+
+    def _update_fps_high_ui(self, value: float):
+        if self._performance_window is not None:
+            self._performance_window.set_fps_high(value)
 
     def _clear_scene(self):
         self._stop()
         self._update_duration_ui(0.0)
+        self._update_fps_ui(0.0)
+        self._update_fps_mean_ui(0.0)
+        self._update_fps_median_ui(0.0)
+        self._update_fps_low_ui(0.0)
+        self._update_fps_high_ui(0.0)
 
         if self._tileset_path is not None:
             self._remove_prim(self._tileset_path)
@@ -510,6 +545,8 @@ class CesiumPerformanceExtension(omni.ext.IExt):
 
     def _stop(self):
         self._active = False
+
+        self._fps_sampler.stop()
 
         if self._tileset_loaded_subscription is not None:
             self._tileset_loaded_subscription.unsubscribe()

--- a/apps/exts/cesium.performance.app/cesium/performance/app/fps_sampler.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/fps_sampler.py
@@ -1,0 +1,85 @@
+import array
+import time
+import carb.events
+import omni.kit.app as app
+import statistics
+from omni.kit.viewport.utility import get_active_viewport
+
+FREQUENCY_IN_SECONDS: float = 0.025
+
+
+class FpsSampler:
+    def __init__(
+        self,
+    ):
+        self._last_time: float = 0.0
+        self._active: bool = False
+        self._fps = 0.0
+
+        self._samples = array.array("f")
+
+        self._median: float = 0.0
+        self._mean: float = 0.0
+        self._low: float = 0.0
+        self._high: float = 0.0
+
+        self._viewport = get_active_viewport()
+
+        update_stream = app.get_app().get_update_event_stream()
+        self._update_frame_subscription = update_stream.create_subscription_to_pop(
+            self._on_update_frame, name="cesium.performance.ON_UPDATE_FRAME"
+        )
+
+    def __del__(self):
+        self.destroy()
+
+    def destroy(self):
+        if self._update_frame_subscription is not None:
+            self._update_frame_subscription.unsubscribe()
+            self._update_frame_subscription = None
+
+    def start(self):
+        self._last_time = time.time()
+        self._active = True
+
+    def stop(self):
+        self._active = False
+
+        if len(self._samples) > 0:
+            self._mean = statistics.mean(self._samples)
+            self._median = statistics.median(self._samples)
+            self._low = min(self._samples)
+            self._high = max(self._samples)
+            self._samples = array.array("f")
+
+    def get_mean(self):
+        assert not self._active
+        return self._mean
+
+    def get_median(self):
+        assert not self._active
+        return self._median
+
+    def get_low(self):
+        assert not self._active
+        return self._low
+
+    def get_high(self):
+        assert not self._active
+        return self._high
+
+    def get_fps(self):
+        assert self._active
+        return self._fps
+
+    def _on_update_frame(self, _e: carb.events.IEvent):
+        if not self._active:
+            return
+
+        current_time = time.time()
+        elapsed = current_time - self._last_time
+        if elapsed > FREQUENCY_IN_SECONDS:
+            fps = self._viewport.fps
+            self._samples.append(fps)
+            self._last_time = current_time
+            self._fps = fps

--- a/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/performance_window.py
@@ -3,7 +3,6 @@ import carb.events
 import omni.kit.app as app
 import omni.ui as ui
 from cesium.omniverse.bindings import ICesiumOmniverseInterface
-from cesium.omniverse.ui.models.space_delimited_number_model import SpaceDelimitedNumberModel
 
 RANDOM_COLORS_TEXT = "Random colors"
 FORBID_HOLES_TEXT = "Forbid holes"
@@ -21,6 +20,11 @@ GRAND_CANYON_GOOGLE_TEXT = "Grand Canyon (Google)"
 TOUR_GOOGLE_TEXT = "Tour (Google)"
 
 DURATION_TEXT = "Duration (seconds)"
+FPS_TEXT = "FPS"
+FPS_MEAN_TEXT = "FPS (mean)"
+FPS_MEDIAN_TEXT = "FPS (median)"
+FPS_LOW_TEXT = "FPS (low)"
+FPS_HIGH_TEXT = "FPS (high)"
 
 
 class CesiumPerformanceWindow(ui.Window):
@@ -37,7 +41,12 @@ class CesiumPerformanceWindow(ui.Window):
         self._forbid_holes_checkbox_model = ui.SimpleBoolModel(False)
         self._frustum_culling_checkbox_model = ui.SimpleBoolModel(True)
 
-        self._duration_model: SpaceDelimitedNumberModel = SpaceDelimitedNumberModel(0)
+        self._duration_model = ui.SimpleFloatModel(0.0)
+        self._fps_model = ui.SimpleFloatModel(0.0)
+        self._fps_mean_model = ui.SimpleFloatModel(0.0)
+        self._fps_median_model = ui.SimpleFloatModel(0.0)
+        self._fps_low_model = ui.SimpleFloatModel(0.0)
+        self._fps_high_model = ui.SimpleFloatModel(0.0)
 
         self.frame.set_build_fn(self._build_fn)
 
@@ -90,6 +99,11 @@ class CesiumPerformanceWindow(ui.Window):
 
                 for label, model in [
                     (DURATION_TEXT, self._duration_model),
+                    (FPS_TEXT, self._fps_model),
+                    (FPS_MEAN_TEXT, self._fps_mean_model),
+                    (FPS_MEDIAN_TEXT, self._fps_median_model),
+                    (FPS_LOW_TEXT, self._fps_low_model),
+                    (FPS_HIGH_TEXT, self._fps_high_model),
                 ]:
                     with ui.HStack(height=0):
                         ui.Label(label, height=0)
@@ -152,5 +166,20 @@ class CesiumPerformanceWindow(ui.Window):
     def get_frustum_culling(self) -> bool:
         return self._frustum_culling_checkbox_model.get_value_as_bool()
 
-    def set_duration(self, duration: float):
-        self._duration_model.set_value(duration)
+    def set_duration(self, value: float):
+        self._duration_model.set_value(value)
+
+    def set_fps(self, value: float):
+        self._fps_model.set_value(value)
+
+    def set_fps_mean(self, value: float):
+        self._fps_mean_model.set_value(value)
+
+    def set_fps_median(self, value: float):
+        self._fps_median_model.set_value(value)
+
+    def set_fps_low(self, value: float):
+        self._fps_low_model.set_value(value)
+
+    def set_fps_high(self, value: float):
+        self._fps_high_model.set_value(value)


### PR DESCRIPTION
Adds some FPS stats to the performance testing window

```
FPS
FPS (mean)
FPS (median)
FPS (low)
FPS (high)
```

The FPS is sampled every 0.025 seconds. After the tileset is loaded it shows the mean, median, low, and high. This should help us determine the best default option for `mainThreadLoadingTimeLimit` (https://github.com/CesiumGS/cesium-omniverse/pull/380)

![Untitled](https://github.com/CesiumGS/cesium-omniverse/assets/915398/fa956c9c-a444-4982-a870-1def98146331)
