### PR TITLE
Tests extension now waits for stage to open before running

### DIFF
--- a/.vscode/launch.linux.json
+++ b/.vscode/launch.linux.json
@@ -111,7 +111,11 @@
         {
           "text": "set print elements 0"
         }
-      ]
+      ],
+      "symbolLoadInfo": {
+        "loadAll": false,
+        "exceptionList": "libcesium.omniverse.plugin.so;libcesium.omniverse.cpp.tests.plugin.so"
+      }
     },
     {
       "name": "Python Debugging (attach)",

--- a/.vscode/launch.linux.json
+++ b/.vscode/launch.linux.json
@@ -88,6 +88,32 @@
       ]
     },
     {
+      "name": "Tests Extension",
+      "preLaunchTask": "Build Only (debug)",
+      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit",
+      "args": [
+        "${workspaceFolder}/apps/cesium.omniverse.cpp.tests.runner.kit"
+      ],
+      "env": {
+        // Disable LSAN when debugging since it doesn't work with GDB and prints harmless but annoying warning messages
+        "ASAN_OPTIONS": "detect_leaks=0",
+        "UBSAN_OPTIONS": "print_stacktrace=1"
+      },
+      "cwd": "${workspaceFolder}",
+      "type": "cppdbg",
+      "request": "launch",
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "text": "set print elements 0"
+        }
+      ]
+    },
+    {
       "name": "Python Debugging (attach)",
       "type": "python",
       "request": "attach",

--- a/.vscode/launch.windows.json
+++ b/.vscode/launch.windows.json
@@ -35,6 +35,17 @@
       "request": "launch"
     },
     {
+      "name": "Tests Extension",
+      "preLaunchTask": "Build Only (debug)",
+      "program": "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/kit.exe",
+      "args": [
+        "${workspaceFolder}/apps/cesium.omniverse.cpp.tests.runner.kit"
+      ],
+      "cwd": "${workspaceFolder}",
+      "type": "cppvsdbg",
+      "request": "launch"
+    },
+    {
       "name": "Python Debugging (attach)",
       "type": "python",
       "request": "attach",

--- a/cesiumOmniverseCppTestsExtension/bindings/PythonBindings.cpp
+++ b/cesiumOmniverseCppTestsExtension/bindings/PythonBindings.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(CesiumOmniverseCppTestsPythonBindings, m) {
     // clang-format off
     carb::defineInterfaceClass<ICesiumOmniverseCppTestsInterface>(
         m, "ICesiumOmniverseCppTestsInterface", "acquire_cesium_omniverse_tests_interface", "release_cesium_omniverse_tests_interface")
-        .def("run_all_tests", &ICesiumOmniverseCppTestsInterface::run_all_tests)
+        .def("run_all_tests", &ICesiumOmniverseCppTestsInterface::runAllTests)
         .def("on_startup", &ICesiumOmniverseCppTestsInterface::onStartup)
         .def("on_shutdown", &ICesiumOmniverseCppTestsInterface::onShutdown);
     // clang-format on

--- a/cesiumOmniverseCppTestsExtension/include/CesiumOmniverseCppTests.h
+++ b/cesiumOmniverseCppTestsExtension/include/CesiumOmniverseCppTests.h
@@ -18,7 +18,7 @@ class ICesiumOmniverseCppTestsInterface {
      */
     virtual void onShutdown() noexcept = 0;
 
-    virtual void run_all_tests(long int stage_id) noexcept = 0;
+    virtual void runAllTests(long int stage_id) noexcept = 0;
 };
 
 } // namespace cesium::omniverse::tests

--- a/cesiumOmniverseCppTestsExtension/include/UsdUtilTests.h
+++ b/cesiumOmniverseCppTestsExtension/include/UsdUtilTests.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void run_all_UsdUtil_tests();

--- a/cesiumOmniverseCppTestsExtension/include/UsdUtilTests.h
+++ b/cesiumOmniverseCppTestsExtension/include/UsdUtilTests.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void run_all_UsdUtil_tests();
+void runAllUsdUtilTests();

--- a/cesiumOmniverseCppTestsExtension/public/CesiumOmniverseCppTests.cpp
+++ b/cesiumOmniverseCppTestsExtension/public/CesiumOmniverseCppTests.cpp
@@ -63,7 +63,7 @@ class CesiumOmniverseCppTestsPlugin final : public ICesiumOmniverseCppTestsInter
         Context::onShutdown();
     }
 
