### PR TITLE
Revert "Temporarily remove nvrtc and nvrtc-builtins from install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,6 +603,22 @@ install(
             COMPONENT library
             EXCLUDE_FROM_ALL)
 
+# Nothing links against nvrtc-builtins but if we don't include it we get a runtime crash.
+# Unfortunately this means we have to bypass CMake's dependency system and install it manually here.
+if(WIN32)
+    install(
+        FILES "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/bin/nvrtc-builtins64_118.dll"
+        DESTINATION "${KIT_EXTENSION_BIN_PATH}"
+        COMPONENT install)
+else()
+    install(
+        FILES "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so"
+              "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so.11.8"
+              "${PROJECT_SOURCE_DIR}/extern/nvidia/_build/target-deps/cuda/cuda/lib64/libnvrtc-builtins.so.11.8.89"
+        DESTINATION "${KIT_EXTENSION_BIN_PATH}"
+        COMPONENT install)
+endif()
+
 install(
     TARGETS CesiumOmniversePythonBindings
     ARCHIVE DESTINATION ${KIT_EXTENSION_BINDINGS_PATH} COMPONENT install

--- a/exts/cesium.omniverse/config/extension.toml
+++ b/exts/cesium.omniverse/config/extension.toml
@@ -52,6 +52,12 @@ archiveDirs = ["vendor"]
 [[native.plugin]]
 path = "bin/cesium.omniverse.plugin"
 
+[[native.library]]
+"filter:platform"."windows-x86_64"."path" = "bin/${lib_prefix}nvrtc-builtins64_118${lib_ext}"
+
+[[native.library]]
+"filter:platform"."linux-x86_64"."path" = "bin/${lib_prefix}nvrtc-builtins${lib_ext}"
+
 [settings]
 exts."cesium.omniverse".defaultAccessToken = ""
 persistent.exts."cesium.omniverse".userAccessToken = ""

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -88,6 +88,7 @@ setup_lib(
         omni_kit
         omni_ui
         cuda
+        nvrtc
         pybind11
         python310
     ADDITIONAL_LIBRARIES


### PR DESCRIPTION
Adds nvrtc and nvrtc-builtins back to the install. They were temporarily removed in https://github.com/CesiumGS/cesium-omniverse/pull/475 before the release since https://github.com/CesiumGS/cesium-omniverse/pull/459 hadn't been merged yet.