### PR TITLE
Fix USD Composer symlink

### DIFF
--- a/extern/nvidia/scripts/link_app.py
+++ b/extern/nvidia/scripts/link_app.py
@@ -9,7 +9,7 @@ import urllib3
 def find_omniverse_apps():
     http = urllib3.PoolManager()
     try:
-        r = http.request("GET", "http://127.0.0.1:33480/components")
+        r = http.request("GET", "http://localhost:33480/components")
     except Exception as e:
         print(f"Failed retrieving apps from an Omniverse Launcher, maybe it is not installed?\nError: {e}")
         sys.exit(1)


### PR DESCRIPTION
@corybarr and I both had trouble symlinking to USD Composer in Windows, possibly due to IPv4 vs. IPv6 configuration on our machines.

Fixed by using `localhost` instead of `127.0.0.1` in `link_app.py`.