### PR TITLE
Material and imagery refactor for Kit 105

### DIFF
--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -33,8 +33,6 @@ class FabricGeometry {
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
         bool hasImagery,
-        const glm::dvec2& imageryTexcoordTranslation,
-        const glm::dvec2& imageryTexcoordScale,
         uint64_t imageryTexcoordSetIndex);
 
     void setActive(bool active);

--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -32,8 +32,7 @@ class FabricGeometry {
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
-        bool hasImagery,
-        uint64_t imageryTexcoordSetIndex);
+        bool hasImagery);
 
     void setActive(bool active);
     void setVisibility(bool visible);

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -16,7 +16,6 @@ class FabricGeometryDefinition {
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
         bool hasImagery,
-        uint64_t imageryTexcoordSetIndex,
         bool disableMaterials);
 
     [[nodiscard]] bool hasMaterial() const;

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -27,7 +27,9 @@ class FabricMaterial {
         int64_t tileId,
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
-        const CesiumGltf::ImageCesium* imagery);
+        const CesiumGltf::ImageCesium* imagery,
+        const glm::dvec2& imageryTexcoordTranslation,
+        const glm::dvec2& imageryTexcoordScale);
 
     void setActive(bool active);
 

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -26,10 +26,13 @@ class FabricMaterial {
         int64_t tilesetId,
         int64_t tileId,
         const CesiumGltf::Model& model,
-        const CesiumGltf::MeshPrimitive& primitive,
+        const CesiumGltf::MeshPrimitive& primitive);
+
+    void setImagery(
         const CesiumGltf::ImageCesium* imagery,
         const glm::dvec2& imageryTexcoordTranslation,
-        const glm::dvec2& imageryTexcoordScale);
+        const glm::dvec2& imageryTexcoordScale,
+        uint64_t imageryTexcoordSetIndex);
 
     void setActive(bool active);
 

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -22,32 +22,11 @@ class FabricMaterialDefinition {
     [[nodiscard]] bool hasBaseColorTexture() const;
     [[nodiscard]] bool hasVertexColors() const;
 
-    [[nodiscard]] float getAlphaCutoff() const;
-    [[nodiscard]] int getAlphaMode() const;
-    [[nodiscard]] float getBaseAlpha() const;
-    [[nodiscard]] pxr::GfVec3f getBaseColorFactor() const;
-    [[nodiscard]] pxr::GfVec3f getEmissiveFactor() const;
-    [[nodiscard]] float getMetallicFactor() const;
-    [[nodiscard]] float getRoughnessFactor() const;
-    [[nodiscard]] int getWrapS() const;
-    [[nodiscard]] int getWrapT() const;
-
     bool operator==(const FabricMaterialDefinition& other) const;
 
   private:
     bool _hasBaseColorTexture;
     bool _hasVertexColors;
-
-    // Remove these once dynamic material values are supported in Kit 105
-    float _alphaCutoff;
-    int _alphaMode;
-    float _baseAlpha;
-    pxr::GfVec3f _baseColorFactor;
-    pxr::GfVec3f _emissiveFactor;
-    float _metallicFactor;
-    float _roughnessFactor;
-    int _wrapS;
-    int _wrapT;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMesh.h
+++ b/src/core/include/cesium/omniverse/FabricMesh.h
@@ -30,6 +30,9 @@ class FabricMesh {
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
+        bool hasImagery);
+
+    void setImagery(
         const CesiumGltf::ImageCesium* imagery,
         const glm::dvec2& imageryTexcoordTranslation,
         const glm::dvec2& imageryTexcoordScale,

--- a/src/core/include/cesium/omniverse/FabricMeshManager.h
+++ b/src/core/include/cesium/omniverse/FabricMeshManager.h
@@ -33,8 +33,7 @@ class FabricMeshManager {
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
-        const CesiumGltf::ImageCesium* imagery,
-        uint64_t imageryTexcoordSetIndex);
+        bool hasImagery);
 
     void releaseMesh(const std::shared_ptr<FabricMesh>& mesh);
 
@@ -57,13 +56,10 @@ class FabricMeshManager {
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
-        const CesiumGltf::ImageCesium* imagery,
-        uint64_t imageryTexcoordSetIndex);
+        bool hasImagery);
 
