### PR TITLE
Better handling for tilesets that are destroyed mid load

### DIFF
--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -20,7 +20,8 @@ class FabricGeometry {
     FabricGeometry(
         const pxr::SdfPath& path,
         const FabricGeometryDefinition& geometryDefinition,
-        bool debugRandomColors);
+        bool debugRandomColors,
+        long stageId);
     ~FabricGeometry();
 
     void setGeometry(
@@ -44,10 +45,12 @@ class FabricGeometry {
   private:
     void initialize();
     void reset();
+    bool stageDestroyed();
 
     const omni::fabric::Path _pathFabric;
     const FabricGeometryDefinition _geometryDefinition;
     const bool _debugRandomColors;
+    const long _stageId;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricGeometryPool.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryPool.h
@@ -12,7 +12,8 @@ class FabricGeometryPool final : public ObjectPool<FabricGeometry> {
         int64_t poolId,
         const FabricGeometryDefinition& geometryDefinition,
         uint64_t initialCapacity,
-        bool debugRandomColors);
+        bool debugRandomColors,
+        long stageId);
 
     [[nodiscard]] const FabricGeometryDefinition& getGeometryDefinition() const;
 
@@ -24,6 +25,7 @@ class FabricGeometryPool final : public ObjectPool<FabricGeometry> {
     const int64_t _poolId;
     const FabricGeometryDefinition _geometryDefinition;
     const bool _debugRandomColors;
+    const long _stageId;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -26,7 +26,8 @@ class FabricMaterial {
     FabricMaterial(
         pxr::SdfPath path,
         const FabricMaterialDefinition& materialDefinition,
-        pxr::SdfAssetPath defaultTextureAssetPath);
+        pxr::SdfAssetPath defaultTextureAssetPath,
+        long stageId);
     ~FabricMaterial();
 
     void setMaterial(int64_t tilesetId, const MaterialInfo& materialInfo);
@@ -46,9 +47,11 @@ class FabricMaterial {
     void setTilesetId(int64_t tilesetId);
     void setMaterialValues(const MaterialInfo& materialInfo);
     void setBaseColorTextureValues(const pxr::SdfAssetPath& textureAssetPath, const TextureInfo& textureInfo);
+    bool stageDestroyed();
 
     const FabricMaterialDefinition _materialDefinition;
     const pxr::SdfAssetPath _defaultTextureAssetPath;
+    const long _stageId;
 
     omni::fabric::Path _materialPathFabric;
     omni::fabric::Path _shaderPathFabric;

--- a/src/core/include/cesium/omniverse/FabricMaterialPool.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialPool.h
@@ -14,7 +14,8 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
         int64_t poolId,
         const FabricMaterialDefinition& materialDefinition,
         uint64_t initialCapacity,
-        pxr::SdfAssetPath defaultTextureAssetPath);
+        pxr::SdfAssetPath defaultTextureAssetPath,
+        long stageId);
 
     [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
 
@@ -26,6 +27,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
     const int64_t _poolId;
     const FabricMaterialDefinition _materialDefinition;
     const pxr::SdfAssetPath _defaultTextureAssetPath;
+    const long _stageId;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
+++ b/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
@@ -68,9 +68,10 @@ class FabricPrepareRenderResources final : public Cesium3DTilesSelection::IPrepa
         const Cesium3DTilesSelection::RasterOverlayTile& rasterTile,
         void* pMainThreadRendererResources) noexcept override;
 
-  private:
     [[nodiscard]] bool tilesetExists() const;
+    void detachTileset();
 
-    const OmniTileset& _tileset;
+  private:
+    const OmniTileset* _tileset;
 };
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricResourceManager.h
+++ b/src/core/include/cesium/omniverse/FabricResourceManager.h
@@ -46,10 +46,13 @@ class FabricResourceManager {
         bool hasImagery,
         const pxr::SdfPath& materialPath) const;
 
-    std::shared_ptr<FabricGeometry>
-    acquireGeometry(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, bool smoothNormals);
+    std::shared_ptr<FabricGeometry> acquireGeometry(
+        const CesiumGltf::Model& model,
+        const CesiumGltf::MeshPrimitive& primitive,
+        bool smoothNormals,
+        long stageId);
 
-    std::shared_ptr<FabricMaterial> acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery);
+    std::shared_ptr<FabricMaterial> acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery, long stageId);
 
     std::shared_ptr<FabricTexture> acquireTexture();
 
