### PR TITLE
Add "Save Carb Settings" action to CesiumPowerTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ _testoutput
 
 # Tracing files
 cesium-trace-*.json
+
+# Carb settings from Cesium Power Tools extensions
+carb_settings.txt

--- a/exts/cesium.powertools/cesium/powertools/powertools_window.py
+++ b/exts/cesium.powertools/cesium/powertools/powertools_window.py
@@ -3,7 +3,11 @@ import omni.ui as ui
 from typing import Callable, Optional, List
 from cesium.omniverse.ui import CesiumOmniverseDebugWindow
 from .georefhelper.georef_helper_window import CesiumGeorefHelperWindow
-from .utils import extend_far_plane
+from .utils import extend_far_plane, save_carb_settings
+import os
+from functools import partial
+
+powertools_extension_location = os.path.join(os.path.dirname(__file__), "../../")
 
 
 class PowertoolsAction:
@@ -39,6 +43,7 @@ class CesiumPowertoolsWindow(ui.Window):
             PowertoolsAction("Open Cesium Debugging Window", CesiumOmniverseDebugWindow.show_window),
             PowertoolsAction("Open Cesium Georeference Helper Window", CesiumGeorefHelperWindow.create_window),
             PowertoolsAction("Extend Far Plane", extend_far_plane),
+            PowertoolsAction("Save Carb Settings", partial(save_carb_settings, powertools_extension_location)),
         ]
 
         self.frame.set_build_fn(self._build_fn)

--- a/exts/cesium.powertools/cesium/powertools/utils/utils.py
+++ b/exts/cesium.powertools/cesium/powertools/utils/utils.py
@@ -1,6 +1,9 @@
 import omni.usd
 from omni.kit.viewport.utility import get_active_viewport
 from pxr import Gf, UsdGeom
+import json
+import carb.settings
+import os
 
 
 # Modified version of ScopedEdit in _build_viewport_cameras in omni.kit.widget.viewport
@@ -38,3 +41,9 @@ def extend_far_plane():
 
     scoped_edit = ScopedEdit(stage)  # noqa: F841
     camera.GetClippingRangeAttr().Set(Gf.Vec2f(1.0, 10000000000.0))
+
+
+def save_carb_settings(powertools_extension_location: str):
+    carb_settings_path = os.path.join(powertools_extension_location, "carb_settings.txt")
+    with open(carb_settings_path, "w") as fh:
+        fh.write(json.dumps(carb.settings.get_settings().get("/"), indent=2))


### PR DESCRIPTION
Adds a "Save Carb Settings" action to the Cesium Power Tools extension. This saves the current carb settings into a file called `carb_settings.json`. The code was copied from https://github.com/CesiumGS/cesium-omniverse/tree/main/docs/kit.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/26360fad-8033-4e72-af76-7c7e0e559a24)
