### PR TITLE
Make show on startup a configurable setting

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -26,7 +26,6 @@ from .ui.credits_viewport_controller import CreditsViewportController
 
 cesium_extension_location = os.path.join(os.path.dirname(__file__), "../../")
 
-
 class CesiumOmniverseExtension(omni.ext.IExt):
     @staticmethod
     def _set_menu(path, value):
@@ -68,7 +67,7 @@ class CesiumOmniverseExtension(omni.ext.IExt):
         )
         ui.Workspace.set_show_window_fn(CesiumOmniverseDebugWindow.WINDOW_NAME, partial(self.show_debug_window, None))
 
-        show_on_startup = True
+        show_on_startup = omni_settings.get_settings().get_as_bool("/exts/cesium.omniverse/showOnStartup")
 
         self._add_to_menu(CesiumOmniverseMainWindow.MENU_PATH, self.show_main_window, show_on_startup)
         self._add_to_menu(CesiumOmniverseAssetWindow.MENU_PATH, self.show_assets_window, False)

--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -26,6 +26,7 @@ from .ui.credits_viewport_controller import CreditsViewportController
 
 cesium_extension_location = os.path.join(os.path.dirname(__file__), "../../")
 
+
 class CesiumOmniverseExtension(omni.ext.IExt):
     @staticmethod
     def _set_menu(path, value):

--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -51,6 +51,7 @@ path = "bin/cesium.omniverse.plugin"
 [settings]
 exts."cesium.omniverse".defaultAccessToken = ""
 persistent.exts."cesium.omniverse".userAccessToken = ""
+exts."cesium.omniverse".showOnStartup = true
 
 [[test]]
 args = [


### PR DESCRIPTION
Some integrations of Cesium for Omniverse do not require a user interface to appear. Currently the interface appears by default and this cannot be controlled on an per app basis.

The existing showOnStartup parameter has been connected to an Omniverse setting of the same name, which enables this behavior to be configured on a per application basis.  

Simply add the following to your applications kit file to prevent the UI from displaying by default. 

```
[settings.exts."cesium.omniverse"]
showOnStartup = false
```

I have tested this across USD composer and view.  Default behavior should be to show the UI, so users should not experience anything different unless manually configuring this setting. 

