### PR TITLE
Update cesium-native from v0.24.0 to v0.26.0

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -25,6 +25,7 @@ add_external_project(
         uriparser
         webpdecoder
         turbojpeg
+        meshoptimizer
     OPTIONS
         CESIUM_TESTS_ENABLED=OFF
         CESIUM_COVERAGE_ENABLED=OFF

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -55,6 +55,7 @@ setup_lib(
         uriparser
         webpdecoder
         turbojpeg
+        meshoptimizer
         cpr::cpr
         stb::stb
         ZLIB::ZLIB


### PR DESCRIPTION
Lots of good improvements in cesium-native [v0.26.0](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md#v0260---2023-08-01):

> ### v0.26.0 - 2023-08-01
> 
> ##### Additions :tada:
> 
> - Added caching support for Google Maps Photorealistic 3D Tiles. Or other cases where the origin server is using combinations of HTTP header directives that previously caused tiles not to go to disk cache (such as `max-age-0`, `stale-while-revalidate`, and `Expires`).
> - Added support for the `EXT_meshopt_compression` extension, which allows decompressing mesh data using the meshoptimizer library. Also added support for the `KHR_mesh_quantization` and `KHR_texture_transform` extensions, which are often used together with the `EXT_meshopt_compression` extension to optimize the size and performance of glTF files.
> 
> ##### Fixes :wrench:
> 
> - Fixed a bug in the 3D Tiles selection algorithm that could cause missing detail if a tileset had a leaf tile that was considered "unconditionally refined" due to having a geometric error larger than its parent's.
> - Fixed a bug where `GltfReader::readImage` would always populate `mipPositions` when reading KTX2 images, even when the KTX2 file indicated that it had no mip levels and that they should be created, if necessary, from the base image. As a result, `generateMipMaps` wouldn't generate any mipmaps for the image.
> 

Once this is merged you may need to delete `build/CMakeCache.txt` or just delete the whole `build` folder