### PR TITLE
Temporarily disabling CentOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,17 +36,18 @@ jobs:
               generator: 'Unix Makefiles',
               coverage: 'false',
             }
-          - {
-              name: 'CentOS 7 - GCC',
-              artifact: 'linux-gcc.tar.xz',
-              os: ubuntu-latest-m,
-              cc: 'gcc-11',
-              cxx: 'g++-11',
-              build-type: 'Release',
-              build-code: 'CentOS7',
-              generator: 'Unix Makefiles',
-              coverage: 'false',
-            }
+# Temporarily disabling CentOS builds while we figure out why they're so slow.
+#          - {
+#              name: 'CentOS 7 - GCC',
+#              artifact: 'linux-gcc.tar.xz',
+#              os: ubuntu-latest-m,
+#              cc: 'gcc-11',
+#              cxx: 'g++-11',
+#              build-type: 'Release',
+#              build-code: 'CentOS7',
+#              generator: 'Unix Makefiles',
+#              coverage: 'false',
+#            }
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
CentOS builds have an issue which is causing them to be very slow, which is clogging up the pipeline. Temporarily disabling while we figure out what is wrong.