### PR TITLE
Clean up Fabric token and path usage

### DIFF
--- a/src/core/include/cesium/omniverse/FabricAttributesBuilder.h
+++ b/src/core/include/cesium/omniverse/FabricAttributesBuilder.h
@@ -6,7 +6,7 @@ namespace cesium::omniverse {
 
 class FabricAttributesBuilder {
   public:
-    void addAttribute(const omni::fabric::Type& type, const omni::fabric::TokenC& name);
+    void addAttribute(const omni::fabric::Type& type, const omni::fabric::Token& name);
     void createAttributes(const omni::fabric::Path& path) const;
 
   private:

--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -35,7 +35,7 @@ class FabricGeometry {
     void setActive(bool active);
     void setVisibility(bool visible);
 
-    [[nodiscard]] omni::fabric::Path getPath() const;
+    [[nodiscard]] const omni::fabric::Path& getPath() const;
     [[nodiscard]] const FabricGeometryDefinition& getGeometryDefinition() const;
 
     void setMaterial(const omni::fabric::Path& materialPath);

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -31,7 +31,7 @@ class FabricMaterial {
 
     void setActive(bool active);
 
-    [[nodiscard]] omni::fabric::Path getPath() const;
+    [[nodiscard]] const omni::fabric::Path& getPath() const;
     [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
 
   private:

--- a/src/core/src/FabricAttributesBuilder.cpp
+++ b/src/core/src/FabricAttributesBuilder.cpp
@@ -3,7 +3,7 @@
 #include "cesium/omniverse/UsdUtil.h"
 
 namespace cesium::omniverse {
-void FabricAttributesBuilder::addAttribute(const omni::fabric::Type& type, const omni::fabric::TokenC& name) {
+void FabricAttributesBuilder::addAttribute(const omni::fabric::Type& type, const omni::fabric::Token& name) {
     assert(_size < MAX_ATTRIBUTES);
     _attributes[_size++] = omni::fabric::AttrNameAndType{type, name};
 }

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -79,7 +79,7 @@ void FabricGeometry::setVisibility(bool visible) {
     *worldVisibilityFabric = visible;
 }
 
-omni::fabric::Path FabricGeometry::getPath() const {
+const omni::fabric::Path& FabricGeometry::getPath() const {
     return _path;
 }
 
@@ -94,8 +94,8 @@ void FabricGeometry::setMaterial(const omni::fabric::Path& materialPath) {
 
     auto srw = UsdUtil::getFabricStageReaderWriter();
     srw.setArrayAttributeSize(_path, FabricTokens::material_binding, 1);
-    auto materialBindingFabric = srw.getArrayAttributeWr<uint64_t>(_path, FabricTokens::material_binding);
-    materialBindingFabric[0] = omni::fabric::PathC(materialPath).path;
+    auto materialBindingFabric = srw.getArrayAttributeWr<omni::fabric::PathC>(_path, FabricTokens::material_binding);
+    materialBindingFabric[0] = materialPath;
 }
 
 void FabricGeometry::initialize() {
@@ -145,7 +145,7 @@ void FabricGeometry::initialize() {
 
     // clang-format off
     auto doubleSidedFabric = srw.getAttributeWr<bool>(_path, FabricTokens::doubleSided);
-    auto subdivisionSchemeFabric = srw.getAttributeWr<omni::fabric::Token>(_path, FabricTokens::subdivisionScheme);
+    auto subdivisionSchemeFabric = srw.getAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::subdivisionScheme);
     // clang-format on
 
     *doubleSidedFabric = doubleSided;
@@ -178,8 +178,8 @@ void FabricGeometry::initialize() {
     srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayOpacity, 1);
 
     // clang-format off
-    auto primvarsFabric = srw.getArrayAttributeWr<omni::fabric::Token>(_path, FabricTokens::primvars);
-    auto primvarInterpolationsFabric = srw.getArrayAttributeWr<omni::fabric::Token>(_path, FabricTokens::primvarInterpolations);
+    auto primvarsFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::primvars);
+    auto primvarInterpolationsFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::primvarInterpolations);
     // clang-format on
 
     primvarsFabric[primvarIndexDisplayColor] = FabricTokens::primvars_displayColor;

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -52,7 +52,7 @@ void FabricMaterial::setActive(bool active) {
     }
 }
 
-omni::fabric::Path FabricMaterial::getPath() const {
+const omni::fabric::Path& FabricMaterial::getPath() const {
     return _materialPath;
 }
 
@@ -130,9 +130,9 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
 
     // clang-format off
     auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(shaderPath, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::Token>(shaderPath, FabricTokens::info_implementationSource);
+    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(shaderPath, FabricTokens::info_implementationSource);
     auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(shaderPath, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::Token>(shaderPath, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(shaderPath, FabricTokens::info_mdl_sourceAsset_subIdentifier);
     // clang-format on
 
     *inputsExcludeFromWhiteModeFabric = false;
@@ -153,15 +153,15 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
     srw.createConnection(
         materialPath,
         FabricTokens::outputs_mdl_surface,
-        omni::fabric::Connection{omni::fabric::PathC(shaderPath), FabricTokens::outputs_out});
+        omni::fabric::Connection{shaderPath, FabricTokens::outputs_out});
     srw.createConnection(
         materialPath,
         FabricTokens::outputs_mdl_displacement,
-        omni::fabric::Connection{omni::fabric::PathC(shaderPath), FabricTokens::outputs_out});
+        omni::fabric::Connection{shaderPath, FabricTokens::outputs_out});
     srw.createConnection(
         materialPath,
         FabricTokens::outputs_mdl_volume,
-        omni::fabric::Connection{omni::fabric::PathC(shaderPath), FabricTokens::outputs_out});
+        omni::fabric::Connection{shaderPath, FabricTokens::outputs_out});
 }
 
 void FabricMaterial::createTexture(
@@ -201,10 +201,10 @@ void FabricMaterial::createTexture(
 
     // clang-format off
     auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(texturePath, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::Token>(texturePath, FabricTokens::info_implementationSource);
+    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(texturePath, FabricTokens::info_implementationSource);
     auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(texturePath, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::Token>(texturePath, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    auto paramColorSpaceFabric = srw.getArrayAttributeWr<omni::fabric::Token>(texturePath, FabricTokens::_paramColorSpace);
+    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(texturePath, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    auto paramColorSpaceFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(texturePath, FabricTokens::_paramColorSpace);
     // clang-format on
 
     *inputsExcludeFromWhiteModeFabric = false;
@@ -216,8 +216,7 @@ void FabricMaterial::createTexture(
     paramColorSpaceFabric[1] = FabricTokens::_auto;
 
     // Create connection from shader to texture.
-    srw.createConnection(
-        shaderPath, shaderInput, omni::fabric::Connection{omni::fabric::PathC(texturePath), FabricTokens::outputs_out});
+    srw.createConnection(shaderPath, shaderInput, omni::fabric::Connection{texturePath, FabricTokens::outputs_out});
 }
 
 void FabricMaterial::reset() {

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -23,14 +23,14 @@ const char* const TYPE_NOT_SUPPORTED_STRING = "[Type Not Supported]";
 // Wraps the token type so that we can define a custom stream insertion operator
 class TokenWrapper {
   private:
-    omni::fabric::Token token;
+    omni::fabric::TokenC token;
 
   public:
     friend std::ostream& operator<<(std::ostream& os, const TokenWrapper& tokenWrapper);
 };
 
 std::ostream& operator<<(std::ostream& os, const TokenWrapper& tokenWrapper) {
-    os << tokenWrapper.token.getString();
+    os << omni::fabric::Token(tokenWrapper.token).getString();
     return os;
 }
 
@@ -614,15 +614,16 @@ void destroyPrim(const omni::fabric::Path& path) {
     // This workaround may not be needed in future Kit versions, but is needed as of Kit 105.0
     const omni::fabric::Path changeTrackingPath("/TempChangeTracking");
 
-    if (srw.getAttribute<uint64_t>(changeTrackingPath, FabricTokens::_deletedPrims) == nullptr) {
+    if (srw.getAttributeRd<omni::fabric::PathC>(changeTrackingPath, FabricTokens::_deletedPrims) == nullptr) {
         return;
     }
 
     const auto deletedPrimsSize = srw.getArrayAttributeSize(changeTrackingPath, FabricTokens::_deletedPrims);
     srw.setArrayAttributeSize(changeTrackingPath, FabricTokens::_deletedPrims, deletedPrimsSize + 1);
-    auto deletedPrimsFabric = srw.getArrayAttributeWr<uint64_t>(changeTrackingPath, FabricTokens::_deletedPrims);
+    auto deletedPrimsFabric =
+        srw.getArrayAttributeWr<omni::fabric::PathC>(changeTrackingPath, FabricTokens::_deletedPrims);
 
-    deletedPrimsFabric[deletedPrimsSize] = omni::fabric::PathC(path).path;
+    deletedPrimsFabric[deletedPrimsSize] = path;
 }
 
 void setTilesetTransform(int64_t tilesetId, const glm::dmat4& ecefToUsdTransform) {


### PR DESCRIPTION
I'm always a bit weary of how we're handling tokens and paths because they're reference counted and can lead to hard to fix bugs if handled incorrectly. So I swept through the code and tried to standardize on some better practices for dealing with tokens and paths.

* Changed `getAttribute` calls so that they return `TokenC` instead of `Token`. This makes token lifetime a bit clearer. There's no need to use the reference counted type when Fabric is just going to memcpy the value. Technically we could use `uint64_t` everywhere but it's clearer if we use `TokenC` which is a simple struct wrapper around a `uint64_t`. Same reason for switching to `PatchC` instead of `Path` whenever we're getting or setting Fabric data.
* In all other places, let Fabric do implicit conversions between `Token`/`TokenC` and `Path`/`PathC` instead of doing it ourselves
* Return const references to paths in a few areas

There will probably be some follow ups as I investigate https://github.com/CesiumGS/cesium-omniverse/issues/425