### PR TITLE
Remove cudart from build system

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -71,7 +71,6 @@ set(USDRT_ROOT "${NVIDIA_BUILD_DIR}/target-deps/usdrt")
 set(CARB_ROOT "${NVIDIA_BUILD_DIR}/target-deps/carb_sdk_plugins")
 set(KIT_SDK_ROOT "${NVIDIA_BUILD_DIR}/target-deps/kit-sdk")
 set(PYBIND11_ROOT "${NVIDIA_BUILD_DIR}/target-deps/pybind11")
-set(CUDA_ROOT "${NVIDIA_BUILD_DIR}/target-deps/cuda")
 
 set(NVIDIA_USD_LIBRARIES
     ar
@@ -239,54 +238,6 @@ add_prebuilt_project_header_only(
         pybind11
 )
 # cmake-format: on
-
-if(WIN32)
-    # cmake-format: off
-    add_prebuilt_project(
-        RELEASE_INCLUDE_DIR
-            "${CUDA_ROOT}"
-        DEBUG_INCLUDE_DIR
-            "${CUDA_ROOT}"
-        RELEASE_LIBRARY_DIR
-            "${CUDA_ROOT}/cuda/lib/x64"
-        RELEASE_DLL_DIR
-            "${CUDA_ROOT}/cuda/bin"
-        DEBUG_LIBRARY_DIR
-            "${CUDA_ROOT}/cuda/lib/x64"
-        DEBUG_DLL_DIR
-            "${CUDA_ROOT}/cuda/bin"
-        RELEASE_LIBRARIES
-            cudart
-        DEBUG_LIBRARIES
-            cudart
-        RELEASE_DLL_LIBRARIES
-            cudart64_110
-        DEBUG_DLL_LIBRARIES
-            cudart64_110
-        TARGET_NAMES
-            cudart
-    )
-    # cmake-format: on
-else()
-    # cmake-format: off
-    add_prebuilt_project(
-        RELEASE_INCLUDE_DIR
-            "${CUDA_ROOT}"
-        DEBUG_INCLUDE_DIR
-            "${CUDA_ROOT}"
-        RELEASE_LIBRARY_DIR
-            "${CUDA_ROOT}/cuda/lib64"
-        DEBUG_LIBRARY_DIR
-            "${CUDA_ROOT}/cuda/lib64"
-        RELEASE_LIBRARIES
-            cudart
-        DEBUG_LIBRARIES
-            cudart
-        TARGET_NAMES
-            cudart
-    )
-    # cmake-format: on
-endif()
 
 # cmake-format: off
 # omni.ui gives us access to DynamicTextureProvider.h

--- a/extern/nvidia/deps/target-deps.packman.xml
+++ b/extern/nvidia/deps/target-deps.packman.xml
@@ -6,7 +6,6 @@
     <filter include="usdrt"/>
     <filter include="carb_sdk_plugins"/>
     <filter include="pybind11"/>
-    <filter include="cuda"/>
   </import>
   <import path="../_build/target-deps/kit-sdk-debug/dev/all-deps.packman.xml">
     <filter include="nv_usd_py310_debug"/>
@@ -18,5 +17,4 @@
   <dependency name="usdrt" linkPath="../_build/target-deps/usdrt"/>
   <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins"/>
   <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11"/>
-  <dependency name="cuda" linkPath="../_build/target-deps/cuda/cuda"/>
 </project>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -84,7 +84,6 @@ setup_lib(
         boost_python310
         tbb
         carb
-        cudart
         omni_kit
         omni_ui
         pybind11


### PR DESCRIPTION
Similar to https://github.com/CesiumGS/cesium-omniverse/pull/405, we no longer depend on cudart due to internal restructurings in Kit 105.

This fixes a problem where the extension doesn't load in Code 2023.1.1:

> 2023-08-04 14:11:42  [Error] [carb] [Plugin: libcesium.omniverse.plugin.so] Could not load the dynamic library from /cesium-omniverse/exts/cesium.omniverse/bin/libcesium.omniverse.plugin.so. Error: libcudart.so.11.0: cannot open shared object file: No such file or directory (Additional information may be available by running the process with the LD_DEBUG environment variable set)

We'll need to figure this out eventually since @corybarr is using cuda for point clouds, but for now we just need to get things working with Code 2023.1.1.