### PR TITLE
Remove rtx_plugins dependency

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -71,7 +71,6 @@ set(CARB_ROOT "${NVIDIA_BUILD_DIR}/target-deps/carb_sdk_plugins")
 set(KIT_SDK_ROOT "${NVIDIA_BUILD_DIR}/target-deps/kit-sdk")
 set(PYBIND11_ROOT "${NVIDIA_BUILD_DIR}/target-deps/pybind11")
 set(CUDA_ROOT "${NVIDIA_BUILD_DIR}/target-deps/cuda")
-set(RTX_PLUGINS_ROOT "${NVIDIA_BUILD_DIR}/target-deps/rtx_plugins")
 
 set(NVIDIA_USD_LIBRARIES
     ar
@@ -187,9 +186,9 @@ endif()
 # cmake-format: off
 add_prebuilt_project(
     RELEASE_INCLUDE_DIR
-        "${USDRT_ROOT}/include"
+        "${USDRT_ROOT}/include/usdrt_only"
     DEBUG_INCLUDE_DIR
-        "${USDRT_ROOT}/include"
+        "${USDRT_ROOT}/include/usdrt_only"
     RELEASE_LIBRARY_DIR
         "${USDRT_ROOT}/_build/${NVIDIA_PLATFORM_NAME}/${NVIDIA_RELEASE_FOLDER_NAME}/usdrt_only"
     DEBUG_LIBRARY_DIR
@@ -199,7 +198,7 @@ add_prebuilt_project(
     DEBUG_LIBRARIES
         omni.fabric.plugin
     TARGET_NAMES
-        usdrt
+        fabric
 )
 # cmake-format: on
 
@@ -305,16 +304,6 @@ add_prebuilt_project(
         omni.ui
     TARGET_NAMES
         omni_ui
-)
-# cmake-format: on
-
-# cmake-format: off
-# DynamicTextureProvider.h includes IImaging.h which only exists in the rtx_plugin package
-add_prebuilt_project_header_only(
-    INCLUDE_DIR
-        "${RTX_PLUGINS_ROOT}/include"
-    TARGET_NAME
-        rtx_plugins
 )
 # cmake-format: on
 

--- a/extern/nvidia/deps/target-deps.packman.xml
+++ b/extern/nvidia/deps/target-deps.packman.xml
@@ -7,7 +7,6 @@
     <filter include="carb_sdk_plugins"/>
     <filter include="pybind11"/>
     <filter include="cuda"/>
-    <filter include="rtx_plugins"/>
   </import>
   <import path="../_build/target-deps/kit-sdk-debug/dev/all-deps.packman.xml">
     <filter include="nv_usd_py310_debug"/>
@@ -20,5 +19,4 @@
   <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins"/>
   <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11"/>
   <dependency name="cuda" linkPath="../_build/target-deps/cuda/cuda"/>
-  <dependency name="rtx_plugins" linkPath="../_build/target-deps/rtx_plugins"/>
 </project>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -58,7 +58,7 @@ setup_lib(
         cpr::cpr
         stb::stb
         ZLIB::ZLIB
-        usdrt
+        fabric
         ar
         arch
         gf
@@ -86,7 +86,6 @@ setup_lib(
         cudart
         omni_kit
         omni_ui
-        rtx_plugins
         pybind11
         python310
     ADDITIONAL_LIBRARIES


### PR DESCRIPTION
We no longer depend on the `rtx_plugins` package, so I removed it from our build system. I also renamed the usdrt target to fabric.

There may be more changes needed once Kit 105.1 is out, but this is an incremental step towards that.