### PR TITLE
Print connections for "Print Fabric stage" button

### DIFF
--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -139,6 +139,19 @@ std::string printAttributeValue(
     }
 }
 
+std::string printConnection(const omni::fabric::Path& primPath, const omni::fabric::Token& attributeName) {
+    auto stageReaderWriter = UsdUtil::getFabricStageReaderWriter();
+    const auto connection = stageReaderWriter.getConnection(primPath, attributeName);
+    if (connection == nullptr) {
+        return NO_DATA_STRING;
+    }
+
+    const auto path = omni::fabric::Path(connection->path).getText();
+    const auto attrName = omni::fabric::Token(connection->attrName).getText();
+
+    return fmt::format("Path: {}, Attribute Name: {}", path, attrName);
+}
+
 std::string printAttributeValue(const omni::fabric::Path& primPath, const omni::fabric::AttrNameAndType& attribute) {
     auto stageReaderWriter = UsdUtil::getFabricStageReaderWriter();
 
@@ -158,6 +171,17 @@ std::string printAttributeValue(const omni::fabric::Path& primPath, const omni::
                 switch (componentCount) {
                     case 1: {
                         return printAttributeValue<false, AssetWrapper, 1>(primPath, name, role);
+                    }
+                    default: {
+                        break;
+                    }
+                }
+                break;
+            }
+            case omni::fabric::BaseDataType::eConnection: {
+                switch (componentCount) {
+                    case 1: {
+                        return printConnection(primPath, name);
                     }
                     default: {
                         break;


### PR DESCRIPTION
This lets us see `connection` values when we print the fabric stage, e.g.

```
Prim: /World/Looks/cesium_gltf_material/Shader (12583937)
  Attributes:
    Attribute: inputs:base_color_texture
      Type: connection
      Value: Path: /World/Looks/cesium_gltf_material/cesium_base_color_texture, Attribute Name: outputs:out
```

This will come in handy for debugging tileset materials.