### PR TITLE
0.11.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ### v0.11.0 - 2023-10-02
 
+* Reduced the number of materials created when loading un-textured tilesets.
 * Added debug option `cesium:debug:disableGeoreferencing` to `CesiumDataPrim` to disable georeferencing and view tilesets in ECEF coordinates.
-* Reduced the number of materials created when loading untextured tilesets.
+* Improvements to C++ testing infrastructure.
 
 ### v0.10.0 - 2023-09-01
 
@@ -63,52 +64,52 @@
 
 ### v0.6.1 - 2023-05-11
 
-- Added `premake5.lua` to `cesium.omniverse` and `cesium.usd.plugins` to better support Kit templates.
-- Fixed crash in the Cesium Debugging window when reloading a stage.
+* Added `premake5.lua` to `cesium.omniverse` and `cesium.usd.plugins` to better support Kit templates.
+* Fixed crash in the Cesium Debugging window when reloading a stage.
 
 ### v0.6.0 - 2023-05-04
 
-- Added option to show credits on screen.
-- Fixed issue where tileset traversal was happening on hidden tilesets.
-- Fixed issue where tile render resources were not being released back into the Fabric mesh pool in certain cases.
-- Fixed regression where the texture wrap mode was no longer clamping to edge.
+* Added option to show credits on screen.
+* Fixed issue where tileset traversal was happening on hidden tilesets.
+* Fixed issue where tile render resources were not being released back into the Fabric mesh pool in certain cases.
+* Fixed regression where the texture wrap mode was no longer clamping to edge.
 
 ### v0.5.0 - 2023-05-01
 
-- Added material pool for better performance and to reduce texture/material loading artifacts.
-- Added support for multiple viewports.
-- Fixed red flashes when materials are loading.
-- Fixed cyan flashes when textures are loading.
-- Fixed adding imagery as base layer for existing tileset.
-- Fixed Fabric types for `tilesetId` and `tileId`.
-- Upgraded to cesium-native v0.23.0.
+* Added material pool for better performance and to reduce texture/material loading artifacts.
+* Added support for multiple viewports.
+* Fixed red flashes when materials are loading.
+* Fixed cyan flashes when textures are loading.
+* Fixed adding imagery as base layer for existing tileset.
+* Fixed Fabric types for `tilesetId` and `tileId`.
+* Upgraded to cesium-native v0.23.0.
 
 ### v0.4.0 - 2023-04-03
 
-- Fixed a crash when removing the last available access token for a tileset.
-- Added search field to the asset window.
-- Added placeholder token name in the create field of the token window.
-- No longer printing "Error adding tileset and imagery to stage" when adding a tileset.
-- Better handling of long names in the asset details panel.
-- Upgraded to cesium-native v0.22.1.
+* Fixed a crash when removing the last available access token for a tileset.
+* Added search field to the asset window.
+* Added placeholder token name in the create field of the token window.
+* No longer printing "Error adding tileset and imagery to stage" when adding a tileset.
+* Better handling of long names in the asset details panel.
+* Upgraded to cesium-native v0.22.1.
 
 ### v0.3.0 - 2023-03-20
 
-- Split the Cesium USD plugins into their own Kit extension.
-- Added on-screen credits.
-- Added modal dialog prompting the user to enable Fabric Scene Delegate.
-- General cleanup before public release.
+* Split the Cesium USD plugins into their own Kit extension.
+* Added on-screen credits.
+* Added modal dialog prompting the user to enable Fabric Scene Delegate.
+* General cleanup before public release.
 
 ### v0.2.0 - 2023-03-16
 
-- Fixed raster overlay refinement.
-- Fixed a crash when removing tileset and imagery using the stage window.
-- Fixed issues around loading pre-existing USD files.
-- Now generating flat normals by default.
-- Added property window widgets for the Cesium USD Schema attributes.
-- Updated documentation.
-- General cleanup.
+* Fixed raster overlay refinement.
+* Fixed a crash when removing tileset and imagery using the stage window.
+* Fixed issues around loading pre-existing USD files.
+* Now generating flat normals by default.
+* Added property window widgets for the Cesium USD Schema attributes.
+* Updated documentation.
+* General cleanup.
 
 ### v0.1.0 - 2023-03-01
 
-- The initial preview build of Cesium for Omniverse!
+* The initial preview build of Cesium for Omniverse!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### v0.11.0 - 2023-10-02
 
+* **Breaking change:** Cesium for Omniverse now requires Kit 105.1 or above (USD Composer 2023.2.0 or above).
 * Reduced the number of materials created when loading un-textured tilesets.
 * Added debug option `cesium:debug:disableGeoreferencing` to `CesiumDataPrim` to disable georeferencing and view tilesets in ECEF coordinates.
 * Improvements to C++ testing infrastructure.
@@ -18,7 +19,7 @@
 
 ### v0.9.0 - 2023-08-01
 
-* Breaking change: `CesiumTilesetPrim` now inherits from `UsdGeomGprim` instead of `UsdGeomBoundable`.
+* **Breaking change:** `CesiumTilesetPrim` now inherits from `UsdGeomGprim` instead of `UsdGeomBoundable`.
 * Improved texture loading performance by moving texture loading to a worker thread.
 * Improved performance when refining with parent tile's imagery by sharing the same texture instead of duplicating it.
 * Added support for assigning materials to a tileset.
@@ -28,11 +29,11 @@
 
 ### v0.8.0 - 2023-07-03
 
