### PR TITLE
Powertools for syncing Sun Study with CesiumGeoreference

### DIFF
--- a/exts/cesium.powertools/cesium/powertools/powertools_window.py
+++ b/exts/cesium.powertools/cesium/powertools/powertools_window.py
@@ -3,7 +3,7 @@ import omni.ui as ui
 from typing import Callable, Optional, List
 from cesium.omniverse.ui import CesiumOmniverseDebugWindow
 from .georefhelper.georef_helper_window import CesiumGeorefHelperWindow
-from .utils import extend_far_plane, save_carb_settings
+from .utils import extend_far_plane, save_carb_settings, set_sunstudy_from_georef
 import os
 from functools import partial
 
@@ -44,6 +44,7 @@ class CesiumPowertoolsWindow(ui.Window):
             PowertoolsAction("Open Cesium Georeference Helper Window", CesiumGeorefHelperWindow.create_window),
             PowertoolsAction("Extend Far Plane", extend_far_plane),
             PowertoolsAction("Save Carb Settings", partial(save_carb_settings, powertools_extension_location)),
+            PowertoolsAction("Set Sun Study from Georef", set_sunstudy_from_georef),
         ]
 
         self.frame.set_build_fn(self._build_fn)


### PR DESCRIPTION
Two small additions to powertools here:

1) A simple button in the Powertools menu to set Sun Study latitude/longitude based on the current CesiumGeoreference latitude/longitude.  This also ensures the north angle is set to 90 degrees, which is required to ensure the sun is at the correct yaw compared to the globe.

2) An addition to the Georeference Helper which will extract latitude/longitude from the Environment prim and set the CesiumGeoreference to match.  This is useful as some of the Omniverse connectors such as Rhino + Sketchup store the latitude and longitude values from the export in environment prim.

