### PR TITLE
Fixed ECEF to USD transform calculation

### DIFF
--- a/src/core/include/cesium/omniverse/GeospatialUtil.h
+++ b/src/core/include/cesium/omniverse/GeospatialUtil.h
@@ -1,15 +1,20 @@
 #pragma once
 
 #include <CesiumGeospatial/Cartographic.h>
+#include <CesiumGeospatial/LocalHorizontalCoordinateSystem.h>
 #include <CesiumUsdSchemas/georeference.h>
 #include <glm/glm.hpp>
 
 namespace CesiumGeospatial {
 class Cartographic;
-}
+class LocalHorizontalCoordinateSystem;
+} // namespace CesiumGeospatial
 
 namespace cesium::omniverse::GeospatialUtil {
 
 CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference);
+
+CesiumGeospatial::LocalHorizontalCoordinateSystem
+getCoordinateSystem(const CesiumGeospatial::Cartographic& origin, const double scaleInMeters);
 
 }; // namespace cesium::omniverse::GeospatialUtil

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -78,8 +78,6 @@ pxr::SdfPath getRootPath();
 pxr::SdfPath getPathUnique(const pxr::SdfPath& parentPath, const std::string& name);
 std::string getSafeName(const std::string& name);
 pxr::SdfAssetPath getDynamicTextureProviderAssetPath(const std::string& name);
-glm::dmat4 computeUsdToEcefTransform(const CesiumGeospatial::Cartographic& origin);
-glm::dmat4 computeEcefToUsdTransform(const CesiumGeospatial::Cartographic& origin);
 glm::dmat4 computeEcefToUsdTransformForPrim(const CesiumGeospatial::Cartographic& origin, const pxr::SdfPath& primPath);
 glm::dmat4 computeUsdToEcefTransformForPrim(const CesiumGeospatial::Cartographic& origin, const pxr::SdfPath& primPath);
 Cesium3DTilesSelection::ViewState

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -232,7 +232,9 @@ void Context::onUpdateFrame(const std::vector<Viewport>& viewports) {
     processUsdNotifications();
 
     const auto georeferenceOrigin = Context::instance().getGeoreferenceOrigin();
-    const auto ecefToUsdTransform = UsdUtil::computeEcefToUsdTransform(georeferenceOrigin);
+    const auto ecefToUsdTransform =
+        GeospatialUtil::getCoordinateSystem(georeferenceOrigin, UsdUtil::getUsdMetersPerUnit())
+            .getEcefToLocalTransformation();
 
     // Check if the ecefToUsd transform has changed and update CesiumSession
     if (ecefToUsdTransform != _ecefToUsdTransform) {

--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -13,4 +13,14 @@ CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::Cesi
     return {glm::radians(longitude), glm::radians(latitude), height};
 }
 
+CesiumGeospatial::LocalHorizontalCoordinateSystem
+getCoordinateSystem(const CesiumGeospatial::Cartographic& origin, const double scaleInMeters) {
+    return {
+        origin,
+        CesiumGeospatial::LocalDirection::East,
+        CesiumGeospatial::LocalDirection::Up,
+        CesiumGeospatial::LocalDirection::South,
+        scaleInMeters};
+}
+
 } // namespace cesium::omniverse::GeospatialUtil


### PR DESCRIPTION
We were doing the ECEF to USD maths wrong which was causing us issues when we tried to do the inverse USD to ECEF.

```cpp
const auto primUsdWorldTransform = computeUsdWorldTransform(primPath);
```

This is actually giving us the Local to World transformation, rather than what we needed, the World to Local transformation. Inverting it gives us what we want.

Additionally, I swapped over to using `affineInverse` for the slight speed benefit. Doubt it will matter but we'll see.