### PR TITLE
Add additional search paths to all .kit apps

### DIFF
--- a/apps/cesium.omniverse.dev.python.debug.kit
+++ b/apps/cesium.omniverse.dev.python.debug.kit
@@ -10,3 +10,11 @@ app = true
 
 [settings]
 app.window.title = "Cesium For Omniverse Python Debugging App"
+
+[settings.app.exts]
+folders.'++' = [
+    "${app}", # Find other applications in this folder
+    "${app}/exts", # Find extensions in this folder
+    "${app}/../exts", # Find cesium.omniverse and cesium.usd.schemas
+    "${app}/../extern/nvidia/app/extscache" # Find omni.kit.window.material_graph
+]

--- a/apps/cesium.omniverse.dev.trace.kit
+++ b/apps/cesium.omniverse.dev.trace.kit
@@ -9,3 +9,11 @@ app = true
 [settings]
 app.window.title = "Cesium For Omniverse Performance Tracing App"
 app.fastShutdown = false
+
+[settings.app.exts]
+folders.'++' = [
+    "${app}", # Find other applications in this folder
+    "${app}/exts", # Find extensions in this folder
+    "${app}/../exts", # Find cesium.omniverse and cesium.usd.schemas
+    "${app}/../extern/nvidia/app/extscache" # Find omni.kit.window.material_graph
+]


### PR DESCRIPTION
This fixes the python debugging application, similar to the fix in https://github.com/CesiumGS/cesium-omniverse/pull/451.

I don't understand why `settings.app.exts` isn't being inherited from `cesium.omniverse.dev` but it doesn't hurt to copy-paste these lines into each app.