### PR TITLE
Add voxel point cloud

### DIFF
--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -292,7 +292,7 @@ void FabricGeometry::setGeometry(
 
     if (primitive.mode == 0) { //if tile is a point cloud
 
-        auto numVoxels = positions.size();
+        const auto numVoxels = positions.size();
         const float quadHalfSize = 1.5f;
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numVoxels * 8));
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numVoxels * 2 * 6);
@@ -378,14 +378,14 @@ void FabricGeometry::setGeometry(
             faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
             faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
 
-            voxelCounter++;
-
-            auto color = vertexColorsSpan[voxelNum];
             if (hasVertexColors) {
+                const auto color = vertexColorsSpan[voxelNum];
                 for (int i = 0; i < 8; i++) {
                     vertexColorsFabric[vertexColorsIndex++] = color;
                 }
             }
+
+            voxelCounter++;
         }
 
         // clang-format off

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -6,6 +6,7 @@
 #include "cesium/omniverse/GltfUtil.h"
 #include "cesium/omniverse/Tokens.h"
 #include "cesium/omniverse/UsdUtil.h"
+
 #include <glm/fwd.hpp>
 
 #ifdef CESIUM_OMNI_MSVC

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -292,7 +292,7 @@ void FabricGeometry::setGeometry(
 
     if (primitive.mode == 0) { //if tile is a point cloud
 
-        const float quadHalfSize = 1.0f;
+        const float quadHalfSize = 2.0f;
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, positions.size() * 4);
 
         size_t primvarsCount = 0;
@@ -307,7 +307,7 @@ void FabricGeometry::setGeometry(
         auto numQuads = positions.size();
 
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numQuads * 4));
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numQuads * 4 * 2);
+        srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numQuads * 2);
         auto pointsFabric =
             srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
         auto faceVertexCountsFabric =

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -292,7 +292,7 @@ void FabricGeometry::setGeometry(
 
     if (primitive.mode == 0) { //if tile is a point cloud
 
-        const float quadHalfSize = 0.5f;
+        const float quadHalfSize = 1.0f;
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, positions.size() * 4);
 
         size_t primvarsCount = 0;
@@ -305,12 +305,6 @@ void FabricGeometry::setGeometry(
         primvarInterpolationsFabric[primvarIndexDisplayColor] = FabricTokens::vertex;
 
         auto numQuads = positions.size();
-
-        const auto primvarsDisplayColorIndicesToken = omni::fabric::Token("primvars:displayColor:indices");
-        const omni::fabric::Type primvarsDisplayColorIndicesType(omni::fabric::BaseDataType::eInt, 1, 1, omni::fabric::AttributeRole::eNone);
-
-        srw.createAttribute(_pathFabric, primvarsDisplayColorIndicesToken, primvarsDisplayColorIndicesType);
-        srw.setArrayAttributeSize(_pathFabric, primvarsDisplayColorIndicesToken, numQuads * 4);
 
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numQuads * 4));
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numQuads * 4 * 2);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -293,10 +293,9 @@ void FabricGeometry::setGeometry(
     const auto worldExtent = UsdUtil::computeWorldExtent(localExtent, localToUsdTransform);
 
     if (primitive.mode == CesiumGltf::MeshPrimitive::Mode::POINTS) {
-
         const auto numVoxels = positions.size();
         const auto shapeHalfSize = 1.5f;
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numVoxels * 8));
+        srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, numVoxels * 8);
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numVoxels * 2 * 6);
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, numVoxels * 6 * 2 * 3);
 