-* Breaking change: Cesium for Omniverse now requires Kit 105 or above (USD Composer 2023.1.0 or above).
-* Breaking change: broke out georeference attributes from `CesiumDataPrim` into dedicated `CesiumGeoreferencePrim` class.
-* Breaking change: `CesiumTilesetPrim` is now a concrete type that inherits from `UsdGeomBoundable`.
-* Breaking change: `CesiumTilesetPrim` now has an explicit binding to a `CesiumGeoreferencePrim`.
-* Breaking change: default values for attributes are no longer written out when saved as `.usd` files.
+* **Breaking change:** Cesium for Omniverse now requires Kit 105 or above (USD Composer 2023.1.0 or above).
+* **Breaking change:** broke out georeference attributes from `CesiumDataPrim` into dedicated `CesiumGeoreferencePrim` class.
+* **Breaking change:** `CesiumTilesetPrim` is now a concrete type that inherits from `UsdGeomBoundable`.
+* **Breaking change:** `CesiumTilesetPrim` now has an explicit binding to a `CesiumGeoreferencePrim`.
+* **Breaking change:** default values for attributes are no longer written out when saved as `.usd` files.
 * Added ability to zoom to extents on tilesets.
 * Added vertex color support.
 * Added `cesium.omniverse.TILESET_LOADED` Carbonite event.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 # Both CXX and C need to be given otherwise Conan may ignore the CMAKE_C_COMPILER flag
 project(
     CesiumOmniverse
-    VERSION 0.10.0
+    VERSION 0.11.0
     DESCRIPTION "Cesium for Omniverse"
     LANGUAGES CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,22 +603,6 @@ install(
             COMPONENT library
             EXCLUDE_FROM_ALL)
 
-# Nothing links against nvrtc-builtins but if we don't include it we get a runtime crash.
-# Unfortunately this means we have to bypass CMake's dependency system and install it manually here.
-if(WIN32)
-    install(
-        FILES "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/bin/nvrtc-builtins64_118.dll"
-        DESTINATION "${KIT_EXTENSION_BIN_PATH}"
-        COMPONENT install)
-else()
-    install(
-        FILES "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so"
-              "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so.11.8"
-              "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so.11.8.89"
-        DESTINATION "${KIT_EXTENSION_BIN_PATH}"
-        COMPONENT install)
-endif()
-
 install(
     TARGETS CesiumOmniversePythonBindings
     ARCHIVE DESTINATION ${KIT_EXTENSION_BINDINGS_PATH} COMPONENT install

--- a/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
+++ b/apps/exts/cesium.performance.app/cesium/performance/app/extension.py
@@ -23,8 +23,8 @@ from cesium.usd.plugins.CesiumUsdSchemas import (
     Tokens as CesiumTokens,
 )
 
-ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlZjM4NjgzNC01Nzg5LTQyMjAtYmYxMC0yNGY2MGEzOGViMGUiLCJpZCI6MjU5LCJpYXQiOjE2OTM1Nzg5MTN9.-J367LOCiroxRBoH9eKhgssEd2Wk_IoqOxROfy-dPjs"  # noqa: E501
-GOOGLE_3D_TILES_URL = "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyBTr9BGnwtJmS0sL86iTb6QhdJlnkAFLoE"
+ION_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwNzhiNWNjOS1iYmUyLTQ5MTYtODliYy0zMTc3NTJmZTk4MWIiLCJpZCI6MjU5LCJpYXQiOjE2OTYyNzYzNzF9.ooL73wypb9IdmEz4zD3MN87rLtEYo1tEgavGzaC5UM8"  # noqa: E501
+GOOGLE_3D_TILES_URL = "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyBxuWsnHCKWkqQnSIhdWpsF7bcWvbgpoos"
 
 CESIUM_DATA_PRIM_PATH = "/Cesium"
 CESIUM_GEOREFERENCE_PRIM_PATH = "/CesiumGeoreference"

--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -52,12 +52,6 @@ archiveDirs = ["vendor"]
 [[native.plugin]]
 path = "bin/cesium.omniverse.plugin"
 
-[[native.library]]
-"filter:platform"."windows-x86_64"."path" = "bin/${lib_prefix}nvrtc-builtins64_118${lib_ext}"
-
-[[native.library]]
-"filter:platform"."linux-x86_64"."path" = "bin/${lib_prefix}nvrtc-builtins${lib_ext}"
-
 [settings]
 exts."cesium.omniverse".defaultAccessToken = ""
 persistent.exts."cesium.omniverse".userAccessToken = ""

--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.10.0"
+version = "0.11.0"
 category = "simulation"
 feature = false
 app = false

--- a/exts/cesium.usd.plugins/config/extension.toml
+++ b/exts/cesium.usd.plugins/config/extension.toml
@@ -30,6 +30,7 @@ readme = "doc/README.md"
 preview_image = "doc/images/preview.jpg"
 icon = "doc/images/icon.png"
 
+# Technically only works in 105.1+, but there's no clear way to denote that
 [package.target]
 kit = ["105.*"]
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -88,7 +88,6 @@ setup_lib(
         omni_kit
         omni_ui
         cuda
-        nvrtc
         pybind11
         python310
     ADDITIONAL_LIBRARIES


### PR DESCRIPTION
Change log:

* **Breaking change:** Cesium for Omniverse now requires Kit 105.1 or above (USD Composer 2023.2.0 or above).
* Reduced the number of materials created when loading un-textured tilesets.
* Added debug option `cesium:debug:disableGeoreferencing` to `CesiumDataPrim` to disable georeferencing and view tilesets in ECEF coordinates.
* Improvements to C++ testing infrastructure.

Note: I temporarily removed nvrtc since https://github.com/CesiumGS/cesium-omniverse/pull/459 didn't make it into the release. I'll revert https://github.com/CesiumGS/cesium-omniverse/commit/ff727729d807b2d77e4b43169d1a5eb203d68d8d once the release is complete.