### PR TITLE
Reuse materials where possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,16 @@
 
 ### v0.10.0 - 2023-09-01
 
-* Added basic point cloud support
-* Fixed loading extension in Omniverse Code 2023.1.1
-* Fixed crashes when reloading tileset
-* Fixed memory leak when removing tileset mid-load
-* Fixed several other bugs related to removing tilesets mid-load
-* Upgraded to cesium-native v0.26.0
+* Reduced the number of materials created when loading untextured tilesets.
+
+### v0.10.0 - 2023-09-01
+
+* Added basic point cloud support.
+* Fixed loading extension in Omniverse Code 2023.1.1.
+* Fixed crashes when reloading tileset.
+* Fixed memory leak when removing tileset mid-load.
+* Fixed several other bugs related to removing tilesets mid-load.
+* Upgraded to cesium-native v0.26.0.
 
 ### v0.9.0 - 2023-08-01
 

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -15,6 +15,7 @@ class FabricMaterialDefinition {
     [[nodiscard]] bool hasBaseColorTexture() const;
     [[nodiscard]] bool hasVertexColors() const;
 
+    // Make sure to update this function when adding new fields to the class
     bool operator==(const FabricMaterialDefinition& other) const;
 
   private:

--- a/src/core/include/cesium/omniverse/FabricResourceManager.h
+++ b/src/core/include/cesium/omniverse/FabricResourceManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cesium/omniverse/GltfUtil.h"
+
 #include <omni/fabric/IPath.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/sdf/path.h>
@@ -28,7 +30,13 @@ class FabricGeometryDefinition;
 class FabricMaterialDefinition;
 class FabricTexture;
 class FabricTexturePool;
-struct MaterialInfo;
+
+struct SharedMaterial {
+    std::shared_ptr<FabricMaterial> material;
+    MaterialInfo materialInfo;
+    int64_t tilesetId;
+    uint64_t referenceCount;
+};
 
 class FabricResourceManager {
   public:
@@ -53,7 +61,8 @@ class FabricResourceManager {
         bool smoothNormals,
         long stageId);
 
-    std::shared_ptr<FabricMaterial> acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery, long stageId);
+    std::shared_ptr<FabricMaterial>
+    acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery, long stageId, int64_t tilesetId);
 
     std::shared_ptr<FabricTexture> acquireTexture();
 
