### PR TITLE
0.10.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,7 @@
 # Change Log
+
 ### v0.10.0 - 2023-09-01
 * Improved error message if fetching tileset fails
-
-### v0.10.0 - 2023-09-01
-
 * Added basic point cloud support
 * Fixed loading extension in Omniverse Code 2023.1.1
 * Fixed crashes when reloading tileset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 # Both CXX and C need to be given otherwise Conan may ignore the CMAKE_C_COMPILER flag
 project(
     CesiumOmniverse
-    VERSION 0.9.0
+    VERSION 0.10.0
     DESCRIPTION "Cesium for Omniverse"
     LANGUAGES CXX C)
 

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -23,8 +23,8 @@ from cesium.usd.plugins.CesiumUsdSchemas import (
     Tokens as CesiumTokens,
 )
 
-ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxM2I2ZjEzMi1jNWNmLTQzNzAtYjNkMi1hNTI3NzRlYjdlZjIiLCJpZCI6MjU5LCJpYXQiOjE2OTA4OTczODB9.ohya-QYuUkbFPi4rR658dgnr2JUHbOrrbpxT6oCbPps"  # noqa: E501
-GOOGLE_3D_TILES_URL = "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyBJeX3XLT9fetpX_hmNqjHYEfWLm3eJbAk"
+ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlZjM4NjgzNC01Nzg5LTQyMjAtYmYxMC0yNGY2MGEzOGViMGUiLCJpZCI6MjU5LCJpYXQiOjE2OTM1Nzg5MTN9.-J367LOCiroxRBoH9eKhgssEd2Wk_IoqOxROfy-dPjs"  # noqa: E501
+GOOGLE_3D_TILES_URL = "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyBTr9BGnwtJmS0sL86iTb6QhdJlnkAFLoE"
 
 CESIUM_DATA_PRIM_PATH = "/Cesium"
 CESIUM_GEOREFERENCE_PRIM_PATH = "/CesiumGeoreference"

--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.9.0"
+version = "0.10.0"
 category = "simulation"
 feature = false
 app = false


### PR DESCRIPTION
Change log:

* Improved error message if fetching tileset fails
* Added basic point cloud support
* Fixed loading extension in Omniverse Code 2023.1.1
* Fixed crashes when reloading tileset
* Fixed memory leak when removing tileset mid-load
* Fixed several other bugs related to removing tilesets mid-load
* Upgraded to cesium-native v0.26.0