@@ -77,6 +80,12 @@ class FabricResourceManager {
     std::shared_ptr<FabricGeometryPool> getGeometryPool(const FabricGeometryDefinition& geometryDefinition);
     std::shared_ptr<FabricMaterialPool> getMaterialPool(const FabricMaterialDefinition& materialDefinition);
     std::shared_ptr<FabricTexturePool> getTexturePool();
+
+    std::shared_ptr<FabricGeometryPool>
+    createGeometryPool(const FabricGeometryDefinition& geometryDefinition, long stageId);
+    std::shared_ptr<FabricMaterialPool>
+    createMaterialPool(const FabricMaterialDefinition& materialDefinition, long stageId);
+    std::shared_ptr<FabricTexturePool> createTexturePool();
 
     int64_t getNextGeometryId();
     int64_t getNextMaterialId();

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -58,6 +58,7 @@ class ScopedEdit {
 static const auto GEOREFERENCE_PATH = pxr::SdfPath("/CesiumGeoreference");
 
 pxr::UsdStageRefPtr getUsdStage();
+long getUsdStageId();
 omni::fabric::StageReaderWriter getFabricStageReaderWriter();
 omni::fabric::StageReaderWriterId getFabricStageReaderWriterId();
 

--- a/src/core/src/FabricGeometryPool.cpp
+++ b/src/core/src/FabricGeometryPool.cpp
@@ -8,11 +8,13 @@ FabricGeometryPool::FabricGeometryPool(
     int64_t poolId,
     const FabricGeometryDefinition& geometryDefinition,
     uint64_t initialCapacity,
-    bool debugRandomColors)
+    bool debugRandomColors,
+    long stageId)
     : ObjectPool<FabricGeometry>()
     , _poolId(poolId)
     , _geometryDefinition(geometryDefinition)
-    , _debugRandomColors(debugRandomColors) {
+    , _debugRandomColors(debugRandomColors)
+    , _stageId(stageId) {
     setCapacity(initialCapacity);
 }
 
@@ -22,7 +24,7 @@ const FabricGeometryDefinition& FabricGeometryPool::getGeometryDefinition() cons
 
 std::shared_ptr<FabricGeometry> FabricGeometryPool::createObject(uint64_t objectId) {
     const auto path = pxr::SdfPath(fmt::format("/fabric_geometry_pool_{}_object_{}", _poolId, objectId));
-    return std::make_shared<FabricGeometry>(path, _geometryDefinition, _debugRandomColors);
+    return std::make_shared<FabricGeometry>(path, _geometryDefinition, _debugRandomColors, _stageId);
 }
 
 void FabricGeometryPool::setActive(std::shared_ptr<FabricGeometry> geometry, bool active) {

--- a/src/core/src/FabricMaterialPool.cpp
+++ b/src/core/src/FabricMaterialPool.cpp
@@ -8,11 +8,13 @@ FabricMaterialPool::FabricMaterialPool(
     int64_t poolId,
     const FabricMaterialDefinition& materialDefinition,
     uint64_t initialCapacity,
-    pxr::SdfAssetPath defaultTextureAssetPath)
+    pxr::SdfAssetPath defaultTextureAssetPath,
+    long stageId)
     : ObjectPool<FabricMaterial>()
     , _poolId(poolId)
     , _materialDefinition(materialDefinition)
-    , _defaultTextureAssetPath(std::move(defaultTextureAssetPath)) {
+    , _defaultTextureAssetPath(std::move(defaultTextureAssetPath))
+    , _stageId(stageId) {
     setCapacity(initialCapacity);
 }
 
@@ -22,7 +24,7 @@ const FabricMaterialDefinition& FabricMaterialPool::getMaterialDefinition() cons
 
 std::shared_ptr<FabricMaterial> FabricMaterialPool::createObject(uint64_t objectId) {
     const auto path = pxr::SdfPath(fmt::format("/fabric_material_pool_{}_object_{}", _poolId, objectId));
-    return std::make_shared<FabricMaterial>(path, _materialDefinition, _defaultTextureAssetPath);
+    return std::make_shared<FabricMaterial>(path, _materialDefinition, _defaultTextureAssetPath, _stageId);
 }
 
 void FabricMaterialPool::setActive(std::shared_ptr<FabricMaterial> material, bool active) {

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -607,11 +607,6 @@ FabricStatistics getStatistics() {
 }
 
 void destroyPrim(const omni::fabric::Path& path) {
-    // Only delete prims if there's still a stage to delete them from
-    if (!UsdUtil::hasStage()) {
-        return;
-    }
-
     auto srw = UsdUtil::getFabricStageReaderWriter();
     srw.destroyPrim(path);
 

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -39,7 +39,9 @@ OmniTileset::OmniTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPath& ge
     UsdUtil::setGeoreferenceForTileset(tilesetPath, georeferencePath);
 }
 
-OmniTileset::~OmniTileset() = default;
+OmniTileset::~OmniTileset() {
+    _renderResourcesPreparer->detachTileset();
+}
 
 pxr::SdfPath OmniTileset::getPath() const {
     return _tilesetPath;

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -27,19 +27,23 @@ pxr::UsdStageRefPtr getUsdStage() {
     return Context::instance().getStage();
 }
 
+long getUsdStageId() {
+    return Context::instance().getStageId();
+}
+
 omni::fabric::StageReaderWriter getFabricStageReaderWriter() {
     return Context::instance().getFabricStageReaderWriter();
 }
 
 omni::fabric::StageReaderWriterId getFabricStageReaderWriterId() {
     const auto iStageReaderWriter = carb::getCachedInterface<omni::fabric::IStageReaderWriter>();
-    const auto stageId = Context::instance().getStageId();
+    const auto stageId = getUsdStageId();
     const auto stageReaderWriterId = iStageReaderWriter->get(omni::fabric::UsdStageId{static_cast<uint64_t>(stageId)});
     return stageReaderWriterId;
 }
 
 bool hasStage() {
-    return Context::instance().getStageId() != 0;
+    return getUsdStageId() != 0;
 }
 
 glm::dvec3 usdToGlmVector(const pxr::GfVec3d& vector) {


### PR DESCRIPTION
After talking with @kring and reading through https://github.com/CesiumGS/cesium-native/pull/554 I realized that `FabricPrepareRenderResources` had a few incorrect assumptions about tileset lifetime management.

When a tileset is destroyed its `TileContentManager` still exists to finish processing tiles that were loading asynchronously. So we need to do a few things:

1. Be careful not to access a tileset that's already been destroyed. Previously we were storing a reference to the tileset in `FabricPrepareRenderResources`, but this has the risk of becoming a dangling reference. Now we store a pointer and set it to null when the tileset is destroyed.
2. Ensure that asynchronously loading tiles make it through `prepareInLoadThread` and `prepareInMainThread` so that the fabric resources can be unloaded later. The previous code would return early a bit too aggressively and potentially lead to memory leaks. A couple `tilesetExists()` checks have been removed.
3. Since tiles may be processed after the fabric stage has been destroyed, make sure we don't modify fabric prims that no longer exist. We had some code like this already, but the new code is more robust.