### PR TITLE
Fix Z up

### DIFF
--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -1,5 +1,7 @@
 #include "cesium/omniverse/GeospatialUtil.h"
 
+#include "cesium/omniverse/UsdUtil.h"
+
 namespace cesium::omniverse::GeospatialUtil {
 
 CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::CesiumGeoreference& georeference) {
@@ -15,6 +17,17 @@ CesiumGeospatial::Cartographic convertGeoreferenceToCartographic(const pxr::Cesi
 
 CesiumGeospatial::LocalHorizontalCoordinateSystem
 getCoordinateSystem(const CesiumGeospatial::Cartographic& origin, const double scaleInMeters) {
+    const auto upAxis = UsdUtil::getUsdUpAxis();
+
+    if (upAxis == pxr::UsdGeomTokens->z) {
+        return {
+            origin,
+            CesiumGeospatial::LocalDirection::East,
+            CesiumGeospatial::LocalDirection::North,
+            CesiumGeospatial::LocalDirection::Up,
+            scaleInMeters};
+    }
+
     return {
         origin,
         CesiumGeospatial::LocalDirection::East,

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -200,7 +200,7 @@ glm::dmat4
 computeEcefToUsdTransformForPrim(const CesiumGeospatial::Cartographic& origin, const pxr::SdfPath& primPath) {
     const auto ecefToUsdTransform =
         GeospatialUtil::getCoordinateSystem(origin, getUsdMetersPerUnit()).getEcefToLocalTransformation();
-    const auto primInverseUsdWorldTransform = glm::affineInverse(computeUsdWorldTransform(primPath));
+    const auto primInverseUsdWorldTransform = computeUsdWorldTransform(primPath);
     const auto primEcefToUsdTransform = primInverseUsdWorldTransform * ecefToUsdTransform;
     return primEcefToUsdTransform;
 }


### PR DESCRIPTION
Resolves #400.

I inadvertently removed the code that handles z+ up when I switched us to use the `LocalHorizontalCoordinateSystem` in Cesium Native.

This also reverts the affine inverse I also added in #397 that broke the gizmo for the tileset. There's a better solution for that problem that I will be implementing soon.