### PR TITLE
Revert #417 to help fix crashes

### DIFF
--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -133,10 +133,6 @@ void FabricResourceManager::releaseGeometry(const std::shared_ptr<FabricGeometry
     const auto geometryPool = getGeometryPool(geometry->getGeometryDefinition());
     assert(geometryPool != nullptr);
     geometryPool->release(geometry);
-
-    if (geometryPool->isEmpty()) {
-        removePool(_geometryPools, geometryPool);
-    }
 }
 
 void FabricResourceManager::releaseMaterial(const std::shared_ptr<FabricMaterial>& material) {
@@ -149,10 +145,6 @@ void FabricResourceManager::releaseMaterial(const std::shared_ptr<FabricMaterial
     const auto materialPool = getMaterialPool(material->getMaterialDefinition());
     assert(materialPool != nullptr);
     materialPool->release(material);
-
-    if (materialPool->isEmpty()) {
-        removePool(_materialPools, materialPool);
-    }
 }
 
 void FabricResourceManager::releaseTexture(const std::shared_ptr<FabricTexture>& texture) {
@@ -165,10 +157,6 @@ void FabricResourceManager::releaseTexture(const std::shared_ptr<FabricTexture>&
     const auto texturePool = getTexturePool();
     assert(texturePool != nullptr);
     texturePool->release(texture);
-
-    if (texturePool->isEmpty()) {
-        removePool(_texturePools, texturePool);
-    }
 }
 
 void FabricResourceManager::setDisableMaterials(bool disableMaterials) {


### PR DESCRIPTION
This PR should help mitigate the amount of crashes we're seeing in https://github.com/CesiumGS/cesium-omniverse/issues/444.

Until we can understand https://github.com/CesiumGS/cesium-omniverse/issues/444 better, the best thing to do is to revert https://github.com/CesiumGS/cesium-omniverse/pull/417 so that prims are reused rather than recreated when reloading a tileset.

This doesn't completely address #444 because it could still crash when a tileset is added for the first time or if the material pool grows.