-    std::shared_ptr<FabricMaterial> acquireMaterial(
-        const CesiumGltf::Model& model,
-        const CesiumGltf::MeshPrimitive& primitive,
-        const CesiumGltf::ImageCesium* imagery);
+    std::shared_ptr<FabricMaterial>
+    acquireMaterial(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, bool hasImagery);
 
     void releaseGeometry(const std::shared_ptr<FabricGeometry>& geometry);
     void releaseMaterial(const std::shared_ptr<FabricMaterial>& material);

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -70,20 +70,13 @@ class NormalsAccessor {
 class TexcoordsAccessor {
   public:
     TexcoordsAccessor();
-    TexcoordsAccessor(
-        const CesiumGltf::AccessorView<glm::fvec2>& view,
-        const glm::fvec2& translation,
-        const glm::fvec2& scale,
-        bool flipVertical);
+    TexcoordsAccessor(const CesiumGltf::AccessorView<glm::fvec2>& view, bool flipVertical);
 
     void fill(const gsl::span<pxr::GfVec2f>& values) const;
     uint64_t size() const;
 
   private:
     CesiumGltf::AccessorView<glm::fvec2> _view;
-    glm::fvec2 _translation;
-    glm::fvec2 _scale;
-    bool _applyTransform;
     bool _flipVertical;
     uint64_t _size;
 };

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -31,12 +31,8 @@ NormalsAccessor getNormals(
     const IndicesAccessor& indices,
     bool smoothNormals);
 
-TexcoordsAccessor getTexcoords(
-    const CesiumGltf::Model& model,
-    const CesiumGltf::MeshPrimitive& primitive,
-    uint64_t setIndex,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale);
+TexcoordsAccessor
+getTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
 
 VertexColorsAccessor
 getVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
@@ -67,12 +63,8 @@ std::optional<uint64_t> getBaseColorTextureIndex(const CesiumGltf::Model& model,
 
 bool getDoubleSided(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-TexcoordsAccessor getImageryTexcoords(
-    const CesiumGltf::Model& model,
-    const CesiumGltf::MeshPrimitive& primitive,
-    uint64_t setIndex,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale);
+TexcoordsAccessor
+getImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
 
 const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, const CesiumGltf::Texture& texture);
 

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -65,6 +65,7 @@ bool hasStage();
 glm::dvec3 usdToGlmVector(const pxr::GfVec3d& vector);
 glm::dmat4 usdToGlmMatrix(const pxr::GfMatrix4d& matrix);
 pxr::GfVec3d glmToUsdVector(const glm::dvec3& vector);
+pxr::GfVec2f glmToUsdVector(const glm::fvec2& vector);
 pxr::GfMatrix4d glmToUsdMatrix(const glm::dmat4& matrix);
 Decomposed glmToUsdMatrixDecomposed(const glm::dmat4& matrix);
 glm::dmat4 computeUsdWorldTransform(const pxr::SdfPath& path);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -248,8 +248,6 @@ void FabricGeometry::setTile(
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
     bool hasImagery,
-    const glm::dvec2& imageryTexcoordTranslation,
-    const glm::dvec2& imageryTexcoordScale,
     uint64_t imageryTexcoordSetIndex) {
 
     const auto hasTexcoords = _geometryDefinition.hasTexcoords();
@@ -262,13 +260,8 @@ void FabricGeometry::setTile(
     const auto indices = GltfUtil::getIndices(model, primitive, positions);
     const auto normals = GltfUtil::getNormals(model, primitive, positions, indices, smoothNormals);
     const auto vertexColors = GltfUtil::getVertexColors(model, primitive, 0);
-    const auto texcoords_0 = GltfUtil::getTexcoords(model, primitive, 0, glm::fvec2(0.0, 0.0), glm::fvec2(1.0, 1.0));
-    const auto imageryTexcoords = GltfUtil::getImageryTexcoords(
-        model,
-        primitive,
-        imageryTexcoordSetIndex,
-        glm::fvec2(imageryTexcoordTranslation),
-        glm::fvec2(imageryTexcoordScale));
+    const auto texcoords_0 = GltfUtil::getTexcoords(model, primitive, 0);
+    const auto imageryTexcoords = GltfUtil::getImageryTexcoords(model, primitive, imageryTexcoordSetIndex);
     const auto extent = GltfUtil::getExtent(model, primitive);
     const auto faceVertexCounts = GltfUtil::getFaceVertexCounts(indices);
 

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -247,8 +247,7 @@ void FabricGeometry::setTile(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
-    bool hasImagery,
-    uint64_t imageryTexcoordSetIndex) {
+    bool hasImagery) {
 
     const auto hasTexcoords = _geometryDefinition.hasTexcoords();
     const auto hasNormals = _geometryDefinition.hasNormals();
@@ -261,7 +260,7 @@ void FabricGeometry::setTile(
     const auto normals = GltfUtil::getNormals(model, primitive, positions, indices, smoothNormals);
     const auto vertexColors = GltfUtil::getVertexColors(model, primitive, 0);
     const auto texcoords_0 = GltfUtil::getTexcoords(model, primitive, 0);
-    const auto imageryTexcoords = GltfUtil::getImageryTexcoords(model, primitive, imageryTexcoordSetIndex);
+    const auto imageryTexcoords = GltfUtil::getImageryTexcoords(model, primitive, 0);
     const auto extent = GltfUtil::getExtent(model, primitive);
     const auto faceVertexCounts = GltfUtil::getFaceVertexCounts(indices);
 

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -16,12 +16,11 @@ FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
     bool hasImagery,
-    uint64_t imageryTexcoordSetIndex,
     bool disableMaterials) {
 
     const auto hasMaterial = GltfUtil::hasMaterial(primitive);
     const auto hasPrimitiveSt = GltfUtil::hasTexcoords(model, primitive, 0);
-    const auto hasImagerySt = GltfUtil::hasImageryTexcoords(model, primitive, imageryTexcoordSetIndex);
+    const auto hasImagerySt = GltfUtil::hasImageryTexcoords(model, primitive, 0);
 
     _hasMaterial = (hasMaterial || hasImagery) && !disableMaterials;
     _hasTexcoords = hasPrimitiveSt || hasImagerySt;

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -427,12 +427,17 @@ void FabricMaterial::setImagery(
     auto rotationFabric = srw.getAttributeWr<float>(_baseColorTexPathFabric, FabricTokens::inputs_rotation);
     auto scaleFabric = srw.getAttributeWr<pxr::GfVec2f>(_baseColorTexPathFabric, FabricTokens::inputs_scale);
 
+    // gltf/pbr.mdl does texture transform math in glTF coordinates (top-left origin), so we needed to convert
+    // the imagery texcoord translate/scale to work in that space
+    glm::dvec2 offset(imageryTexcoordTranslation.x, 1.0 - imageryTexcoordTranslation.y - imageryTexcoordScale.y);
+    glm::dvec2 scale(imageryTexcoordScale.x, imageryTexcoordScale.y);
+
     *texCoordIndexFabric = static_cast<int>(imageryTexcoordSetIndex);
     *wrapSFabric = CesiumGltf::Sampler::WrapS::CLAMP_TO_EDGE;
     *wrapTFabric = CesiumGltf::Sampler::WrapS::CLAMP_TO_EDGE;
-    *offsetFabric = UsdUtil::glmToUsdVector(glm::fvec2(imageryTexcoordTranslation));
+    *offsetFabric = UsdUtil::glmToUsdVector(glm::fvec2(offset));
     *rotationFabric = DEFAULT_ROTATION;
-    *scaleFabric = UsdUtil::glmToUsdVector(glm::fvec2(imageryTexcoordScale));
+    *scaleFabric = UsdUtil::glmToUsdVector(glm::fvec2(scale));
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -26,9 +26,6 @@ FabricMaterial::FabricMaterial(pxr::SdfPath path, const FabricMaterialDefinition
     : _materialDefinition(materialDefinition) {
 
     initialize(std::move(path), materialDefinition);
-
-    // Remove this function once dynamic material values are supported in Kit 105
-    setInitialValues(materialDefinition);
 }
 
 FabricMaterial::~FabricMaterial() {
@@ -288,38 +285,6 @@ void FabricMaterial::reset() {
 
     if (hasBaseColorTexture) {
         FabricUtil::setTilesetIdAndTileId(_baseColorTexPathFabric, -1, -1);
-    }
-}
-
-void FabricMaterial::setInitialValues(const FabricMaterialDefinition& materialDefinition) {
-    const auto hasBaseColorTexture = _materialDefinition.hasBaseColorTexture();
-
-    auto srw = UsdUtil::getFabricStageReaderWriter();
-
-    // clang-format off
-    auto alphaCutoffFabric = srw.getAttributeWr<float>(_shaderPathFabric, FabricTokens::inputs_alpha_cutoff);
-    auto alphaModeFabric = srw.getAttributeWr<int>(_shaderPathFabric, FabricTokens::inputs_alpha_mode);
-    auto baseAlphaFabric = srw.getAttributeWr<float>(_shaderPathFabric, FabricTokens::inputs_base_alpha);
-    auto baseColorFactorFabric = srw.getAttributeWr<pxr::GfVec3f>(_shaderPathFabric, FabricTokens::inputs_base_color_factor);
-    auto emissiveFactorFabric = srw.getAttributeWr<pxr::GfVec3f>(_shaderPathFabric, FabricTokens::inputs_emissive_factor);
-    auto metallicFactorFabric = srw.getAttributeWr<float>(_shaderPathFabric, FabricTokens::inputs_metallic_factor);
-    auto roughnessFactorFabric = srw.getAttributeWr<float>(_shaderPathFabric, FabricTokens::inputs_roughness_factor);
-    // clang-format on
-
-    *alphaCutoffFabric = materialDefinition.getAlphaCutoff();
-    *alphaModeFabric = materialDefinition.getAlphaMode();
-    *baseAlphaFabric = materialDefinition.getBaseAlpha();
-    *baseColorFactorFabric = materialDefinition.getBaseColorFactor();
-    *emissiveFactorFabric = materialDefinition.getEmissiveFactor();
-    *metallicFactorFabric = materialDefinition.getMetallicFactor();
-    *roughnessFactorFabric = materialDefinition.getRoughnessFactor();
-
-    if (hasBaseColorTexture) {
-        auto wrapSFabric = srw.getAttributeWr<int>(_baseColorTexPathFabric, FabricTokens::inputs_wrap_s);
-        auto wrapTFabric = srw.getAttributeWr<int>(_baseColorTexPathFabric, FabricTokens::inputs_wrap_t);
-
-        *wrapSFabric = materialDefinition.getWrapS();
-        *wrapTFabric = materialDefinition.getWrapT();
     }
 }
 

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -408,7 +408,6 @@ void FabricMaterial::setImagery(
     const glm::dvec2& imageryTexcoordTranslation,
     const glm::dvec2& imageryTexcoordScale,
     uint64_t imageryTexcoordSetIndex) {
-    auto srw = UsdUtil::getFabricStageReaderWriter();
 
     if (!_materialDefinition.hasBaseColorTexture()) {
         return;
@@ -419,6 +418,8 @@ void FabricMaterial::setImagery(
         carb::Uint2{static_cast<uint32_t>(imagery->width), static_cast<uint32_t>(imagery->height)},
         omni::ui::kAutoCalculateStride,
         carb::Format::eRGBA8_SRGB);
+
+    auto srw = UsdUtil::getFabricStageReaderWriter();
 
     auto texCoordIndexFabric = srw.getAttributeWr<int>(_baseColorTexPathFabric, FabricTokens::inputs_tex_coord_index);
     auto wrapSFabric = srw.getAttributeWr<int>(_baseColorTexPathFabric, FabricTokens::inputs_wrap_s);

--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -21,33 +21,13 @@ FabricMaterialDefinition::FabricMaterialDefinition(
 
     if (hasGltfMaterial) {
         const auto& material = model.materials[static_cast<size_t>(primitive.material)];
-        _alphaCutoff = GltfUtil::getAlphaCutoff(material);
-        _alphaMode = GltfUtil::getAlphaMode(material);
-        _baseAlpha = GltfUtil::getBaseAlpha(material);
-        _baseColorFactor = GltfUtil::getBaseColorFactor(material);
-        _emissiveFactor = GltfUtil::getEmissiveFactor(material);
-        _metallicFactor = GltfUtil::getMetallicFactor(material);
-        _roughnessFactor = GltfUtil::getRoughnessFactor(material);
         _hasBaseColorTexture = GltfUtil::getBaseColorTextureIndex(model, material).has_value();
-        _wrapS = GltfUtil::getBaseColorTextureWrapS(model, material);
-        _wrapT = GltfUtil::getBaseColorTextureWrapT(model, material);
     } else {
-        _alphaCutoff = GltfUtil::getDefaultAlphaCutoff();
-        _alphaMode = GltfUtil::getDefaultAlphaMode();
-        _baseAlpha = GltfUtil::getDefaultBaseAlpha();
-        _baseColorFactor = GltfUtil::getDefaultBaseColorFactor();
-        _emissiveFactor = GltfUtil::getDefaultEmissiveFactor();
-        _metallicFactor = 0.0f; // Override the glTF default of 1.0
-        _roughnessFactor = GltfUtil::getDefaultRoughnessFactor();
         _hasBaseColorTexture = false;
-        _wrapS = GltfUtil::getDefaultWrapS();
-        _wrapT = GltfUtil::getDefaultWrapT();
     }
 
     if (hasImagery) {
         _hasBaseColorTexture = true;
-        _wrapS = CesiumGltf::Sampler::WrapS::CLAMP_TO_EDGE;
-        _wrapT = CesiumGltf::Sampler::WrapS::CLAMP_TO_EDGE;
     }
 
     if (disableTextures) {
@@ -65,42 +45,6 @@ bool FabricMaterialDefinition::hasVertexColors() const {
     return _hasVertexColors;
 }
 
-float FabricMaterialDefinition::getAlphaCutoff() const {
-    return _alphaCutoff;
-}
-
-int FabricMaterialDefinition::getAlphaMode() const {
-    return _alphaMode;
-}
-
-float FabricMaterialDefinition::getBaseAlpha() const {
-    return _baseAlpha;
-}
-
-pxr::GfVec3f FabricMaterialDefinition::getBaseColorFactor() const {
-    return _baseColorFactor;
-}
-
-pxr::GfVec3f FabricMaterialDefinition::getEmissiveFactor() const {
-    return _emissiveFactor;
-}
-
-float FabricMaterialDefinition::getMetallicFactor() const {
-    return _metallicFactor;
-}
-
-float FabricMaterialDefinition::getRoughnessFactor() const {
-    return _roughnessFactor;
-}
-
-int FabricMaterialDefinition::getWrapS() const {
-    return _wrapS;
-}
-
-int FabricMaterialDefinition::getWrapT() const {
-    return _wrapT;
-}
-
 // In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other) const {
     if (_hasBaseColorTexture != other._hasBaseColorTexture) {
@@ -108,42 +52,6 @@ bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other)
     }
 
     if (_hasVertexColors != other._hasVertexColors) {
-        return false;
-    }
-
-    if (_alphaCutoff != other._alphaCutoff) {
-        return false;
-    }
-
-    if (_alphaMode != other._alphaMode) {
-        return false;
-    }
-
-    if (_baseAlpha != other._baseAlpha) {
-        return false;
-    }
-
-    if (_baseColorFactor != other._baseColorFactor) {
-        return false;
-    }
-
-    if (_emissiveFactor != other._emissiveFactor) {
-        return false;
-    }
-
-    if (_metallicFactor != other._metallicFactor) {
-        return false;
-    }
-
-    if (_roughnessFactor != other._roughnessFactor) {
-        return false;
-    }
-
-    if (_wrapS != other._wrapS) {
-        return false;
-    }
-
-    if (_wrapT != other._wrapT) {
         return false;
     }
 

--- a/src/core/src/FabricMesh.cpp
+++ b/src/core/src/FabricMesh.cpp
@@ -27,17 +27,12 @@ void FabricMesh::setTile(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
-    const CesiumGltf::ImageCesium* imagery,
-    const glm::dvec2& imageryTexcoordTranslation,
-    const glm::dvec2& imageryTexcoordScale,
-    uint64_t imageryTexcoordSetIndex) {
+    bool hasImagery) {
 
     const auto geometry = getGeometry();
     const auto material = getMaterial();
 
     assert(geometry != nullptr);
-
-    const auto hasImagery = imagery != nullptr;
 
     geometry->setTile(
         tilesetId,
@@ -48,13 +43,23 @@ void FabricMesh::setTile(
         model,
         primitive,
         smoothNormals,
-        hasImagery,
-        imageryTexcoordSetIndex);
+        hasImagery);
 
     if (material != nullptr) {
-        material->setTile(
-            tilesetId, tileId, model, primitive, imagery, imageryTexcoordTranslation, imageryTexcoordScale);
+        material->setTile(tilesetId, tileId, model, primitive);
         geometry->assignMaterial(material);
+    }
+}
+
+void FabricMesh::setImagery(
+    const CesiumGltf::ImageCesium* imagery,
+    const glm::dvec2& imageryTexcoordTranslation,
+    const glm::dvec2& imageryTexcoordScale,
+    uint64_t imageryTexcoordSetIndex) {
+    const auto material = getMaterial();
+
+    if (material != nullptr) {
+        material->setImagery(imagery, imageryTexcoordTranslation, imageryTexcoordScale, imageryTexcoordSetIndex);
     }
 }
 

--- a/src/core/src/FabricMesh.cpp
+++ b/src/core/src/FabricMesh.cpp
@@ -56,6 +56,7 @@ void FabricMesh::setImagery(
     const glm::dvec2& imageryTexcoordTranslation,
     const glm::dvec2& imageryTexcoordScale,
     uint64_t imageryTexcoordSetIndex) {
+
     const auto material = getMaterial();
 
     if (material != nullptr) {

--- a/src/core/src/FabricMesh.cpp
+++ b/src/core/src/FabricMesh.cpp
@@ -49,12 +49,11 @@ void FabricMesh::setTile(
         primitive,
         smoothNormals,
         hasImagery,
-        imageryTexcoordTranslation,
-        imageryTexcoordScale,
         imageryTexcoordSetIndex);
 
     if (material != nullptr) {
-        material->setTile(tilesetId, tileId, model, primitive, imagery);
+        material->setTile(
+            tilesetId, tileId, model, primitive, imagery, imageryTexcoordTranslation, imageryTexcoordScale);
         geometry->assignMaterial(material);
     }
 }

--- a/src/core/src/FabricMeshManager.cpp
+++ b/src/core/src/FabricMeshManager.cpp
@@ -16,16 +16,15 @@ std::shared_ptr<FabricMesh> FabricMeshManager::acquireMesh(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
-    const CesiumGltf::ImageCesium* imagery,
-    uint64_t imageryTexcoordSetIndex) {
+    bool hasImagery) {
 
-    const auto geometry = acquireGeometry(model, primitive, smoothNormals, imagery, imageryTexcoordSetIndex);
+    const auto geometry = acquireGeometry(model, primitive, smoothNormals, hasImagery);
 
     const auto hasMaterial = geometry->getGeometryDefinition().hasMaterial();
     auto material = std::shared_ptr<FabricMaterial>(nullptr);
 
     if (hasMaterial) {
-        material = acquireMaterial(model, primitive, imagery);
+        material = acquireMaterial(model, primitive, hasImagery);
     }
 
     return std::make_shared<FabricMesh>(geometry, material);
@@ -85,12 +84,9 @@ std::shared_ptr<FabricGeometry> FabricMeshManager::acquireGeometry(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals,
-    const CesiumGltf::ImageCesium* imagery,
-    uint64_t imageryTexcoordSetIndex) {
+    bool hasImagery) {
 
-    const auto hasImagery = imagery != nullptr;
-    FabricGeometryDefinition geometryDefinition(
-        model, primitive, smoothNormals, hasImagery, imageryTexcoordSetIndex, _disableMaterials);
+    FabricGeometryDefinition geometryDefinition(model, primitive, smoothNormals, hasImagery, _disableMaterials);
 
     if (_disableGeometryPool) {
         const auto path = pxr::SdfPath(fmt::format("/fabric_geometry_{}", getNextGeometryId()));
@@ -107,9 +103,8 @@ std::shared_ptr<FabricGeometry> FabricMeshManager::acquireGeometry(
 std::shared_ptr<FabricMaterial> FabricMeshManager::acquireMaterial(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const CesiumGltf::ImageCesium* imagery) {
+    bool hasImagery) {
 
-    const auto hasImagery = imagery != nullptr;
     FabricMaterialDefinition materialDefinition(model, primitive, hasImagery, _disableTextures);
 
     if (_disableMaterialPool) {

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -184,9 +184,7 @@ uint64_t NormalsAccessor::size() const {
 TexcoordsAccessor::TexcoordsAccessor()
     : _size(0) {}
 
-TexcoordsAccessor::TexcoordsAccessor(
-    const CesiumGltf::AccessorView<glm::fvec2>& view,
-    bool flipVertical)
+TexcoordsAccessor::TexcoordsAccessor(const CesiumGltf::AccessorView<glm::fvec2>& view, bool flipVertical)
     : _view(view)
     , _flipVertical(flipVertical)
     , _size(view.size()) {}

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -186,13 +186,8 @@ TexcoordsAccessor::TexcoordsAccessor()
 
 TexcoordsAccessor::TexcoordsAccessor(
     const CesiumGltf::AccessorView<glm::fvec2>& view,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale,
     bool flipVertical)
     : _view(view)
-    , _translation(translation)
-    , _scale(scale)
-    , _applyTransform(translation != glm::fvec2(0.0, 0.0) && scale != glm::fvec2(1.0, 1.0))
     , _flipVertical(flipVertical)
     , _size(view.size()) {}
 
@@ -204,13 +199,6 @@ void TexcoordsAccessor::fill(const gsl::span<pxr::GfVec2f>& values) const {
     if (_flipVertical) {
         for (uint64_t i = 0; i < _size; i++) {
             values[i][1] = 1.0f - values[i][1];
-        }
-    }
-
-    if (_applyTransform) {
-        for (uint64_t i = 0; i < _size; i++) {
-            values[i][0] = values[i][0] * _scale.x + _translation.x;
-            values[i][1] = values[i][1] * _scale.y + _translation.y;
         }
     }
 }

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -127,8 +127,6 @@ TexcoordsAccessor getTexcoords(
     const CesiumGltf::MeshPrimitive& primitive,
     const std::string& semantic,
     uint64_t setIndex,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale,
     bool flipVertical) {
 
     const auto texcoordsView = getTexcoordsView(model, primitive, semantic, setIndex);
@@ -137,7 +135,7 @@ TexcoordsAccessor getTexcoords(
         return {};
     }
 
-    return {texcoordsView, translation, scale, flipVertical};
+    return {texcoordsView, flipVertical};
 }
 
 template <typename VertexColorType>
@@ -253,13 +251,9 @@ NormalsAccessor getNormals(
     return {};
 }
 
-TexcoordsAccessor getTexcoords(
-    const CesiumGltf::Model& model,
-    const CesiumGltf::MeshPrimitive& primitive,
-    uint64_t setIndex,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale) {
-    return getTexcoords(model, primitive, "TEXCOORD", setIndex, translation, scale, true);
+TexcoordsAccessor
+getTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex) {
+    return getTexcoords(model, primitive, "TEXCOORD", setIndex, true);
 }
 
 VertexColorsAccessor
@@ -455,13 +449,9 @@ bool getDoubleSided(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimit
     return material.doubleSided;
 }
 
-TexcoordsAccessor getImageryTexcoords(
-    const CesiumGltf::Model& model,
-    const CesiumGltf::MeshPrimitive& primitive,
-    uint64_t setIndex,
-    const glm::fvec2& translation,
-    const glm::fvec2& scale) {
-    return getTexcoords(model, primitive, "_CESIUMOVERLAY", setIndex, translation, scale, false);
+TexcoordsAccessor
+getImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex) {
+    return getTexcoords(model, primitive, "_CESIUMOVERLAY", setIndex, false);
 }
 
 const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, const CesiumGltf::Texture& texture) {

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -97,6 +97,10 @@ pxr::GfVec3d glmToUsdVector(const glm::dvec3& vector) {
     return {vector.x, vector.y, vector.z};
 }
 
+pxr::GfVec2f glmToUsdVector(const glm::fvec2& vector) {
+    return {vector.x, vector.y};
+}
+
 pxr::GfMatrix4d glmToUsdMatrix(const glm::dmat4& matrix) {
     // Column-major to row-major
     return pxr::GfMatrix4d{


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/242

This PR removes a bunch of workarounds that we had in place for Kit 104.2 since it didn't support dynamic material values.

* No longer need to bake material properties like `baseColorFactor`, `emissiveFactor`, etc in the material definition.
* No longer need to bake texcoord translate / scale into the texcoord attribute
* No longer need to destroy prims when higher res imagery is attached to a tile

Only one imagery layer is supported per tileset still. Multiple raster overlays is a bigger lift since it means parsing multiple texcoord sets from the glTF (e.g. geographic vs. web mercator texcoords), storing multiple textures in `FabricMaterial` (possibly requiring a texture pool), and forking gltf/pbr.mdl to read from additional textures.