@@ -317,7 +316,7 @@ void FabricGeometry::setGeometry(
         size_t faceVertexIndex = 0;
         size_t vertexColorsIndex = 0;
         for (size_t voxelIndex = 0; voxelIndex < numVoxels; voxelIndex++) {
-            const auto center = positions.get(voxelIndex);
+            const auto& center = positions.get(voxelIndex);
 
             pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
             pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
@@ -377,23 +376,20 @@ void FabricGeometry::setGeometry(
             faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
 
             if (hasVertexColors) {
-                const auto color = vertexColorsSpan[voxelIndex];
+                const auto& color = vertexColorsSpan[voxelIndex];
                 for (int i = 0; i < 8; i++) {
                     vertexColorsFabric[vertexColorsIndex++] = color;
                 }
             }
         }
-
     } else {
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, faceVertexCounts.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, indices.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, positions.size());
 
-        // clang-format off
         auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
         auto pointsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::points);
-        // clang-format on
 
         faceVertexCounts.fill(faceVertexCountsFabric);
         indices.fill(faceVertexIndicesFabric);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -383,23 +383,6 @@ void FabricGeometry::setGeometry(
             }
         }
 
-        // clang-format off
-        auto extentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::extent);
-        auto worldExtentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::_worldExtent);
-        auto localToEcefTransformFabric = srw.getAttributeWr<pxr::GfMatrix4d>(_pathFabric, FabricTokens::_cesium_localToEcefTransform);
-        auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_pathFabric, FabricTokens::_worldPosition);
-        auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_pathFabric, FabricTokens::_worldOrientation);
-        auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::_worldScale);
-        // clang-format on
-
-        *extentFabric = localExtent;
-        *worldExtentFabric = worldExtent;
-        *localToEcefTransformFabric = UsdUtil::glmToUsdMatrix(localToEcefTransform);
-        *worldPositionFabric = worldPosition;
-        *worldOrientationFabric = worldOrientation;
-        *worldScaleFabric = worldScale;
-
-        FabricUtil::setTilesetId(_pathFabric, tilesetId);
     } else {
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, faceVertexCounts.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, indices.size());
@@ -409,12 +392,6 @@ void FabricGeometry::setGeometry(
         auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
         auto pointsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::points);
-        auto extentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::extent);
-        auto worldExtentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::_worldExtent);
-        auto localToEcefTransformFabric = srw.getAttributeWr<pxr::GfMatrix4d>(_pathFabric, FabricTokens::_cesium_localToEcefTransform);
-        auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_pathFabric, FabricTokens::_worldPosition);
-        auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_pathFabric, FabricTokens::_worldOrientation);
-        auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::_worldScale);
         auto displayColorFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::primvars_displayColor);
         auto displayOpacityFabric = srw.getArrayAttributeWr<float>(_pathFabric, FabricTokens::primvars_displayOpacity);
         // clang-format on
@@ -422,15 +399,6 @@ void FabricGeometry::setGeometry(
         faceVertexCounts.fill(faceVertexCountsFabric);
         indices.fill(faceVertexIndicesFabric);
         positions.fill(pointsFabric);
-
-        *extentFabric = localExtent;
-        *worldExtentFabric = worldExtent;
-        *localToEcefTransformFabric = UsdUtil::glmToUsdMatrix(localToEcefTransform);
-        *worldPositionFabric = worldPosition;
-        *worldOrientationFabric = worldOrientation;
-        *worldScaleFabric = worldScale;
-
-        FabricUtil::setTilesetId(_pathFabric, tilesetId);
 
         if (_debugRandomColors) {
             const auto r = glm::linearRand(0.0f, 1.0f);
@@ -470,6 +438,24 @@ void FabricGeometry::setGeometry(
             vertexColors.fill(vertexColorsFabric);
         }
     }
+
+    // clang-format off
+    auto extentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::extent);
+    auto worldExtentFabric = srw.getAttributeWr<pxr::GfRange3d>(_pathFabric, FabricTokens::_worldExtent);
+    auto localToEcefTransformFabric = srw.getAttributeWr<pxr::GfMatrix4d>(_pathFabric, FabricTokens::_cesium_localToEcefTransform);
+    auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_pathFabric, FabricTokens::_worldPosition);
+    auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_pathFabric, FabricTokens::_worldOrientation);
+    auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::_worldScale);
+    // clang-format on
+
+    *extentFabric = localExtent;
+    *worldExtentFabric = worldExtent;
+    *localToEcefTransformFabric = UsdUtil::glmToUsdMatrix(localToEcefTransform);
+    *worldPositionFabric = worldPosition;
+    *worldOrientationFabric = worldOrientation;
+    *worldScaleFabric = worldScale;
+
+    FabricUtil::setTilesetId(_pathFabric, tilesetId);
 }
 
 bool FabricGeometry::stageDestroyed() {

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -292,22 +292,12 @@ void FabricGeometry::setGeometry(
 
     if (primitive.mode == 0) { //if tile is a point cloud
 
-        const float quadHalfSize = 2.0f;
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, positions.size() * 4);
-
-        size_t primvarsCount = 0;
-        const size_t primvarIndexDisplayColor = primvarsCount++;
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars, primvarsCount);
-        auto primvarsFabric = srw.getArrayAttribute<omni::fabric::Token>(_pathFabric, FabricTokens::primvars);
-        primvarsFabric[primvarIndexDisplayColor] = FabricTokens::primvars_displayColor;
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvarInterpolations, 1);
-        auto primvarInterpolationsFabric = srw.getArrayAttributeWr<omni::fabric::Token>(_pathFabric, FabricTokens::primvarInterpolations);
-        primvarInterpolationsFabric[primvarIndexDisplayColor] = FabricTokens::vertex;
-
         auto numQuads = positions.size();