-    void run_all_tests(long int stage_id) noexcept override {
+    void runAllTests(long int stage_id) noexcept override {
 
         CESIUM_LOG_INFO("Running Cesium Omniverse Tests with stage id: {}", stage_id);
 
@@ -80,7 +80,7 @@ class CesiumOmniverseCppTestsPlugin final : public ICesiumOmniverseCppTestsInter
         context.setAssertHandler(handler);
 
         exampleTest();
-        run_all_UsdUtil_tests();
+        runAllUsdUtilTests();
 
         CESIUM_LOG_INFO("Cesium Omniverse Tests complete");
     }

--- a/cesiumOmniverseCppTestsExtension/public/CesiumOmniverseCppTests.cpp
+++ b/cesiumOmniverseCppTestsExtension/public/CesiumOmniverseCppTests.cpp
@@ -5,9 +5,10 @@
 
 #include "CesiumOmniverseCppTests.h"
 
+#include "UsdUtilTests.h"
+
 #include "cesium/omniverse/Context.h"
 #include "cesium/omniverse/LoggerSink.h"
-#include "cesium/omniverse/UsdUtil.h"
 
 #include <carb/PluginUtils.h>
 #include <doctest/doctest.h>
@@ -66,7 +67,9 @@ class CesiumOmniverseCppTestsPlugin final : public ICesiumOmniverseCppTestsInter
 
         CESIUM_LOG_INFO("Running Cesium Omniverse Tests with stage id: {}", stage_id);
 
-        // construct a context
+        Context::instance().setStageId(stage_id);
+
+        // construct a doctest context
         doctest::Context context;
 
         // sets the context as the default one - so asserts used outside of a testing context do not crash
@@ -77,6 +80,7 @@ class CesiumOmniverseCppTestsPlugin final : public ICesiumOmniverseCppTestsInter
         context.setAssertHandler(handler);
 
         exampleTest();
+        run_all_UsdUtil_tests();
 
         CESIUM_LOG_INFO("Cesium Omniverse Tests complete");
     }

--- a/cesiumOmniverseCppTestsExtension/public/UsdUtilTests.cpp
+++ b/cesiumOmniverseCppTestsExtension/public/UsdUtilTests.cpp
@@ -1,0 +1,20 @@
+// #define DOCTEST_CONFIG_IMPLEMENT
+// #define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+// #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+#include "UsdUtilTests.h"
+
+#include "cesium/omniverse/Context.h"
+#include "cesium/omniverse/LoggerSink.h"
+#include "cesium/omniverse/UsdUtil.h"
+
+#include <doctest/doctest.h>
+
+#include <iostream>
+
+void run_all_UsdUtil_tests() {
+    using namespace cesium::omniverse;
+    CESIUM_LOG_INFO("Running UsdUtil Tests...");
+    CHECK(cesium::omniverse::UsdUtil::primExists(pxr::SdfPath("/Cesium")));
+    CESIUM_LOG_INFO("UsdUtil Tests complete!");
+}

--- a/cesiumOmniverseCppTestsExtension/public/UsdUtilTests.cpp
+++ b/cesiumOmniverseCppTestsExtension/public/UsdUtilTests.cpp
@@ -1,7 +1,3 @@
-// #define DOCTEST_CONFIG_IMPLEMENT
-// #define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
-// #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
 #include "UsdUtilTests.h"
 
 #include "cesium/omniverse/Context.h"
@@ -10,11 +6,10 @@
 
 #include <doctest/doctest.h>
 
-#include <iostream>
-
-void run_all_UsdUtil_tests() {
+void runAllUsdUtilTests() {
+    // CESIUM_LOG_INFO macro can only be run inside the cesium::omniverse namespace
     using namespace cesium::omniverse;
     CESIUM_LOG_INFO("Running UsdUtil Tests...");
-    CHECK(cesium::omniverse::UsdUtil::primExists(pxr::SdfPath("/Cesium")));
+    CHECK(UsdUtil::primExists(pxr::SdfPath("/Cesium")));
     CESIUM_LOG_INFO("UsdUtil Tests complete!");
 }

--- a/exts/cesium.omniverse.cpp.tests/cesium/omniverse/cpp/tests/extension.py
+++ b/exts/cesium.omniverse.cpp.tests/cesium/omniverse/cpp/tests/extension.py
@@ -1,6 +1,8 @@
+import os
 import omni.ext
 import omni.usd
 import omni.kit.ui
+import omni.kit.app
 from .bindings import acquire_cesium_omniverse_tests_interface, release_cesium_omniverse_tests_interface
 
 
@@ -14,14 +16,26 @@ class CesiumOmniverseCppTestsExtension(omni.ext.IExt):
         global tests_interface
         tests_interface = acquire_cesium_omniverse_tests_interface()
 
-        tests_interface.on_startup("exts/cesium.omniverse")
+        tests_interface.on_startup(os.path.join(os.path.dirname(__file__), "../../../../../cesium.omniverse"))
 
-        # TODO ensure the stage has been set up before getting stage id
-        stageId = omni.usd.get_context().get_stage_id()
+        update_stream = omni.kit.app.get_app().get_update_event_stream()
 
-        tests_interface.run_all_tests(stageId)
+        # To ensure the tests only run after the stage has been opened, we
+        # attach a handler to an event that occurs every frame. That handler
+        # checks if the stage has opened, runs once, then detaches itself
+        self._run_once_sub = update_stream.create_subscription_to_pop(
+            self.run_once_after_stage_opens, name="Run once after stage opens"
+        )
 
         print("Started Cesium Tests Extension.")
+
+    def run_once_after_stage_opens(self, _):
+        if omni.usd.get_context().get_stage_state() == omni.usd.StageState.OPENED:
+            print("Beginning Cesium Tests Extension tests")
+            stageId = omni.usd.get_context().get_stage_id()
+            tests_interface.run_all_tests(stageId)
+            print("Cesium Tests Extension tests complete")
+            self._run_once_sub.unsubscribe()
 
     def on_shutdown(self):
         print("Stopping Cesium Tests Extension...")


### PR DESCRIPTION
fixes #470 fixes #310. Ensures the tests extension runs after the stage has opened and introduces the first actual test of a cpp function that depends on the USD stage.