### PR TITLE
Reload tileset when disableTexturePool property changes

### DIFF
--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -239,6 +239,7 @@ void Context::processCesiumDataChanged(const ChangedPrim& changedPrim) {
         name == pxr::CesiumTokens->cesiumDebugDisableTextures ||
         name == pxr::CesiumTokens->cesiumDebugDisableGeometryPool ||
         name == pxr::CesiumTokens->cesiumDebugDisableMaterialPool ||
+        name == pxr::CesiumTokens->cesiumDebugDisableTexturePool ||
         name == pxr::CesiumTokens->cesiumDebugGeometryPoolInitialCapacity ||
         name == pxr::CesiumTokens->cesiumDebugMaterialPoolInitialCapacity ||
         name == pxr::CesiumTokens->cesiumDebugTexturePoolInitialCapacity ||


### PR DESCRIPTION
Force the tileset to reload when the `disableTexturePool` property changes. Small omission from https://github.com/CesiumGS/cesium-omniverse/pull/389