### PR TITLE
Fix hangs when loading tileset materials

### DIFF
--- a/apps/cesium.omniverse.dev.kit
+++ b/apps/cesium.omniverse.dev.kit
@@ -17,6 +17,7 @@ app.window.title = "Cesium for Omniverse Testing App"
 app.useFabricSceneDelegate = true
 app.usdrt.scene_delegate.enableProxyCubes = false
 app.usdrt.scene_delegate.geometryStreaming.enabled = false
+omnihydra.parallelHydraSprimSync = false
 app.fastShutdown = true
 # Both searchPaths settings must be set in order for material graph to find cesium mdl exports
 renderer.mdl.searchPaths.custom = "${app}/../exts/cesium.omniverse/mdl"

--- a/exts/cesium.omniverse/cesium/omniverse/ui/fabric_modal.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/fabric_modal.py
@@ -19,6 +19,7 @@ class CesiumFabricModal(ui.Window):
         carb.settings.get_settings().set_bool("/app/useFabricSceneDelegate", True)
         carb.settings.get_settings().set_bool("/app/usdrt/scene_delegate/enableProxyCubes", False)
         carb.settings.get_settings().set_bool("/app/usdrt/scene_delegate/geometryStreaming/enabled", False)
+        carb.settings.get_settings().set_bool("/omnihydra/parallelHydraSprimSync", False)
         omni.kit.window.file.new()
         self.visible = False
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/477

In Kit 105.1 we noticed that Omniverse would sometimes hang when loading tileset materials, i.e. the loading bar would get stuck at some %.

Setting `omnihydra.parallelHydraSprimSync` to `false` almost completely fixes these issues. A bonus is that materials no longer appear white/red when textures are loading.

I printed the carb settings for USD Composer 2023.2.0 and noticed that it's false there too, so I feel pretty confident this is the right fix for us. Since USD Composer already has the "fix" I don't think we need to do a patch release.

```
  "omnihydra": {
    "staticMaterialNetworkTopology": false,
    "parallelHydraSprimSync": false
  },
```