@@ -80,6 +89,18 @@ class FabricResourceManager {
     ~FabricResourceManager();
 
   private:
+    std::shared_ptr<FabricMaterial> createMaterial(const FabricMaterialDefinition& materialDefinition, long stageId);
+
+    void removeSharedMaterial(const SharedMaterial& sharedMaterial);
+    SharedMaterial* getSharedMaterial(const MaterialInfo& materialInfo, int64_t tilesetId);
+    SharedMaterial* getSharedMaterial(const std::shared_ptr<FabricMaterial>& material);
+    std::shared_ptr<FabricMaterial> acquireSharedMaterial(
+        const MaterialInfo& materialInfo,
+        const FabricMaterialDefinition& materialDefinition,
+        long stageId,
+        int64_t tilesetId);
+    void releaseSharedMaterial(const std::shared_ptr<FabricMaterial>& material);
+
     std::shared_ptr<FabricGeometryPool> getGeometryPool(const FabricGeometryDefinition& geometryDefinition);
     std::shared_ptr<FabricMaterialPool> getMaterialPool(const FabricMaterialDefinition& materialDefinition);
     std::shared_ptr<FabricTexturePool> getTexturePool();
@@ -122,6 +143,8 @@ class FabricResourceManager {
     pxr::TfToken _defaultTextureAssetPathToken;
 
     std::vector<omni::fabric::Path> _retainedPaths;
+
+    std::vector<SharedMaterial> _sharedMaterials;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -21,6 +21,9 @@ struct TextureInfo {
     int32_t wrapS;
     int32_t wrapT;
     bool flipVertical;
+
+    // Make sure to update this function when adding new fields to the struct
+    bool operator==(const TextureInfo& other) const;
 };
 
 struct MaterialInfo {
@@ -34,6 +37,9 @@ struct MaterialInfo {
     bool doubleSided;
     bool hasVertexColors;
     std::optional<TextureInfo> baseColorTexture;
+
+    // Make sure to update this function when adding new fields to the struct
+    bool operator==(const MaterialInfo& other) const;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -122,7 +122,8 @@ std::vector<FabricMesh> acquireFabricMeshes(
         if (shouldAcquireMaterial) {
             const auto materialInfo = GltfUtil::getMaterialInfo(model, primitive);
 
-            const auto fabricMaterial = fabricResourceManager.acquireMaterial(materialInfo, hasImagery, stageId);
+            const auto fabricMaterial =
+                fabricResourceManager.acquireMaterial(materialInfo, hasImagery, stageId, tileset.getTilesetId());
 
             fabricMesh.material = fabricMaterial;
             fabricMesh.materialInfo = materialInfo;

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -18,12 +18,9 @@ namespace cesium::omniverse {
 
 namespace {
 template <typename T> void removePool(std::vector<T>& pools, const T& pool) {
-    auto it =
-        std::find_if(pools.begin(), pools.end(), [&pool](const auto& other) { return pool.get() == other.get(); });
-
-    if (it != pools.end()) {
-        pools.erase(it);
-    }
+    pools.erase(
+        std::remove_if(pools.begin(), pools.end(), [&pool](const auto& other) { return pool.get() == other.get(); }),
+        pools.end());
 }
 
 } // namespace
@@ -81,14 +78,102 @@ std::shared_ptr<FabricGeometry> FabricResourceManager::acquireGeometry(
 
     return geometry;
 }
+
+bool useSharedMaterial(const FabricMaterialDefinition& materialDefinition) {
+    if (materialDefinition.hasBaseColorTexture()) {
+        return false;
+    }
+
+    return true;
+}
+
 std::shared_ptr<FabricMaterial>
-FabricResourceManager::acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery, long stageId) {
+FabricResourceManager::createMaterial(const FabricMaterialDefinition& materialDefinition, long stageId) {
+    const auto pathStr = fmt::format("/fabric_material_{}", getNextMaterialId());
+    const auto path = omni::fabric::Path(pathStr.c_str());
+    return std::make_shared<FabricMaterial>(path, materialDefinition, _defaultTextureAssetPathToken, stageId);
+}
+
+void FabricResourceManager::removeSharedMaterial(const SharedMaterial& sharedMaterial) {
+    _sharedMaterials.erase(
+        std::remove_if(
+            _sharedMaterials.begin(),
+            _sharedMaterials.end(),
+            [&sharedMaterial](const auto& other) { return &sharedMaterial == &other; }),
+        _sharedMaterials.end());
+}
+
+SharedMaterial* FabricResourceManager::getSharedMaterial(const MaterialInfo& materialInfo, int64_t tilesetId) {
+    for (auto& sharedMaterial : _sharedMaterials) {
+        if (sharedMaterial.materialInfo == materialInfo && sharedMaterial.tilesetId == tilesetId) {
+            return &sharedMaterial;
+        }
+    }
+
+    return nullptr;
+}
+
+SharedMaterial* FabricResourceManager::getSharedMaterial(const std::shared_ptr<FabricMaterial>& material) {
+    for (auto& sharedMaterial : _sharedMaterials) {
+        if (sharedMaterial.material.get() == material.get()) {
+            return &sharedMaterial;
+        }
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<FabricMaterial> FabricResourceManager::acquireSharedMaterial(
+    const MaterialInfo& materialInfo,
+    const FabricMaterialDefinition& materialDefinition,
+    long stageId,
+    int64_t tilesetId) {
+
+    const auto sharedMaterial = getSharedMaterial(materialInfo, tilesetId);
+
+    if (sharedMaterial != nullptr) {
+        sharedMaterial->referenceCount++;
+        return sharedMaterial->material;
+    }
+
+    auto material = createMaterial(materialDefinition, stageId);
+
+    _sharedMaterials.emplace_back(SharedMaterial{
+        material,
+        materialInfo,
+        tilesetId,
+        1,
+    });
+
+    return material;
+}
+
+void FabricResourceManager::releaseSharedMaterial(const std::shared_ptr<FabricMaterial>& material) {
+    const auto sharedMaterial = getSharedMaterial(material);
+
+    assert(sharedMaterial != nullptr);
+
+    if (sharedMaterial != nullptr) {
+        sharedMaterial->referenceCount--;
+        if (sharedMaterial->referenceCount == 0) {
+            removeSharedMaterial(*sharedMaterial);
+        }
+    }
+}
+
+std::shared_ptr<FabricMaterial> FabricResourceManager::acquireMaterial(
+    const MaterialInfo& materialInfo,
+    bool hasImagery,
+    long stageId,
+    int64_t tilesetId) {
     FabricMaterialDefinition materialDefinition(materialInfo, hasImagery, _disableTextures);
 
+    if (useSharedMaterial(materialDefinition)) {
+        return acquireSharedMaterial(materialInfo, materialDefinition, stageId, tilesetId);
+    }
+
     if (_disableMaterialPool) {
-        const auto pathStr = fmt::format("/fabric_material_{}", getNextMaterialId());
-        const auto path = omni::fabric::Path(pathStr.c_str());
-        return std::make_shared<FabricMaterial>(path, materialDefinition, _defaultTextureAssetPathToken, stageId);
+        return createMaterial(materialDefinition, stageId);
     }
 
     std::scoped_lock<std::mutex> lock(_poolMutex);
@@ -136,13 +221,20 @@ void FabricResourceManager::releaseGeometry(const std::shared_ptr<FabricGeometry
 }
 
 void FabricResourceManager::releaseMaterial(const std::shared_ptr<FabricMaterial>& material) {
+    const auto& materialDefinition = material->getMaterialDefinition();
+
+    if (useSharedMaterial(materialDefinition)) {
+        releaseSharedMaterial(material);
+        return;
+    }
+
     if (_disableMaterialPool) {
         return;
     }
 
     std::scoped_lock<std::mutex> lock(_poolMutex);
 
-    const auto materialPool = getMaterialPool(material->getMaterialDefinition());
+    const auto materialPool = getMaterialPool(materialDefinition);
     assert(materialPool != nullptr);
     materialPool->release(material);
 }
@@ -205,6 +297,7 @@ void FabricResourceManager::clear() {
     _geometryPools.clear();
     _materialPools.clear();
     _texturePools.clear();
+    _sharedMaterials.clear();
 }
 
 std::shared_ptr<FabricGeometryPool>

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -549,3 +549,85 @@ bool hasMaterial(const CesiumGltf::MeshPrimitive& primitive) {
 }
 
 } // namespace cesium::omniverse::GltfUtil
+
+namespace cesium::omniverse {
+
+// In C++ 20 we can use the default equality comparison (= default)
+bool TextureInfo::operator==(const TextureInfo& other) const {
+    if (offset != other.offset) {
+        return false;
+    }
+
+    if (rotation != other.rotation) {
+        return false;
+    }
+
+    if (scale != other.scale) {
+        return false;
+    }
+
+    if (setIndex != other.setIndex) {
+        return false;
+    }
+
+    if (wrapS != other.wrapS) {
+        return false;
+    }
+
+    if (wrapT != other.wrapT) {
+        return false;
+    }
+
+    if (flipVertical != other.flipVertical) {
+        return false;
+    }
+    return true;
+}
+
+// In C++ 20 we can use the default equality comparison (= default)
+bool MaterialInfo::operator==(const MaterialInfo& other) const {
+    if (alphaCutoff != other.alphaCutoff) {
+        return false;
+    }
+
+    if (alphaMode != other.alphaMode) {
+        return false;
+    }
+
+    if (baseAlpha != other.baseAlpha) {
+        return false;
+    }
+
+    if (baseColorFactor != other.baseColorFactor) {
+        return false;
+    }
+
+    if (emissiveFactor != other.emissiveFactor) {
+        return false;
+    }
+
+    if (metallicFactor != other.metallicFactor) {
+        return false;
+    }
+
+    if (roughnessFactor != other.roughnessFactor) {
+        return false;
+    }
+
+    if (doubleSided != other.doubleSided) {
+        return false;
+    }
+
+    if (hasVertexColors != other.hasVertexColors) {
+        return false;
+    }
+
+    // != operator doesn't compile for some reason
+    if (!(baseColorTexture == other.baseColorTexture)) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace cesium::omniverse


### PR DESCRIPTION
Fixes #344 so that tiles with identical materials now reference the same FabricMaterial instead of allocating an object pool. This is for tilesets with untextured materials like CWT (without imagery), Cesium OSM Buildings, and point clouds. It should be a pretty good performance improvement for these types of tilesets.

Most of the code changes are in FabricResourceManager. A SharedMaterial object encapsulates a FabricMaterial, its material values, and a reference count. When calling `FabricResourceManager::acquireMaterial` it checks if there's an existing material with the same material values and returns that. When the material is released the reference count is decremented and if it hits zero the material is destroyed.

You can test this by adding Cesium World Terrain without imagery and seeing that only one material is being used.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/6f71128c-de74-4887-892b-070bfcbc12bb)
