### PR TITLE
Add CUDA to build system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.config.name != 'CentOS 7 - GCC' }}
         run: |
           sudo apt update
-          sudo apt install -y doxygen clang-tidy-14 gcovr
+          sudo apt install -y doxygen clang-tidy-14 gcovr nvidia-driver-535
           sudo pip3 install conan==1.58.0 black==23.1.0 flake8==6.0.0
 
       # Could not figure out how to add Chocolatey libraries to the PATH automatically with refreshenv, so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,7 +537,7 @@ set(INSTALL_PRE_EXCLUDE_REGEXES "api-ms-*" "ext-ms-*" "cuda")
 set(INSTALL_POST_EXCLUDE_REGEXES "system32" "^\/lib")
 
 # Skip all runtime dependencies except nvrtc when installing to exts/cesium-omniverse/bin
-set(INSTALL_PRE_INCLUDE_REGEXES "nvtrc")
+set(INSTALL_PRE_INCLUDE_REGEXES "nvrtc")
 
 install(
     TARGETS CesiumUsdSchemas

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,8 +532,12 @@ execute_process(COMMAND "${Python3_EXECUTABLE}" "${SCRIPTS_DIRECTORY}/update_cer
 
 get_property(INSTALL_SEARCH_PATHS GLOBAL PROPERTY NVIDIA_ADDITIONAL_SEARCH_PATHS_PROPERTY)
 
-set(INSTALL_PRE_EXCLUDE_REGEXES "api-ms-*" "ext-ms-*")
+# Skip system libraries when running install
+set(INSTALL_PRE_EXCLUDE_REGEXES "api-ms-*" "ext-ms-*" "cuda")
 set(INSTALL_POST_EXCLUDE_REGEXES "system32" "^\/lib")
+
+# Skip all runtime dependencies except nvrtc when installing to exts/cesium-omniverse/bin
+set(INSTALL_PRE_INCLUDE_REGEXES "nvtrc")
 
 install(
     TARGETS CesiumUsdSchemas
@@ -562,6 +566,13 @@ install(
 
 install(
     TARGETS cesium.omniverse.plugin
+            RUNTIME_DEPENDENCIES
+            PRE_INCLUDE_REGEXES
+            ${INSTALL_PRE_INCLUDE_REGEXES}
+            PRE_EXCLUDE_REGEXES
+            ".*"
+            POST_EXCLUDE_REGEXES
+            ${INSTALL_POST_EXCLUDE_REGEXES}
     ARCHIVE DESTINATION ${KIT_EXTENSION_BIN_PATH} COMPONENT install
     LIBRARY DESTINATION ${KIT_EXTENSION_BIN_PATH} COMPONENT install
     RUNTIME DESTINATION ${KIT_EXTENSION_BIN_PATH} COMPONENT install)

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -1,4 +1,4 @@
-FROM cesiumgs/omniverse-centos7-build:2023-08-29
+FROM cesiumgs/omniverse-centos7-build:2023-09-05
 
 WORKDIR /var/app
 

--- a/docker/CentOS7.Dockerfile
+++ b/docker/CentOS7.Dockerfile
@@ -4,7 +4,10 @@ FROM centos:7
 
 RUN yum update -y -q
 
-# extra repositories that have newer versions of some packages
+# Add nvidia repository
+RUN yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+
+# Extra repositories that have newer versions of some packages
 RUN yum install -y -q \
     epel-release \
     centos-release-scl
@@ -30,7 +33,8 @@ RUN yum install -y -q \
     libffi-devel \
     zlib-devel \
     sqlite-devel \
-    xz-devel
+    xz-devel \
+    nvidia-driver-branch-535.x86_64
 
 # Create links to some of the custom packages
 RUN update-alternatives --install /usr/bin/gcc gcc /opt/rh/devtoolset-11/root/usr/bin/gcc 100 && \

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -86,6 +86,7 @@ set(USDRT_ROOT "${NVIDIA_BUILD_DIR}/target-deps/usdrt")
 set(CARB_ROOT "${NVIDIA_BUILD_DIR}/target-deps/carb_sdk_plugins")
 set(KIT_SDK_ROOT "${NVIDIA_BUILD_DIR}/target-deps/kit-sdk")
 set(PYBIND11_ROOT "${NVIDIA_BUILD_DIR}/target-deps/pybind11")
+set(CUDA_ROOT "${NVIDIA_BUILD_DIR}/target-deps/cuda")
 
 set(NVIDIA_USD_LIBRARIES
     ar
@@ -253,6 +254,101 @@ add_prebuilt_project_header_only(
         pybind11
 )
 # cmake-format: on
+
+if(WIN32)
+    # cmake-format: off
+    add_prebuilt_project_import_library_only(
+        RELEASE_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        DEBUG_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        RELEASE_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib/x64"
+        DEBUG_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib/x64"
+        RELEASE_LIBRARIES
+            cuda
+        DEBUG_LIBRARIES
+            cuda
+        TARGET_NAMES
+            cuda
+    )
+    # cmake-format: on
+else()
+    # Find the directory containing libcuda.so, e.g. /usr/lib/x86_64-linux-gnu
+    find_library(
+        CUDA_DRIVER_LIB
+        cuda
+        REQUIRED
+        NO_CACHE)
+    get_filename_component(CUDA_DRIVER_DIR "${CUDA_DRIVER_LIB}" DIRECTORY)
+
+    # cmake-format: off
+    add_prebuilt_project(
+        RELEASE_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        DEBUG_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        RELEASE_LIBRARY_DIR
+            "${CUDA_DRIVER_DIR}"
+        DEBUG_LIBRARY_DIR
+            "${CUDA_DRIVER_DIR}"
+        RELEASE_LIBRARIES
+            cuda
+        DEBUG_LIBRARIES
+            cuda
+        TARGET_NAMES
+            cuda)
+    # cmake-format: on
+endif()
+
+if(WIN32)
+    # cmake-format: off
+    add_prebuilt_project(
+        RELEASE_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        DEBUG_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        RELEASE_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib/x64"
+        RELEASE_DLL_DIR
+            "${CUDA_ROOT}/cuda/bin"
+        DEBUG_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib/x64"
+        DEBUG_DLL_DIR
+            "${CUDA_ROOT}/cuda/bin"
+        RELEASE_LIBRARIES
+            nvrtc
+        DEBUG_LIBRARIES
+            nvrtc
+        RELEASE_DLL_LIBRARIES
+            nvrtc64_112_0
+        DEBUG_DLL_LIBRARIES
+            nvrtc64_112_0
+        TARGET_NAMES
+            nvrtc
+    )
+    # cmake-format: on
+else()
+    # cmake-format: off
+    add_prebuilt_project(
+        RELEASE_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        DEBUG_INCLUDE_DIR
+            "${CUDA_ROOT}"
+        RELEASE_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib64"
+        DEBUG_LIBRARY_DIR
+            "${CUDA_ROOT}/cuda/lib64"
+        RELEASE_LIBRARIES
+            nvrtc
+        DEBUG_LIBRARIES
+            nvrtc
+        TARGET_NAMES
+            nvrtc
+    )
+    # cmake-format: on
+endif()
 
 # cmake-format: off
 # omni.ui gives us access to DynamicTextureProvider.h

--- a/extern/nvidia/deps/target-deps.packman.xml
+++ b/extern/nvidia/deps/target-deps.packman.xml
@@ -6,6 +6,7 @@
     <filter include="usdrt"/>
     <filter include="carb_sdk_plugins"/>
     <filter include="pybind11"/>
+    <filter include="cuda"/>
   </import>
   <import path="../_build/target-deps/kit-sdk-debug/dev/all-deps.packman.xml">
     <filter include="nv_usd_py310_debug"/>
@@ -17,4 +18,5 @@
   <dependency name="usdrt" linkPath="../_build/target-deps/usdrt"/>
   <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins"/>
   <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11"/>
+  <dependency name="cuda" linkPath="../_build/target-deps/cuda/cuda"/>
 </project>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -86,6 +86,8 @@ setup_lib(
         carb
         omni_kit
         omni_ui
+        cuda
+        nvrtc
         pybind11
         python310
     ADDITIONAL_LIBRARIES


### PR DESCRIPTION
Adds cuda and nvrtc to the build system in preparation for @corybarr's point cloud PRs.

A couple things to note:

* We're now installing nvidia drivers on Linux CI so that we can link against libcuda.so. The reason we don't need to do this on Windows is because we can link against the import library nvcuda.lib which is provided in packman. As far as I can tell there's no equivalent workflow in Linux.
* nvrtc doesn't ship with kit so we need to install it manually in `exts/cesium.omniverse/bin` and include it in our release zip. Unfortunately this adds an extra 40MB to the zip. It would be better if we did kernel compilation at build time instead of runtime, then we could drop nvrtc. @corybarr is this possible?