### PR TITLE
partial fix for performance test crashes

### DIFF
--- a/apps/cesium.performance.kit
+++ b/apps/cesium.performance.kit
@@ -9,3 +9,11 @@ app = true
 
 [settings]
 app.window.title = "Cesium For Omniverse Performance Testing App"
+
+[settings.app.exts]
+folders.'++' = [
+    "${app}", # Find other applications in this folder
+    "${app}/exts", # Find extensions in this folder
+    "${app}/../exts", # Find cesium.omniverse and cesium.usd.schemas
+    "${app}/../extern/nvidia/app/extscache" # Find omni.kit.window.material_graph
+]


### PR DESCRIPTION
partial fix for #450. @lilleyse found that this allows the performace app to load without crashing. CI appears to be failing for server-side issues, I'll retry those jobs shortly