### PR TITLE
Temporary workaround(s) to get python tests running

### DIFF
--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -54,8 +54,8 @@ persistent.exts."cesium.omniverse".userAccessToken = ""
 
 [[test]]
 args = [
-    "--/renderer/enabled=pxr",
-    "--/renderer/active=pxr",
+    "--/renderer/enabled=rtx",
+    "--/renderer/active=rtx",
     "--/app/window/dpiScaleOverride=1.0",
     "--/app/window/scaleToMonitor=false",
     "--/app/file/ignoreUnsavedOnExit=true",


### PR DESCRIPTION
Currently nvidia is looking into an issue where the `pxr` renderer and `usdrt` are not working together correctly. Running python tests crashes without this at the moment.
Of note, one particular test (checking if the main Cesium window is docked) will also fail iff powertools is enabled in `cesium.omniverse.dev.kit`. I am not sure why yet, but would welcome any input on that here or in slack.