-
+        const float quadHalfSize = 2.0f;
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numQuads * 4));
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numQuads * 2);
+        srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars_displayColor, numQuads * 4);
+
         auto pointsFabric =
             srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
         auto faceVertexCountsFabric =
@@ -315,7 +305,6 @@ void FabricGeometry::setGeometry(
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, numQuads * 4 * 2 * 3);
         auto faceVertexIndicesFabric =
             srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars_displayColor, numQuads * 4);
 
         std::vector<glm::fvec3> vertexColorsData(numQuads);
         gsl::span<glm::fvec3> vertexColorsSpan(vertexColorsData);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -393,24 +393,11 @@ void FabricGeometry::setGeometry(
         auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
         auto pointsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::points);
-        auto displayColorFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::primvars_displayColor);
-        auto displayOpacityFabric = srw.getArrayAttributeWr<float>(_pathFabric, FabricTokens::primvars_displayOpacity);
         // clang-format on
 
         faceVertexCounts.fill(faceVertexCountsFabric);
         indices.fill(faceVertexIndicesFabric);
         positions.fill(pointsFabric);
-
-        if (_debugRandomColors) {
-            const auto r = glm::linearRand(0.0f, 1.0f);
-            const auto g = glm::linearRand(0.0f, 1.0f);
-            const auto b = glm::linearRand(0.0f, 1.0f);
-            displayColorFabric[0] = pxr::GfVec3f(r, g, b);
-        } else {
-            displayColorFabric[0] = DEFAULT_VERTEX_COLOR;
-        }
-
-        displayOpacityFabric[0] = DEFAULT_VERTEX_OPACITY;
 
         if (hasTexcoords) {
             const auto& texcoords = hasImagery ? imageryTexcoords : texcoords_0;
@@ -447,6 +434,8 @@ void FabricGeometry::setGeometry(
     auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_pathFabric, FabricTokens::_worldPosition);
     auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_pathFabric, FabricTokens::_worldOrientation);
     auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::_worldScale);
+    auto displayColorFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::primvars_displayColor);
+    auto displayOpacityFabric = srw.getArrayAttributeWr<float>(_pathFabric, FabricTokens::primvars_displayOpacity);
     // clang-format on
 
     *extentFabric = localExtent;
