### PR TITLE
Remove empty pools

### DIFF
--- a/src/core/include/cesium/omniverse/ObjectPool.h
+++ b/src/core/include/cesium/omniverse/ObjectPool.h
@@ -46,6 +46,10 @@ template <typename T> class ObjectPool {
         return _queue.size();
     }
 
+    [[nodiscard]] bool isEmpty() const {
+        return getNumberInactive() == getCapacity();
+    }
+
     [[nodiscard]] double computePercentActive() const {
         const auto numberActive = static_cast<double>(getNumberActive());
         const auto capacity = static_cast<double>(getCapacity());

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -16,6 +16,18 @@
 
 namespace cesium::omniverse {
 
+namespace {
+template <typename T> void removePool(std::vector<T>& pools, const T& pool) {
+    auto it =
+        std::find_if(pools.begin(), pools.end(), [&pool](const auto& other) { return pool.get() == other.get(); });
+
+    if (it != pools.end()) {
+        pools.erase(it);
+    }
+}
+
+} // namespace
+
 FabricResourceManager::FabricResourceManager() {
     const auto defaultTextureName = "fabric_default_texture";
     _defaultTextureAssetPath = UsdUtil::getDynamicTextureProviderAssetPath(defaultTextureName);
@@ -119,6 +131,10 @@ void FabricResourceManager::releaseGeometry(const std::shared_ptr<FabricGeometry
     const auto geometryPool = getGeometryPool(geometry->getGeometryDefinition());
     assert(geometryPool != nullptr);
     geometryPool->release(geometry);
+
+    if (geometryPool->isEmpty()) {
+        removePool(_geometryPools, geometryPool);
+    }
 }
 
 void FabricResourceManager::releaseMaterial(const std::shared_ptr<FabricMaterial>& material) {
@@ -131,6 +147,10 @@ void FabricResourceManager::releaseMaterial(const std::shared_ptr<FabricMaterial
     const auto materialPool = getMaterialPool(material->getMaterialDefinition());
     assert(materialPool != nullptr);
     materialPool->release(material);
+
+    if (materialPool->isEmpty()) {
+        removePool(_materialPools, materialPool);
+    }
 }
 
 void FabricResourceManager::releaseTexture(const std::shared_ptr<FabricTexture>& texture) {
@@ -143,6 +163,10 @@ void FabricResourceManager::releaseTexture(const std::shared_ptr<FabricTexture>&
     const auto texturePool = getTexturePool();
     assert(texturePool != nullptr);
     texturePool->release(texture);
+
+    if (texturePool->isEmpty()) {
+        removePool(_texturePools, texturePool);
+    }
 }
 
 void FabricResourceManager::setDisableMaterials(bool disableMaterials) {


### PR DESCRIPTION
Fixes one of the items in https://github.com/CesiumGS/cesium-omniverse/pull/406:

> Delete material pools that are no longer in use. This is especially important now that the tileset material is part of the material definition.

Basically we don't want to keep empty pools around because the inactive prims just take up space and may never be reused.