### PR TITLE
Reenable CentOS 7 builds using a new container image

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: '../../docker/CentOS7.Dockerfile'
+  image: '../../docker/CI.Dockerfile'
   # Tell Conan to look for or create its build folder (.conan) in the repository's root directory
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,17 +82,6 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}/.conan
           key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v3
 
-      # The -v{num} is a cache key buster to invalidate the Docker image cache
-      - name: Load Docker image cache
-        if: matrix.config.name == 'CentOS 7 - GCC'
-        uses: jpribyl/action-docker-layer-caching@v0.1.1
-        continue-on-error: true
-        with:
-          key: docker-layer-caching-v1-${{ github.workflow }}-{hash}
-          restore-keys: |
-            docker-layer-caching-v1-${{ github.workflow }}-
-            layer-docker-layer-caching-v1-${{ github.workflow }}-
-
       - name: CentOS Build with Docker
         uses: ./.github/actions
         if: matrix.config.name == 'CentOS 7 - GCC'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,18 +36,17 @@ jobs:
               generator: 'Unix Makefiles',
               coverage: 'false',
             }
-# Temporarily disabling CentOS builds while we figure out why they're so slow.
-#          - {
-#              name: 'CentOS 7 - GCC',
-#              artifact: 'linux-gcc.tar.xz',
-#              os: ubuntu-latest-m,
-#              cc: 'gcc-11',
-#              cxx: 'g++-11',
-#              build-type: 'Release',
-#              build-code: 'CentOS7',
-#              generator: 'Unix Makefiles',
-#              coverage: 'false',
-#            }
+          - {
+              name: 'CentOS 7 - GCC',
+              artifact: 'linux-gcc.tar.xz',
+              os: ubuntu-latest-m,
+              cc: 'gcc-11',
+              cxx: 'g++-11',
+              build-type: 'Release',
+              build-code: 'CentOS7',
+              generator: 'Unix Makefiles',
+              coverage: 'false',
+            }
 
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +89,9 @@ jobs:
         continue-on-error: true
         with:
           key: docker-layer-caching-v1-${{ github.workflow }}-{hash}
-          restore-keys: docker-layer-caching-v1-${{ github.workflow }}-
+          restore-keys: |
+            docker-layer-caching-v1-${{ github.workflow }}-
+            layer-docker-layer-caching-v1-${{ github.workflow }}-
 
       - name: CentOS Build with Docker
         uses: ./.github/actions

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -1,0 +1,5 @@
+FROM cesiumgs/omniverse-centos7-build:2023-08-29
+
+WORKDIR /var/app
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/CentOS7.Dockerfile
+++ b/docker/CentOS7.Dockerfile
@@ -1,3 +1,5 @@
+# This is used to generate the image with dependencies that CI.Dockerfile relies on.
+# For instructions for deploying this, check docs/release-guide/push-docker-image.md.
 FROM centos:7
 
 RUN yum update -y -q

--- a/docs/release-guide/push-docker-image.md
+++ b/docs/release-guide/push-docker-image.md
@@ -1,0 +1,49 @@
+# Pushing the Docker Image for CentOS 7 builds.
+
+We use a docker image for our CentOS 7 builds that contains all of our build dependencies, so we don't have to build the image from scratch on each build. This document outlines how to build and push this to Docker Hub.
+
+## Installing Docker
+
+Install [Docker Desktop](https://docs.docker.com/desktop/install/ubuntu/). You will need a license for this and access to our account.
+
+On Linux, docker is run as root. To avoid the requirement for `sudo`, you should add your user to the `docker` group:
+
+```shell
+sudo usermod -aG docker $USER
+```
+
+## Building the container
+
+Confirm that you have push access to the [container repo](https://hub.docker.com/r/cesiumgs/omniverse-centos7-build).
+
+### Log in
+
+Log into docker using:
+
+```shell
+docker login
+```
+
+### Build the docker image
+
+After making your changes to the docker file, execute:
+
+```shell
+docker build --tag cesiumgs/omniverse-centos7-build:$TAGNAME -f docker/CentOS7.Dockerfile . --no-cache
+```
+
+You should replace `TAGNAME` with the current date in `YYYY-MM-DD` format. So if it's the 29th of August, 2023, you would use `2023-08-29`.
+
+### Push the image to Docker Hub
+
+The build will take some time. Once it is finished, execute the following to push the image to Docker Hub:
+
+```shell
+docker push cesiumgs/omniverse-centos7-build:$TAGNAME
+```
+
+Again, you should replace `$TAGNAME` with the current date in `YYYY-MM-DD` format. So if it's the 29th of August, 2023, you would use `2023-08-29`.
+
+### Update CI.Dockerfile
+
+The `docker/CI.Dockerfile` file is used as part of the CentOS build step in our GitHub actions. You will need to update the version of the Docker image used to the tagged version you just uploaded.


### PR DESCRIPTION
Resolves #449.

As discussed in CesiumGS/engineering/issues/218, a new container image has been created for CentOS 7 builds which uses a new container image to prevent us having to rebuild the Docker image on every single build. This should drastically speed up the CentOS build process.

I've added a file at `docs/release-guide/push-docker-image.md` that contains some instructions on how to rebuild this image. Currently this requires access to our Docker Hub account so it costs the company money, and just @lilleyse and I can do this for now. In the future if we decide we need more people to be able to handle this task we can request Docker access for them then.