@@ -455,6 +444,17 @@ void FabricGeometry::setGeometry(
     *worldPositionFabric = worldPosition;
     *worldOrientationFabric = worldOrientation;
     *worldScaleFabric = worldScale;
+
+    if (_debugRandomColors) {
+        const auto r = glm::linearRand(0.0f, 1.0f);
+        const auto g = glm::linearRand(0.0f, 1.0f);
+        const auto b = glm::linearRand(0.0f, 1.0f);
+        displayColorFabric[0] = pxr::GfVec3f(r, g, b);
+    } else {
+        displayColorFabric[0] = DEFAULT_VERTEX_COLOR;
+    }
+
+    displayOpacityFabric[0] = DEFAULT_VERTEX_OPACITY;
 
     FabricUtil::setTilesetId(_pathFabric, tilesetId);
 }

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -6,6 +6,7 @@
 #include "cesium/omniverse/GltfUtil.h"
 #include "cesium/omniverse/Tokens.h"
 #include "cesium/omniverse/UsdUtil.h"
+#include <glm/fwd.hpp>
 
 #ifdef CESIUM_OMNI_MSVC
 #pragma push_macro("OPAQUE")
@@ -298,7 +299,7 @@ void FabricGeometry::setGeometry(
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numVoxels * 2 * 6);
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, numVoxels * 6 * 2 * 3);
 
-        auto pointsFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
+        auto pointsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::points);
         auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
 
@@ -313,77 +314,73 @@ void FabricGeometry::setGeometry(
         size_t vertIndex = 0;
         size_t vertexCountsIndex = 0;
         size_t faceVertexIndex = 0;
-        size_t voxelCounter = 0;
         size_t vertexColorsIndex = 0;
-        for (size_t voxelNum = 0; voxelNum < numVoxels; voxelNum++) {
-            auto centerGlm = positions.get(voxelNum);
-            pxr::GfVec3f center{centerGlm.x, centerGlm.y, centerGlm.z};
+        for (size_t voxelIndex = 0; voxelIndex < numVoxels; voxelIndex++) {
+            const auto center = positions.get(voxelIndex);
 
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{-shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = glm::fvec3{shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
 
             for (int i = 0; i < 6; i++) {
                 faceVertexCountsFabric[vertexCountsIndex++] = 3;
                 faceVertexCountsFabric[vertexCountsIndex++] = 3;
             }
 
-            //front
-            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelCounter * 8);
-            //left
-            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelCounter * 8);
-            //right
-            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelCounter * 8);
-            //top
-            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelCounter * 8);
-            //bottom
-            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelCounter * 8);
-            //back
-            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelCounter * 8);
-            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelCounter * 8);
+            // front
+            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelIndex * 8);
+            // left
+            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelIndex * 8);
+            // right
+            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelIndex * 8);
+            // top
+            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 1 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 2 + static_cast<int>(voxelIndex * 8);
+            // bottom
+            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 3 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 0 + static_cast<int>(voxelIndex * 8);
+            // back
+            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 6 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
+            faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
 
             if (hasVertexColors) {
-                const auto color = vertexColorsSpan[voxelNum];
+                const auto color = vertexColorsSpan[voxelIndex];
                 for (int i = 0; i < 8; i++) {
                     vertexColorsFabric[vertexColorsIndex++] = color;
                 }
             }
-
-            voxelCounter++;
         }
 
         // clang-format off

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -300,12 +300,9 @@ void FabricGeometry::setGeometry(
 
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, numVoxels * 6 * 2 * 3);
 
-        auto pointsFabric =
-            srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
-        auto faceVertexCountsFabric =
-            srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
-        auto faceVertexIndicesFabric =
-            srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
+        auto pointsFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
+        auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexCounts);
+        auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_pathFabric, FabricTokens::faceVertexIndices);
 
         std::vector<glm::fvec3> vertexColorsData(numVoxels);
         gsl::span<glm::fvec3> vertexColorsSpan(vertexColorsData);
@@ -313,8 +310,7 @@ void FabricGeometry::setGeometry(
             vertexColors.fill(vertexColorsSpan);
             srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars_vertexColor, numVoxels * 8);
         }
