### PR TITLE
increase window wait for ui tests until window doesn't require delay

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/tests/extension_test.py
+++ b/exts/cesium.omniverse/cesium/omniverse/tests/extension_test.py
@@ -13,6 +13,12 @@ _window_ref: Optional[ui_test.WidgetRef] = None
 class ExtensionTest(omni.kit.test.AsyncTestCase):
     async def setUp(self):
         global _window_ref
+
+        # can be removed (or at least decreased) once there is no delay
+        # required before spawning the cesium window. See:
+        # https://github.com/CesiumGS/cesium-omniverse/pull/423
+        await ui_test.wait_n_updates(24)
+
         _window_ref = ui_test.find("Cesium")
 
     async def tearDown(self):
@@ -27,7 +33,6 @@ class ExtensionTest(omni.kit.test.AsyncTestCase):
         # docked is false if the window is not in focus,
         # as may be the case if other extensions are loaded
         await _window_ref.focus()
-        await ui_test.wait_n_updates(4)
         self.assertTrue(_window_ref.window.docked)
 
     async def test_blank_tileset(self):


### PR DESCRIPTION
fixes #437 . The delay introduced in spawning the cesium window in #423 caused UI tests to run before the windows had actually spawned. Adding a timeout to the tests with a comment for context