### PR TITLE
Speed up launching extension from VSCode debugging panel and other launch.json changes

### DIFF
--- a/.vscode/launch.linux.json
+++ b/.vscode/launch.linux.json
@@ -14,39 +14,13 @@
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
       "cwd": "${workspaceFolder}",
-      "type": "lldb",
+      "type": "cppdbg",
       "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
       "MIMode": "gdb",
-      "setupCommands": [
-        {
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        },
-        {
-          "text": "set print elements 0"
-        }
-      ]
-    },
-    {
-      "name": "Tests Extension",
-      "preLaunchTask": "Build Only (debug)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit",
-      "args": [
-        "${workspaceFolder}/apps/cesium.omniverse.cpp.tests.runner.kit"
-      ],
-      "env": {
-        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
-        "ASAN_OPTIONS": "detect_leaks=0",
-        "UBSAN_OPTIONS": "print_stacktrace=1"
+      "symbolLoadInfo": {
+        "loadAll": false,
+        "exceptionList": "libcesium.omniverse.plugin.so;libcesium.omniverse.cpp.tests.plugin.so"
       },
-      "cwd": "${workspaceFolder}",
-      "type": "lldb",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
-      "MIMode": "gdb",
       "setupCommands": [
         {
           "text": "-enable-pretty-printing",
@@ -70,91 +44,8 @@
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
       "cwd": "${workspaceFolder}",
-      "type": "lldb",
+      "type": "cppdbg",
       "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
-      "MIMode": "gdb",
-      "setupCommands": [
-        {
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        },
-        {
-          "text": "set print elements 0"
-        }
-      ]
-    },
-    {
-      "name": "Performance Tracing",
-      "preLaunchTask": "Build Only (release)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit",
-      "args": [
-        "${workspaceFolder}/apps/cesium.omniverse.dev.trace.kit"
-      ],
-      "env": {
-        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
-        "ASAN_OPTIONS": "detect_leaks=0",
-        "UBSAN_OPTIONS": "print_stacktrace=1"
-      },
-      "cwd": "${workspaceFolder}",
-      "type": "lldb",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
-      "MIMode": "gdb",
-      "setupCommands": [
-        {
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        },
-        {
-          "text": "set print elements 0"
-        }
-      ]
-    },
-    {
-      "name": "Performance Testing App",
-      "preLaunchTask": "Build Only (release)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit",
-      "args": [
-        "${workspaceFolder}/apps/cesium.performance.kit"
-      ],
-      "env": {
-        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
-        "ASAN_OPTIONS": "detect_leaks=0",
-        "UBSAN_OPTIONS": "print_stacktrace=1"
-      },
-      "cwd": "${workspaceFolder}",
-      "type": "lldb",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
-      "MIMode": "gdb",
-      "setupCommands": [
-        {
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        },
-        {
-          "text": "set print elements 0"
-        }
-      ]
-    },
-    {
-      "name": "C++ Unit Tests",
-      "preLaunchTask": "Build Only (debug)",
-      "program": "${workspaceFolder}/build-debug/bin/tests",
-      "env": {
-        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
-        "ASAN_OPTIONS": "detect_leaks=0",
-        "UBSAN_OPTIONS": "print_stacktrace=1"
-      },
-      "cwd": "${workspaceFolder}",
-      "type": "lldb",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
       "MIMode": "gdb",
       "setupCommands": [
         {
@@ -171,7 +62,7 @@
       "preLaunchTask": "Build Only (debug)",
       "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit",
       "args": [
-        "${workspaceFolder}/apps/cesium.omniverse.dev.kit"
+        "${workspaceFolder}/apps/cesium.omniverse.dev.python.debug.kit"
       ],
       "env": {
         // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
@@ -179,11 +70,13 @@
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
       "cwd": "${workspaceFolder}",
-      "type": "lldb",
+      "type": "cppdbg",
       "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
       "MIMode": "gdb",
+      "symbolLoadInfo": {
+        "loadAll": false,
+        "exceptionList": "libcesium.omniverse.plugin.so;libcesium.omniverse.cpp.tests.plugin.so"
+      },
       "setupCommands": [
         {
           "text": "-enable-pretty-printing",

--- a/.vscode/launch.windows.json
+++ b/.vscode/launch.windows.json
@@ -10,9 +10,7 @@
       ],
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
+      "request": "launch"
     },
     {
       "name": "Development App (Kit Debug)",
@@ -23,67 +21,7 @@
       ],
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Performance Tracing",
-      "preLaunchTask": "Build Only (release)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit.exe",
-      "args": [
-        "${workspaceFolder}/apps/cesium.omniverse.dev.trace.kit"
-      ],
-      "cwd": "${workspaceFolder}",
-      "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Performance Testing App",
-      "preLaunchTask": "Build Only (release)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit.exe",
-      "args": [
-        "${workspaceFolder}/apps/cesium.performance.kit"
-      ],
-      "cwd": "${workspaceFolder}",
-      "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "C++ Unit Tests",
-      "preLaunchTask": "Build Only (debug)",
-      "program": "${workspaceFolder}/build/bin/Debug/tests.exe",
-      "cwd": "${workspaceFolder}",
-      "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
-    },
-    {
-      "name": "Tests Extension",
-      "preLaunchTask": "Build Only (debug)",
-      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit.exe",
-      "args": [
-        "${workspaceFolder}/apps/cesium.omniverse.cpp.tests.runner.kit"
-      ],
-      "cwd": "${workspaceFolder}",
-      "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
-      "setupCommands": [
-        {
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        },
-        {
-          "text": "set print elements 0"
-        }
-      ]
+      "request": "launch"
     },
     {
       "name": "Python Debugging (start)",
@@ -94,9 +32,7 @@
       ],
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
-      "request": "launch",
-      "console": "externalTerminal",
-      "internalConsoleOptions": "openOnSessionStart"
+      "request": "launch"
     },
     {
       "name": "Python Debugging (attach)",


### PR DESCRIPTION
I made a few tweaks to `launch.json`

* Disabled symbol loading for everything except `libcesium.omniverse.plugin.so`. This improves start time from 70 seconds to 15 seconds on Linux.
  * The one exception is `Development App (Kit Debug)` where we still include all symbols
  *  This required switching to `cppdgb` and using [`symbolLoadInfo`](https://code.visualstudio.com/docs/cpp/launch-json-reference#_symbolloadinfo)
  * No change for Windows, which was already fast enough
* Removed a few configurations
  * **Performance Tracing** - I'm concerned the VSCode debugger may affect performance numbers even when running release builds, so this configuration has been removed and should be run on the command line instead 
  * **Performance Testing App** - same as above
  * **C++ Unit Tests** - these will eventually be folded into the tests extension, in the meantime they can still be run on the command line
  * **Tests Extension** - requires https://github.com/CesiumGS/cesium-omniverse/issues/470 to be fixed first
* Switched back to using VSCode integrated terminal. The original reason for switching to an external terminal is no longer applicable: https://github.com/CesiumGS/cesium-omniverse/pull/371.