-        auto vertexColorsFabric =
-            srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::primvars_vertexColor);
+        auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::primvars_vertexColor);
 
         size_t vertIndex = 0;
         size_t vertexCountsIndex = 0;
@@ -387,8 +383,9 @@ void FabricGeometry::setGeometry(
             auto color = vertexColorsSpan[voxelNum];
             if (hasVertexColors) {
                 for (int i = 0; i < 8; i++) {
-                   vertexColorsFabric[vertexColorsIndex++] = color;
-}            }
+                    vertexColorsFabric[vertexColorsIndex++] = color;
+                }
+            }
         }
 
         // clang-format off
@@ -406,8 +403,7 @@ void FabricGeometry::setGeometry(
         *worldPositionFabric = worldPosition;
         *worldOrientationFabric = worldOrientation;
         *worldScaleFabric = worldScale;
-    }
-    else {
+    } else {
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, faceVertexCounts.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, indices.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, positions.size());
@@ -471,7 +467,8 @@ void FabricGeometry::setGeometry(
         if (hasVertexColors) {
             srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars_vertexColor, vertexColors.size());
 
-            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::primvars_vertexColor);
+            auto vertexColorsFabric =
+                srw.getArrayAttributeWr<glm::fvec3>(_pathFabric, FabricTokens::primvars_vertexColor);
 
             vertexColors.fill(vertexColorsFabric);
         }

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -293,11 +293,9 @@ void FabricGeometry::setGeometry(
     if (primitive.mode == 0) { //if tile is a point cloud
 
         const auto numVoxels = positions.size();
-        const float quadHalfSize = 1.5f;
+        const auto shapeHalfSize = 1.5f;
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::points, static_cast<size_t>(numVoxels * 8));
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, numVoxels * 2 * 6);
-        srw.setArrayAttributeSize(_pathFabric, FabricTokens::primvars_displayColor, numVoxels * 8);
-
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, numVoxels * 6 * 2 * 3);
 
         auto pointsFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_pathFabric, FabricTokens::points);
@@ -321,14 +319,14 @@ void FabricGeometry::setGeometry(
             auto centerGlm = positions.get(voxelNum);
             pxr::GfVec3f center{centerGlm.x, centerGlm.y, centerGlm.z};
 
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-quadHalfSize, -quadHalfSize, -quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-quadHalfSize, quadHalfSize, -quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{quadHalfSize, quadHalfSize, -quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{quadHalfSize, -quadHalfSize, -quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-quadHalfSize, -quadHalfSize, quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{-quadHalfSize, quadHalfSize, quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{quadHalfSize, quadHalfSize, quadHalfSize} + center;
-            pointsFabric[vertIndex++] = pxr::GfVec3f{quadHalfSize, -quadHalfSize, quadHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, -shapeHalfSize, -shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{-shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, shapeHalfSize, shapeHalfSize} + center;
+            pointsFabric[vertIndex++] = pxr::GfVec3f{shapeHalfSize, -shapeHalfSize, shapeHalfSize} + center;
 
             for (int i = 0; i < 6; i++) {
                 faceVertexCountsFabric[vertexCountsIndex++] = 3;
@@ -403,6 +401,8 @@ void FabricGeometry::setGeometry(
         *worldPositionFabric = worldPosition;
         *worldOrientationFabric = worldOrientation;
         *worldScaleFabric = worldScale;
+
+        FabricUtil::setTilesetId(_pathFabric, tilesetId);
     } else {
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexCounts, faceVertexCounts.size());
         srw.setArrayAttributeSize(_pathFabric, FabricTokens::faceVertexIndices, indices.size());


### PR DESCRIPTION
This PR adds a voxel-based point-cloud viewer to point-cloud tilesets.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/1040194/627193b2-f5f2-4261-b672-449eb7c6dff4)

This is the first in a series of pull requests to enable customizable point-cloud rendering based on CUDA kernels. 

The next pull request will enable voxel attenuation based on geometric error.