### PR TITLE
Fixed the windows not showing up in the menu

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -55,7 +55,7 @@ class CesiumOmniverseExtension(omni.ext.IExt):
         self._attributes_widget_controller: Optional[CesiumAttributesWidgetController] = None
         self._credits_viewport_controller: Optional[CreditsViewportController] = None
         self._logger: logging.Logger = logging.getLogger(__name__)
-        self._menu = None
+        self._menus = []
         self._num_credits_viewport_frames: int = 0
 
         perform_vendor_install()
@@ -129,7 +129,7 @@ class CesiumOmniverseExtension(omni.ext.IExt):
         )
 
     def on_shutdown(self):
-        self._menu = None
+        self._menus.clear()
 
         if self._main_window is not None:
             self._main_window.destroy()
@@ -324,7 +324,7 @@ class CesiumOmniverseExtension(omni.ext.IExt):
         editor_menu = omni.kit.ui.get_editor_menu()
 
         if editor_menu:
-            self._menu = editor_menu.add_item(path, callback, toggle=True, value=show_on_startup)
+            self._menus.append(editor_menu.add_item(path, callback, toggle=True, value=show_on_startup))
 
     async def _destroy_window_async(self, path):
         # Wait one frame, this is due to the one frame defer in Window::_moveToMainOSWindow()


### PR DESCRIPTION
Resolves #408.

I believe the signature of the `add_item` option in `omni.kit.ui.Menu` has changed slightly to this new signature:

`def add_item(self, menu_path: str, on_click: typing.Callable[[str, bool], None] = None, toggle: bool = False, priority: int = 0, value: bool = False, enabled: bool = True, original_svg_color: bool = False, auto_release: bool = True) -> carb._carb.Subscription: ...`

I don't remember seeing the SVG color or the `auto_release` arguments, and in fact it was the `auto_release` in addition to the fact that we weren't properly keeping track of our menus here that was hurting us. Since we kept overwriting `self._menu` with whatever the last menu item was, the other two options were being released and thus not showing.

I fixed this by turning `self._menu` into an array named `_menus` and storing our menu items in it.