### PR TITLE
Simplify token creation

### DIFF
--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -1,136 +1,107 @@
 #pragma once
 
-#include <omni/fabric/SimStageWithHistory.h>
-#include <pxr/base/tf/token.h>
+#include <omni/fabric/FabricUSD.h>
+#include <pxr/base/tf/staticTokens.h>
 
 // clang-format off
+namespace pxr {
 
-namespace cesium::omniverse::FabricTokens {
-extern const omni::fabric::TokenC baseColorTexture;
-extern const omni::fabric::TokenC cesium_material;
-extern const omni::fabric::TokenC cesium_texture_lookup;
-extern const omni::fabric::TokenC constant;
-extern const omni::fabric::TokenC doubleSided;
-extern const omni::fabric::TokenC extent;
-extern const omni::fabric::TokenC faceVertexCounts;
-extern const omni::fabric::TokenC faceVertexIndices;
-extern const omni::fabric::TokenC info_implementationSource;
-extern const omni::fabric::TokenC info_mdl_sourceAsset;
-extern const omni::fabric::TokenC info_mdl_sourceAsset_subIdentifier;
-extern const omni::fabric::TokenC inputs_alpha_cutoff;
-extern const omni::fabric::TokenC inputs_alpha_mode;
-extern const omni::fabric::TokenC inputs_base_alpha;
-extern const omni::fabric::TokenC inputs_base_color_factor;
-extern const omni::fabric::TokenC inputs_base_color_texture;
-extern const omni::fabric::TokenC inputs_emissive_factor;
-extern const omni::fabric::TokenC inputs_excludeFromWhiteMode;
-extern const omni::fabric::TokenC inputs_metallic_factor;
-extern const omni::fabric::TokenC inputs_offset;
-extern const omni::fabric::TokenC inputs_rotation;
-extern const omni::fabric::TokenC inputs_roughness_factor;
-extern const omni::fabric::TokenC inputs_scale;
-extern const omni::fabric::TokenC inputs_tex_coord_index;
-extern const omni::fabric::TokenC inputs_texture;
-extern const omni::fabric::TokenC inputs_vertex_color_name;
-extern const omni::fabric::TokenC inputs_wrap_s;
-extern const omni::fabric::TokenC inputs_wrap_t;
-extern const omni::fabric::TokenC Material;
-extern const omni::fabric::TokenC material_binding;
-extern const omni::fabric::TokenC Mesh;
-extern const omni::fabric::TokenC none;
-extern const omni::fabric::TokenC out;
-extern const omni::fabric::TokenC outputs_mdl_displacement;
-extern const omni::fabric::TokenC outputs_mdl_surface;
-extern const omni::fabric::TokenC outputs_mdl_volume;
-extern const omni::fabric::TokenC outputs_out;
-extern const omni::fabric::TokenC points;
-extern const omni::fabric::TokenC primvarInterpolations;
-extern const omni::fabric::TokenC primvars;
-extern const omni::fabric::TokenC primvars_displayColor;
-extern const omni::fabric::TokenC primvars_displayOpacity;
-extern const omni::fabric::TokenC primvars_normals;
-extern const omni::fabric::TokenC primvars_st;
-extern const omni::fabric::TokenC primvars_vertexColor;
-extern const omni::fabric::TokenC Shader;
-extern const omni::fabric::TokenC sourceAsset;
-extern const omni::fabric::TokenC subdivisionScheme;
-extern const omni::fabric::TokenC vertex;
-extern const omni::fabric::TokenC vertexColor;
-extern const omni::fabric::TokenC _auto;
-extern const omni::fabric::TokenC _cesium_localToEcefTransform;
-extern const omni::fabric::TokenC _cesium_tilesetId;
-extern const omni::fabric::TokenC _deletedPrims;
-extern const omni::fabric::TokenC _paramColorSpace;
-extern const omni::fabric::TokenC _sdrMetadata;
-extern const omni::fabric::TokenC _worldExtent;
-extern const omni::fabric::TokenC _worldOrientation;
-extern const omni::fabric::TokenC _worldPosition;
-extern const omni::fabric::TokenC _worldScale;
-extern const omni::fabric::TokenC _worldVisibility;
+#ifdef CESIUM_OMNI_MSVC
+__pragma(warning(push)) __pragma(warning(disable : 4003))
+#endif
+
+// Note: variable names should match the USD token names as closely as possible, with special characters converted to underscores
+
+#define USD_TOKENS \
+    (baseColorTexture) \
+    (cesium_material) \
+    (cesium_texture_lookup) \
+    (constant) \
+    (doubleSided) \
+    (extent) \
+    (faceVertexCounts) \
+    (faceVertexIndices) \
+    (Material) \
+    (Mesh) \
+    (none) \
+    (points) \
+    (primvarInterpolations) \
+    (primvars) \
+    (Shader) \
+    (sourceAsset) \
+    (subdivisionScheme) \
+    (vertex) \
+    (vertexColor) \
+    (_cesium_localToEcefTransform) \
+    (_cesium_tilesetId) \
+    (_deletedPrims) \
+    (_paramColorSpace) \
+    (_sdrMetadata) \
+    (_worldExtent) \
+    (_worldOrientation) \
+    (_worldPosition) \
+    (_worldScale) \
+    (_worldVisibility) \
+    ((_auto, "auto")) \
+    ((info_implementationSource, "info:implementationSource")) \
+    ((info_mdl_sourceAsset, "info:mdl:sourceAsset")) \
+    ((info_mdl_sourceAsset_subIdentifier, "info:mdl:sourceAsset:subIdentifier")) \
+    ((inputs_alpha_cutoff, "inputs:alpha_cutoff")) \
+    ((inputs_alpha_mode, "inputs:alpha_mode")) \
+    ((inputs_base_alpha, "inputs:base_alpha")) \
+    ((inputs_base_color_factor, "inputs:base_color_factor")) \
+    ((inputs_base_color_texture, "inputs:base_color_texture")) \
+    ((inputs_emissive_factor, "inputs:emissive_factor")) \
+    ((inputs_excludeFromWhiteMode, "inputs:excludeFromWhiteMode")) \
+    ((inputs_metallic_factor, "inputs:metallic_factor")) \
+    ((inputs_offset, "inputs:offset")) \
+    ((inputs_rotation, "inputs:rotation")) \
+    ((inputs_roughness_factor, "inputs:roughness_factor")) \
+    ((inputs_scale, "inputs:scale")) \
+    ((inputs_tex_coord_index, "inputs:tex_coord_index")) \
+    ((inputs_texture, "inputs:texture")) \
+    ((inputs_vertex_color_name, "inputs:vertex_color_name")) \
+    ((inputs_wrap_s, "inputs:wrap_s")) \
+    ((inputs_wrap_t, "inputs:wrap_t")) \
+    ((material_binding, "material:binding")) \
+    ((outputs_mdl_displacement, "outputs:mdl:displacement")) \
+    ((outputs_mdl_surface, "outputs:mdl:surface")) \
+    ((outputs_mdl_volume, "outputs:mdl:volume")) \
+    ((outputs_out, "outputs:out")) \
+    ((primvars_displayColor, "primvars:displayColor")) \
+    ((primvars_displayOpacity, "primvars:displayOpacity")) \
+    ((primvars_normals, "primvars:normals")) \
+    ((primvars_st, "primvars:st")) \
+    ((primvars_vertexColor, "primvars:vertexColor"))
+
+TF_DECLARE_PUBLIC_TOKENS(UsdTokens, USD_TOKENS);
+
+#define FABRIC_DEFINE_TOKEN_ELEM(elem) const omni::fabric::TokenC elem = omni::fabric::asInt(pxr::UsdTokens->elem);
+
+#define FABRIC_DEFINE_TOKEN(r, data, elem) \
+    BOOST_PP_TUPLE_ELEM(1, 0, BOOST_PP_IIF(TF_PP_IS_TUPLE(elem), \
+        (FABRIC_DEFINE_TOKEN_ELEM(BOOST_PP_TUPLE_ELEM(2, 0, elem))), \
+        (FABRIC_DEFINE_TOKEN_ELEM(elem))))
+
+#define FABRIC_DEFINE_TOKENS(seq) BOOST_PP_SEQ_FOR_EACH(FABRIC_DEFINE_TOKEN, ~, seq)
+
+#define FABRIC_DECLARE_TOKEN_ELEM(elem) extern const omni::fabric::TokenC elem;
+
+#define FABRIC_DECLARE_TOKEN(r, data, elem) \
+    BOOST_PP_TUPLE_ELEM(1, 0, BOOST_PP_IIF(TF_PP_IS_TUPLE(elem), \
+        (FABRIC_DECLARE_TOKEN_ELEM(BOOST_PP_TUPLE_ELEM(2, 0, elem))), \
+        (FABRIC_DECLARE_TOKEN_ELEM(elem))))
+
+#define FABRIC_DECLARE_TOKENS(seq) BOOST_PP_SEQ_FOR_EACH(FABRIC_DECLARE_TOKEN, ~, seq)
+
+#ifdef CESIUM_OMNI_MSVC
+__pragma(warning(pop))
+#endif
+
 }
 
-namespace cesium::omniverse::UsdTokens {
-extern const pxr::TfToken& baseColorTexture;
-extern const pxr::TfToken& cesium_material;
-extern const pxr::TfToken& cesium_texture_lookup;
-extern const pxr::TfToken& constant;
-extern const pxr::TfToken& doubleSided;
-extern const pxr::TfToken& extent;
-extern const pxr::TfToken& faceVertexCounts;
-extern const pxr::TfToken& faceVertexIndices;
-extern const pxr::TfToken& info_implementationSource;
-extern const pxr::TfToken& info_mdl_sourceAsset;
-extern const pxr::TfToken& info_mdl_sourceAsset_subIdentifier;
-extern const pxr::TfToken& inputs_alpha_cutoff;
-extern const pxr::TfToken& inputs_alpha_mode;
-extern const pxr::TfToken& inputs_base_alpha;
-extern const pxr::TfToken& inputs_base_color_factor;
-extern const pxr::TfToken& inputs_base_color_texture;
-extern const pxr::TfToken& inputs_emissive_factor;
-extern const pxr::TfToken& inputs_excludeFromWhiteMode;
-extern const pxr::TfToken& inputs_metallic_factor;
-extern const pxr::TfToken& inputs_offset;
-extern const pxr::TfToken& inputs_rotation;
-extern const pxr::TfToken& inputs_roughness_factor;
-extern const pxr::TfToken& inputs_scale;
-extern const pxr::TfToken& inputs_tex_coord_index;
-extern const pxr::TfToken& inputs_texture;
-extern const pxr::TfToken& inputs_vertex_color_name;
-extern const pxr::TfToken& inputs_wrap_s;
-extern const pxr::TfToken& inputs_wrap_t;
-extern const pxr::TfToken& Material;
-extern const pxr::TfToken& material_binding;
-extern const pxr::TfToken& Mesh;
-extern const pxr::TfToken& none;
-extern const pxr::TfToken& out;
-extern const pxr::TfToken& outputs_mdl_displacement;
-extern const pxr::TfToken& outputs_mdl_surface;
-extern const pxr::TfToken& outputs_mdl_volume;
-extern const pxr::TfToken& outputs_out;
-extern const pxr::TfToken& points;
-extern const pxr::TfToken& primvarInterpolations;
-extern const pxr::TfToken& primvars;
-extern const pxr::TfToken& primvars_displayColor;
-extern const pxr::TfToken& primvars_displayOpacity;
-extern const pxr::TfToken& primvars_normals;
-extern const pxr::TfToken& primvars_st;
-extern const pxr::TfToken& primvars_vertexColor;
-extern const pxr::TfToken& Shader;
-extern const pxr::TfToken& sourceAsset;
-extern const pxr::TfToken& subdivisionScheme;
-extern const pxr::TfToken& vertex;
-extern const pxr::TfToken& vertexColor;
-extern const pxr::TfToken& _auto;
-extern const pxr::TfToken& _cesium_localToEcefTransform;
-extern const pxr::TfToken& _cesium_tilesetId;
-extern const pxr::TfToken& _deletedPrims;
-extern const pxr::TfToken& _paramColorSpace;
-extern const pxr::TfToken& _sdrMetadata;
-extern const pxr::TfToken& _worldExtent;
-extern const pxr::TfToken& _worldOrientation;
-extern const pxr::TfToken& _worldPosition;
-extern const pxr::TfToken& _worldScale;
-extern const pxr::TfToken& _worldVisibility;
+namespace cesium::omniverse::FabricTokens {
+FABRIC_DECLARE_TOKENS(USD_TOKENS);
 }
 
 namespace cesium::omniverse::FabricTypes {

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -323,7 +323,7 @@ void Context::processCesiumTilesetChanged(const ChangedPrim& changedPrim) {
         name == pxr::CesiumTokens->cesiumSmoothNormals ||
         name == pxr::CesiumTokens->cesiumMainThreadLoadingTimeLimit ||
         name == pxr::CesiumTokens->cesiumShowCreditsOnScreen ||
-        name == UsdTokens::material_binding) {
+        name == pxr::UsdTokens->material_binding) {
         tileset.value()->reload();
     }
     // clang-format on

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -142,11 +142,11 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
     *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_material;
 
     if (hasVertexColors) {
-        const auto vertexColorPrimvarNameSize = UsdTokens::vertexColor.GetString().size();
+        const auto vertexColorPrimvarNameSize = pxr::UsdTokens->vertexColor.GetString().size();
         srw.setArrayAttributeSize(shaderPath, FabricTokens::inputs_vertex_color_name, vertexColorPrimvarNameSize);
         auto vertexColorNameFabric =
             srw.getArrayAttributeWr<uint8_t>(shaderPath, FabricTokens::inputs_vertex_color_name);
-        memcpy(vertexColorNameFabric.data(), UsdTokens::vertexColor.GetText(), vertexColorPrimvarNameSize);
+        memcpy(vertexColorNameFabric.data(), pxr::UsdTokens->vertexColor.GetText(), vertexColorPrimvarNameSize);
     }
 
     // Connect the material terminals to the shader.

--- a/src/core/src/Tokens.cpp
+++ b/src/core/src/Tokens.cpp
@@ -1,82 +1,16 @@
 #include "cesium/omniverse/Tokens.h"
 
-#include <omni/fabric/FabricUSD.h>
-#include <pxr/base/tf/staticTokens.h>
-
 // clang-format off
 namespace pxr {
-
-// Note: variable names should match the USD token names as closely as possible, with special characters converted to underscores
 
 #ifdef CESIUM_OMNI_MSVC
 __pragma(warning(push))
 __pragma(warning(disable: 4003))
 #endif
 
-TF_DEFINE_PRIVATE_TOKENS(
+TF_DEFINE_PUBLIC_TOKENS(
     UsdTokens,
-    (baseColorTexture)
-    (cesium_material)
-    (cesium_texture_lookup)
-    (constant)
-    (doubleSided)
-    (extent)
-    (faceVertexCounts)
-    (faceVertexIndices)
-    (Material)
-    (Mesh)
-    (none)
-    (out)
-    (points)
-    (primvarInterpolations)
-    (primvars)
-    (Shader)
-    (sourceAsset)
-    (subdivisionScheme)
-    (vertex)
-    (vertexColor)
-    (_cesium_localToEcefTransform)
-    (_cesium_tilesetId)
-    (_deletedPrims)
-    (_paramColorSpace)
-    (_sdrMetadata)
-    (_worldExtent)
-    (_worldOrientation)
-    (_worldPosition)
-    (_worldScale)
-    (_worldVisibility)
-    ((_auto, "auto"))
-    ((info_implementationSource, "info:implementationSource"))
-    ((info_mdl_sourceAsset, "info:mdl:sourceAsset"))
-    ((info_mdl_sourceAsset_subIdentifier, "info:mdl:sourceAsset:subIdentifier"))
-    ((inputs_alpha_cutoff, "inputs:alpha_cutoff"))
-    ((inputs_alpha_mode, "inputs:alpha_mode"))
-    ((inputs_base_alpha, "inputs:base_alpha"))
-    ((inputs_base_color_factor, "inputs:base_color_factor"))
-    ((inputs_base_color_texture, "inputs:base_color_texture"))
-    ((inputs_emissive_factor, "inputs:emissive_factor"))
-    ((inputs_excludeFromWhiteMode, "inputs:excludeFromWhiteMode"))
-    ((inputs_metallic_factor, "inputs:metallic_factor"))
-    ((inputs_offset, "inputs:offset"))
-    ((inputs_rotation, "inputs:rotation"))
-    ((inputs_roughness_factor, "inputs:roughness_factor"))
-    ((inputs_scale, "inputs:scale"))
-    ((inputs_tex_coord_index, "inputs:tex_coord_index"))
-    ((inputs_texture, "inputs:texture"))
-    ((inputs_vertex_color_name, "inputs:vertex_color_name"))
-    ((inputs_wrap_s, "inputs:wrap_s"))
-    ((inputs_wrap_t, "inputs:wrap_t"))
-    ((material_binding, "material:binding"))
-    ((outputs_mdl_displacement, "outputs:mdl:displacement"))
-    ((outputs_mdl_surface, "outputs:mdl:surface"))
-    ((outputs_mdl_volume, "outputs:mdl:volume"))
-    ((outputs_out, "outputs:out"))
-    ((primvars_displayColor, "primvars:displayColor"))
-    ((primvars_displayOpacity, "primvars:displayOpacity"))
-    ((primvars_normals, "primvars:normals"))
-    ((primvars_st, "primvars:st"))
-    ((primvars_vertexColor, "primvars:vertexColor"))
-);
+    USD_TOKENS);
 
 #ifdef CESIUM_OMNI_MSVC
 __pragma(warning(pop))
@@ -85,130 +19,6 @@ __pragma(warning(pop))
 }
 
 namespace cesium::omniverse::FabricTokens {
-const omni::fabric::TokenC baseColorTexture = omni::fabric::asInt(pxr::UsdTokens->baseColorTexture);
-const omni::fabric::TokenC cesium_material = omni::fabric::asInt(pxr::UsdTokens->cesium_material);
-const omni::fabric::TokenC cesium_texture_lookup = omni::fabric::asInt(pxr::UsdTokens->cesium_texture_lookup);
-const omni::fabric::TokenC constant = omni::fabric::asInt(pxr::UsdTokens->constant);
-const omni::fabric::TokenC doubleSided = omni::fabric::asInt(pxr::UsdTokens->doubleSided);
-const omni::fabric::TokenC extent = omni::fabric::asInt(pxr::UsdTokens->extent);
-const omni::fabric::TokenC faceVertexCounts = omni::fabric::asInt(pxr::UsdTokens->faceVertexCounts);
-const omni::fabric::TokenC faceVertexIndices = omni::fabric::asInt(pxr::UsdTokens->faceVertexIndices);
-const omni::fabric::TokenC info_implementationSource = omni::fabric::asInt(pxr::UsdTokens->info_implementationSource);
-const omni::fabric::TokenC info_mdl_sourceAsset = omni::fabric::asInt(pxr::UsdTokens->info_mdl_sourceAsset);
-const omni::fabric::TokenC info_mdl_sourceAsset_subIdentifier = omni::fabric::asInt(pxr::UsdTokens->info_mdl_sourceAsset_subIdentifier);
-const omni::fabric::TokenC inputs_alpha_cutoff = omni::fabric::asInt(pxr::UsdTokens->inputs_alpha_cutoff);
-const omni::fabric::TokenC inputs_alpha_mode = omni::fabric::asInt(pxr::UsdTokens->inputs_alpha_mode);
-const omni::fabric::TokenC inputs_base_alpha = omni::fabric::asInt(pxr::UsdTokens->inputs_base_alpha);
-const omni::fabric::TokenC inputs_base_color_factor = omni::fabric::asInt(pxr::UsdTokens->inputs_base_color_factor);
-const omni::fabric::TokenC inputs_base_color_texture = omni::fabric::asInt(pxr::UsdTokens->inputs_base_color_texture);
-const omni::fabric::TokenC inputs_emissive_factor = omni::fabric::asInt(pxr::UsdTokens->inputs_emissive_factor);
-const omni::fabric::TokenC inputs_excludeFromWhiteMode = omni::fabric::asInt(pxr::UsdTokens->inputs_excludeFromWhiteMode);
-const omni::fabric::TokenC inputs_metallic_factor = omni::fabric::asInt(pxr::UsdTokens->inputs_metallic_factor);
-const omni::fabric::TokenC inputs_offset = omni::fabric::asInt(pxr::UsdTokens->inputs_offset);
-const omni::fabric::TokenC inputs_rotation = omni::fabric::asInt(pxr::UsdTokens->inputs_rotation);
-const omni::fabric::TokenC inputs_roughness_factor = omni::fabric::asInt(pxr::UsdTokens->inputs_roughness_factor);
-const omni::fabric::TokenC inputs_scale = omni::fabric::asInt(pxr::UsdTokens->inputs_scale);
-const omni::fabric::TokenC inputs_tex_coord_index = omni::fabric::asInt(pxr::UsdTokens->inputs_tex_coord_index);
-const omni::fabric::TokenC inputs_texture = omni::fabric::asInt(pxr::UsdTokens->inputs_texture);
-const omni::fabric::TokenC inputs_vertex_color_name = omni::fabric::asInt(pxr::UsdTokens->inputs_vertex_color_name);
-const omni::fabric::TokenC inputs_wrap_s = omni::fabric::asInt(pxr::UsdTokens->inputs_wrap_s);
-const omni::fabric::TokenC inputs_wrap_t = omni::fabric::asInt(pxr::UsdTokens->inputs_wrap_t);
-const omni::fabric::TokenC Material = omni::fabric::asInt(pxr::UsdTokens->Material);
-const omni::fabric::TokenC material_binding = omni::fabric::asInt(pxr::UsdTokens->material_binding);
-const omni::fabric::TokenC Mesh = omni::fabric::asInt(pxr::UsdTokens->Mesh);
-const omni::fabric::TokenC none = omni::fabric::asInt(pxr::UsdTokens->none);
-const omni::fabric::TokenC out = omni::fabric::asInt(pxr::UsdTokens->out);
-const omni::fabric::TokenC outputs_mdl_displacement = omni::fabric::asInt(pxr::UsdTokens->outputs_mdl_displacement);
-const omni::fabric::TokenC outputs_mdl_surface = omni::fabric::asInt(pxr::UsdTokens->outputs_mdl_surface);
-const omni::fabric::TokenC outputs_mdl_volume = omni::fabric::asInt(pxr::UsdTokens->outputs_mdl_volume);
-const omni::fabric::TokenC outputs_out = omni::fabric::asInt(pxr::UsdTokens->outputs_out);
-const omni::fabric::TokenC points = omni::fabric::asInt(pxr::UsdTokens->points);
-const omni::fabric::TokenC primvarInterpolations = omni::fabric::asInt(pxr::UsdTokens->primvarInterpolations);
-const omni::fabric::TokenC primvars = omni::fabric::asInt(pxr::UsdTokens->primvars);
-const omni::fabric::TokenC primvars_displayColor = omni::fabric::asInt(pxr::UsdTokens->primvars_displayColor);
-const omni::fabric::TokenC primvars_displayOpacity = omni::fabric::asInt(pxr::UsdTokens->primvars_displayOpacity);
-const omni::fabric::TokenC primvars_normals = omni::fabric::asInt(pxr::UsdTokens->primvars_normals);
-const omni::fabric::TokenC primvars_st = omni::fabric::asInt(pxr::UsdTokens->primvars_st);
-const omni::fabric::TokenC primvars_vertexColor = omni::fabric::asInt(pxr::UsdTokens->primvars_vertexColor);
-const omni::fabric::TokenC Shader = omni::fabric::asInt(pxr::UsdTokens->Shader);
-const omni::fabric::TokenC sourceAsset = omni::fabric::asInt(pxr::UsdTokens->sourceAsset);
-const omni::fabric::TokenC subdivisionScheme = omni::fabric::asInt(pxr::UsdTokens->subdivisionScheme);
-const omni::fabric::TokenC vertex = omni::fabric::asInt(pxr::UsdTokens->vertex);
-const omni::fabric::TokenC vertexColor = omni::fabric::asInt(pxr::UsdTokens->vertexColor);
-const omni::fabric::TokenC _auto = omni::fabric::asInt(pxr::UsdTokens->_auto);
-const omni::fabric::TokenC _cesium_localToEcefTransform = omni::fabric::asInt(pxr::UsdTokens->_cesium_localToEcefTransform);
-const omni::fabric::TokenC _cesium_tilesetId = omni::fabric::asInt(pxr::UsdTokens->_cesium_tilesetId);
-const omni::fabric::TokenC _deletedPrims = omni::fabric::asInt(pxr::UsdTokens->_deletedPrims);
-const omni::fabric::TokenC _paramColorSpace = omni::fabric::asInt(pxr::UsdTokens->_paramColorSpace);
-const omni::fabric::TokenC _sdrMetadata = omni::fabric::asInt(pxr::UsdTokens->_sdrMetadata);
-const omni::fabric::TokenC _worldExtent = omni::fabric::asInt(pxr::UsdTokens->_worldExtent);
-const omni::fabric::TokenC _worldOrientation = omni::fabric::asInt(pxr::UsdTokens->_worldOrientation);
-const omni::fabric::TokenC _worldPosition = omni::fabric::asInt(pxr::UsdTokens->_worldPosition);
-const omni::fabric::TokenC _worldScale = omni::fabric::asInt(pxr::UsdTokens->_worldScale);
-const omni::fabric::TokenC _worldVisibility = omni::fabric::asInt(pxr::UsdTokens->_worldVisibility);
-}
-
-namespace cesium::omniverse::UsdTokens {
-const pxr::TfToken& baseColorTexture = pxr::UsdTokens->baseColorTexture;
-const pxr::TfToken& cesium_material = pxr::UsdTokens->cesium_material;
-const pxr::TfToken& cesium_texture_lookup = pxr::UsdTokens->cesium_texture_lookup;
-const pxr::TfToken& constant = pxr::UsdTokens->constant;
-const pxr::TfToken& doubleSided = pxr::UsdTokens->doubleSided;
-const pxr::TfToken& extent = pxr::UsdTokens->extent;
-const pxr::TfToken& faceVertexCounts = pxr::UsdTokens->faceVertexCounts;
-const pxr::TfToken& faceVertexIndices = pxr::UsdTokens->faceVertexIndices;
-const pxr::TfToken& info_implementationSource = pxr::UsdTokens->info_implementationSource;
-const pxr::TfToken& info_mdl_sourceAsset = pxr::UsdTokens->info_mdl_sourceAsset;
-const pxr::TfToken& info_mdl_sourceAsset_subIdentifier = pxr::UsdTokens->info_mdl_sourceAsset_subIdentifier;
-const pxr::TfToken& inputs_alpha_cutoff = pxr::UsdTokens->inputs_alpha_cutoff;
-const pxr::TfToken& inputs_alpha_mode = pxr::UsdTokens->inputs_alpha_mode;
-const pxr::TfToken& inputs_base_alpha = pxr::UsdTokens->inputs_base_alpha;
-const pxr::TfToken& inputs_base_color_factor = pxr::UsdTokens->inputs_base_color_factor;
-const pxr::TfToken& inputs_base_color_texture = pxr::UsdTokens->inputs_base_color_texture;
-const pxr::TfToken& inputs_emissive_factor = pxr::UsdTokens->inputs_emissive_factor;
-const pxr::TfToken& inputs_excludeFromWhiteMode = pxr::UsdTokens->inputs_excludeFromWhiteMode;
-const pxr::TfToken& inputs_metallic_factor = pxr::UsdTokens->inputs_metallic_factor;
-const pxr::TfToken& inputs_offset = pxr::UsdTokens->inputs_offset;
-const pxr::TfToken& inputs_rotation = pxr::UsdTokens->inputs_rotation;
-const pxr::TfToken& inputs_roughness_factor = pxr::UsdTokens->inputs_roughness_factor;
-const pxr::TfToken& inputs_scale = pxr::UsdTokens->inputs_scale;
-const pxr::TfToken& inputs_tex_coord_index = pxr::UsdTokens->inputs_tex_coord_index;
-const pxr::TfToken& inputs_texture = pxr::UsdTokens->inputs_texture;
-const pxr::TfToken& inputs_vertex_color_name = pxr::UsdTokens->inputs_vertex_color_name;
-const pxr::TfToken& inputs_wrap_s = pxr::UsdTokens->inputs_wrap_s;
-const pxr::TfToken& inputs_wrap_t = pxr::UsdTokens->inputs_wrap_t;
-const pxr::TfToken& Material = pxr::UsdTokens->Material;
-const pxr::TfToken& material_binding = pxr::UsdTokens->material_binding;
-const pxr::TfToken& Mesh = pxr::UsdTokens->Mesh;
-const pxr::TfToken& none = pxr::UsdTokens->none;
-const pxr::TfToken& out = pxr::UsdTokens->out;
-const pxr::TfToken& outputs_mdl_displacement = pxr::UsdTokens->outputs_mdl_displacement;
-const pxr::TfToken& outputs_mdl_surface = pxr::UsdTokens->outputs_mdl_surface;
-const pxr::TfToken& outputs_mdl_volume = pxr::UsdTokens->outputs_mdl_volume;
-const pxr::TfToken& outputs_out = pxr::UsdTokens->outputs_out;
-const pxr::TfToken& points = pxr::UsdTokens->points;
-const pxr::TfToken& primvarInterpolations = pxr::UsdTokens->primvarInterpolations;
-const pxr::TfToken& primvars = pxr::UsdTokens->primvars;
-const pxr::TfToken& primvars_displayColor = pxr::UsdTokens->primvars_displayColor;
-const pxr::TfToken& primvars_displayOpacity = pxr::UsdTokens->primvars_displayOpacity;
-const pxr::TfToken& primvars_normals = pxr::UsdTokens->primvars_normals;
-const pxr::TfToken& primvars_st = pxr::UsdTokens->primvars_st;
-const pxr::TfToken& primvars_vertexColor = pxr::UsdTokens->primvars_vertexColor;
-const pxr::TfToken& Shader = pxr::UsdTokens->Shader;
-const pxr::TfToken& sourceAsset = pxr::UsdTokens->sourceAsset;
-const pxr::TfToken& subdivisionScheme = pxr::UsdTokens->subdivisionScheme;
-const pxr::TfToken& vertex = pxr::UsdTokens->vertex;
-const pxr::TfToken& vertexColor = pxr::UsdTokens->vertexColor;
-const pxr::TfToken& _auto = pxr::UsdTokens->_auto;
-const pxr::TfToken& _cesium_localToEcefTransform = pxr::UsdTokens->_cesium_localToEcefTransform;
-const pxr::TfToken& _cesium_tilesetId = pxr::UsdTokens->_cesium_tilesetId;
-const pxr::TfToken& _deletedPrims = pxr::UsdTokens->_deletedPrims;
-const pxr::TfToken& _paramColorSpace = pxr::UsdTokens->_paramColorSpace;
-const pxr::TfToken& _sdrMetadata = pxr::UsdTokens->_sdrMetadata;
-const pxr::TfToken& _worldExtent = pxr::UsdTokens->_worldExtent;
-const pxr::TfToken& _worldOrientation = pxr::UsdTokens->_worldOrientation;
-const pxr::TfToken& _worldPosition = pxr::UsdTokens->_worldPosition;
-const pxr::TfToken& _worldScale = pxr::UsdTokens->_worldScale;
-const pxr::TfToken& _worldVisibility = pxr::UsdTokens->_worldVisibility;
+FABRIC_DEFINE_TOKENS(USD_TOKENS);
 }
 // clang-format on


### PR DESCRIPTION
The previous approach for adding new tokens was overly complex, requiring changes in 5 different places within `Tokens.h` and `Tokens.cpp`. Now it's as simple as adding a new token to `USD_TOKENS` and letting the macros do the rest of the work.

USD tokens are now created in a more standard way with `TF_DECLARE_PUBLIC_TOKENS` and `TF_DEFINE_PUBLIC_TOKENS` and are accessed as `pxr::UsdTokens->tokenName`.

Fabric tokens are created with `FABRIC_DECLARE_TOKENS` and `FABRIC_DEFINE_TOKENS` which are inspired by the pxr macros and are accessed as `FabricTokens::tokenName` like before.