### PR TITLE
visually enable/disable top bar buttons based on sign-in status

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -140,9 +140,8 @@ class CesiumOmniverseMainWindow(ui.Window):
             # Since this goes across the pybind barrier, just grab it once.
             is_connected = session.is_connected()
             self._sign_in_widget.visible = not is_connected
-            self._add_button.enabled = is_connected
-            self._upload_button.enabled = is_connected
-            self._sign_out_button.enabled = is_connected
+
+            self._set_top_bar_button_status(is_connected)
 
     def _on_assets_updated(self, _e: carb.events.IEvent):
         self._logger.info("Received ion Assets updated event.")
@@ -180,24 +179,39 @@ class CesiumOmniverseMainWindow(ui.Window):
             message,
         )
 
+    def _set_top_bar_button_status(self, enabled: bool):
+        self._add_button.enabled = enabled
+        self._upload_button.enabled = enabled
+        self._sign_out_button.enabled = enabled
+
+        if enabled:
+            self._add_button.style = CesiumOmniverseUiStyles.top_bar_button_style
+            self._upload_button.style = CesiumOmniverseUiStyles.top_bar_button_style
+            self._sign_out_button.style = CesiumOmniverseUiStyles.top_bar_button_style
+        else:
+            self._add_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
+            self._upload_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
+            self._sign_out_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
+
     def _build_fn(self):
         """Builds all UI components."""
 
         with ui.VStack(spacing=0):
             button_style = CesiumOmniverseUiStyles.top_bar_button_style
+            disabled_button_style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
 
             with ui.HStack(height=ui.Length(80, ui.UnitType.PIXEL)):
                 self._add_button = ui.Button(
                     "Add",
                     image_url=f"{self._icon_path}/FontAwesome/plus-solid.png",
-                    style=button_style,
+                    style=disabled_button_style,
                     clicked_fn=self._add_button_clicked,
                     enabled=False,
                 )
                 self._upload_button = ui.Button(
                     "Upload",
                     image_url=f"{self._icon_path}/FontAwesome/cloud-upload-alt-solid.png",
-                    style=button_style,
+                    style=disabled_button_style,
                     clicked_fn=self._upload_button_clicked,
                     enabled=False,
                 )
@@ -222,7 +236,8 @@ class CesiumOmniverseMainWindow(ui.Window):
                 self._sign_out_button = ui.Button(
                     "Sign Out",
                     image_url=f"{self._icon_path}/FontAwesome/sign-out-alt-solid.png",
-                    style=button_style,
+                    # style=button_style,
+                    style=disabled_button_style,
                     clicked_fn=self._sign_out_button_clicked,
                     enabled=False,
                 )
@@ -269,6 +284,8 @@ class CesiumOmniverseMainWindow(ui.Window):
         session = self._cesium_omniverse_interface.get_session()
         if session is not None:
             session.disconnect()
+
+        self._set_top_bar_button_status(False)
 
     def _show_token_window(self):
         self._cesium_omniverse_interface.get_session().refresh_tokens()

--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -184,34 +184,24 @@ class CesiumOmniverseMainWindow(ui.Window):
         self._upload_button.enabled = enabled
         self._sign_out_button.enabled = enabled
 
-        if enabled:
-            self._add_button.style = CesiumOmniverseUiStyles.top_bar_button_style
-            self._upload_button.style = CesiumOmniverseUiStyles.top_bar_button_style
-            self._sign_out_button.style = CesiumOmniverseUiStyles.top_bar_button_style
-        else:
-            self._add_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
-            self._upload_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
-            self._sign_out_button.style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
-
     def _build_fn(self):
         """Builds all UI components."""
 
         with ui.VStack(spacing=0):
             button_style = CesiumOmniverseUiStyles.top_bar_button_style
-            disabled_button_style = CesiumOmniverseUiStyles.top_bar_button_disabled_style
 
             with ui.HStack(height=ui.Length(80, ui.UnitType.PIXEL)):
                 self._add_button = ui.Button(
                     "Add",
                     image_url=f"{self._icon_path}/FontAwesome/plus-solid.png",
-                    style=disabled_button_style,
+                    style=button_style,
                     clicked_fn=self._add_button_clicked,
                     enabled=False,
                 )
                 self._upload_button = ui.Button(
                     "Upload",
                     image_url=f"{self._icon_path}/FontAwesome/cloud-upload-alt-solid.png",
-                    style=disabled_button_style,
+                    style=button_style,
                     clicked_fn=self._upload_button_clicked,
                     enabled=False,
                 )
@@ -237,7 +227,7 @@ class CesiumOmniverseMainWindow(ui.Window):
                     "Sign Out",
                     image_url=f"{self._icon_path}/FontAwesome/sign-out-alt-solid.png",
                     # style=button_style,
-                    style=disabled_button_style,
+                    style=button_style,
                     clicked_fn=self._sign_out_button_clicked,
                     enabled=False,
                 )

--- a/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
@@ -44,6 +44,15 @@ class CesiumOmniverseUiStyles:
         "Button.Label": {"alignment": Alignment.CENTER_BOTTOM},
     }
 
+    top_bar_button_disabled_style = {
+        "Button": {"padding": 10.0, "stack_direction": Direction.TOP_TO_BOTTOM},
+        "Button.Image": {
+            "alignment": Alignment.CENTER,
+            "color": cl("#808080"),
+        },
+        "Button.Label": {"alignment": Alignment.CENTER_BOTTOM, "color": cl("#808080")},
+    }
+
     asset_detail_frame = {"ScrollingFrame": {"background_color": cl("#1F2123"), "padding": 10}}
 
     asset_detail_name_label = {"font_size": 22}

--- a/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/styles.py
@@ -42,15 +42,8 @@ class CesiumOmniverseUiStyles:
             "alignment": Alignment.CENTER,
         },
         "Button.Label": {"alignment": Alignment.CENTER_BOTTOM},
-    }
-
-    top_bar_button_disabled_style = {
-        "Button": {"padding": 10.0, "stack_direction": Direction.TOP_TO_BOTTOM},
-        "Button.Image": {
-            "alignment": Alignment.CENTER,
-            "color": cl("#808080"),
-        },
-        "Button.Label": {"alignment": Alignment.CENTER_BOTTOM, "color": cl("#808080")},
+        "Button.Image:disabled": {"color": cl("#808080")},
+        "Button.Label:disabled": {"color": cl("#808080")},
     }
 
     asset_detail_frame = {"ScrollingFrame": {"background_color": cl("#1F2123"), "padding": 10}}


### PR DESCRIPTION
Previously all buttons would appear clickable even if they were deactivated. This greys out the correct buttons in the top bar of the Cesium window when the user is signed out and enables them when the user is signed in.
![Screenshot from 2023-07-26 15-57-47](https://github.com/CesiumGS/cesium-omniverse/assets/62680156/0b12a391-4672-4cc2-8691-abeaf520a36a)
![Screenshot from 2023-07-26 15-58-07](https://github.com/CesiumGS/cesium-omniverse/assets/62680156/1d1227f7-e506-4672-95af-06b25f631c0a)
