### PR TITLE
Add support for multiple raster overlays

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -11,6 +11,64 @@ module [[
     anno::display_name("Cesium MDL functions")
 ]];
 
-// For internal use only. See note in FabricMaterial.cpp
+// For internal use only
 export gltf_texture_lookup_value cesium_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();
 export material cesium_material(*) [[ anno::hidden() ]] = gltf_material();
+
+export gltf_texture_lookup_value cesium_texture_array_lookup(
+    uniform int texture_count = 0,
+    gltf_texture_lookup_value texture_0 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_1 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_2 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_3 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_4 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_5 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_6 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_7 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_8 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_9 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_10 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_11 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_12 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_13 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_14 = gltf_texture_lookup(),
+    gltf_texture_lookup_value texture_15 = gltf_texture_lookup()
+) [[ anno::hidden() ]]
+{
+    // The array length should match MAX_TEXTURE_LAYER_COUNT in Tokens.h
+    gltf_texture_lookup_value[16] texture_values(
+        texture_0,
+        texture_1,
+        texture_2,
+        texture_3,
+        texture_4,
+        texture_5,
+        texture_6,
+        texture_7,
+        texture_8,
+        texture_9,
+        texture_10,
+        texture_11,
+        texture_12,
+        texture_13,
+        texture_14,
+        texture_15,
+    );
+
+    float3 final = float3(1.0, 1.0, 1.0);
+
+    for (int i = 0; i < texture_count; i++) {
+        gltf_texture_lookup_value value = texture_values[i];
+        if (value.valid) {
+            float3 rgb = float3(value.value[0], value.value[1], value.value[2]);
+            float alpha = value.value[3];
+            final = alpha * rgb + (1.0 - alpha) * final;
+        }
+    }
+
+    gltf_texture_lookup_value tex_ret;
+    tex_ret.value = float4(final[0], final[1], final[2], 1.0);
+    tex_ret.valid = true;
+
+    return tex_ret;
+}

--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -30,7 +30,8 @@ class FabricGeometry {
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals,
-        bool hasImagery);
+        const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping,
+        const std::unordered_map<uint64_t, uint64_t>& imageryTexcoordIndexMapping);
 
     void setActive(bool active);
     void setVisibility(bool visible);

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -16,18 +16,18 @@ class FabricGeometryDefinition {
         const CesiumGltf::MeshPrimitive& primitive,
         bool smoothNormals);
 
-    [[nodiscard]] bool hasTexcoords() const;
     [[nodiscard]] bool hasNormals() const;
     [[nodiscard]] bool hasVertexColors() const;
     [[nodiscard]] bool getDoubleSided() const;
+    [[nodiscard]] uint64_t getTexcoordSetCount() const;
 
     bool operator==(const FabricGeometryDefinition& other) const;
 
   private:
-    bool _hasTexcoords{false};
     bool _hasNormals{false};
     bool _hasVertexColors{false};
     bool _doubleSided{false};
+    uint64_t _texcoordSetCount{0};
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -20,14 +20,19 @@ class FabricMaterial {
         const omni::fabric::Path& path,
         const FabricMaterialDefinition& materialDefinition,
         const pxr::TfToken& defaultTextureAssetPathToken,
+        const pxr::TfToken& defaultTransparentTextureAssetPathToken,
         long stageId);
     ~FabricMaterial();
 
     void setMaterial(int64_t tilesetId, const MaterialInfo& materialInfo);
-    void setBaseColorTexture(const pxr::TfToken& textureAssetPathToken, const TextureInfo& textureInfo);
+    void setBaseColorTexture(
+        const pxr::TfToken& textureAssetPathToken,
+        const TextureInfo& textureInfo,
+        uint64_t texcoordIndex,
+        uint64_t textureIndex);
 
     void clearMaterial();
-    void clearBaseColorTexture();
+    void clearBaseColorTexture(uint64_t textureIndex);
 
     void setActive(bool active);
 
@@ -43,23 +48,31 @@ class FabricMaterial {
         const omni::fabric::Path& texturePath,
         const omni::fabric::Path& shaderPath,
         const omni::fabric::Token& shaderInput);
-
+    void createTextureArray(
+        const omni::fabric::Path& texturePath,
+        const omni::fabric::Path& shaderPath,
+        const omni::fabric::Token& shaderInput,
+        uint64_t textureCount);
     void reset();
     void setShaderValues(const omni::fabric::Path& shaderPath, const MaterialInfo& materialInfo);
     void setTextureValues(
         const omni::fabric::Path& texturePath,
         const pxr::TfToken& textureAssetPathToken,
-        const TextureInfo& textureInfo);
+        const TextureInfo& textureInfo,
+        uint64_t texcoordIndex);
     void setTilesetId(int64_t tilesetId);
     bool stageDestroyed();
+    void clearBaseColorTextures();
 
     omni::fabric::Path _materialPath;
     const FabricMaterialDefinition _materialDefinition;
     const pxr::TfToken _defaultTextureAssetPathToken;
+    const pxr::TfToken _defaultTransparentTextureAssetPathToken;
     const long _stageId;
 
     omni::fabric::Path _shaderPath;
     omni::fabric::Path _baseColorTexturePath;
+    std::vector<omni::fabric::Path> _baseColorTextureLayerPaths;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -10,17 +10,18 @@ struct MaterialInfo;
 
 class FabricMaterialDefinition {
   public:
-    FabricMaterialDefinition(const MaterialInfo& materialInfo, bool hasImagery, bool disableTextures);
+    FabricMaterialDefinition(const MaterialInfo& materialInfo, uint64_t imageryLayerCount, bool disableTextures);
 
-    [[nodiscard]] bool hasBaseColorTexture() const;
     [[nodiscard]] bool hasVertexColors() const;
+    [[nodiscard]] uint64_t getBaseColorTextureCount() const;
+    [[nodiscard]] bool hasBaseColorTextures() const;
 
     // Make sure to update this function when adding new fields to the class
     bool operator==(const FabricMaterialDefinition& other) const;
 
   private:
-    bool _hasBaseColorTexture;
     bool _hasVertexColors;
+    uint64_t _baseColorTextureCount;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMaterialPool.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialPool.h
@@ -15,6 +15,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
         const FabricMaterialDefinition& materialDefinition,
         uint64_t initialCapacity,
         const pxr::TfToken& defaultTextureAssetPathToken,
+        const pxr::TfToken& defaultTransparentTextureAssetPathToken,
         long stageId);
 
     [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
@@ -27,6 +28,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
     const int64_t _poolId;
     const FabricMaterialDefinition _materialDefinition;
     const pxr::TfToken _defaultTextureAssetPathToken;
+    const pxr::TfToken _defaultTransparentTextureAssetPathToken;
     const long _stageId;
 };
 

--- a/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
+++ b/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
@@ -22,6 +22,8 @@ struct FabricMesh {
     std::shared_ptr<FabricMaterial> material;
     std::shared_ptr<FabricTexture> baseColorTexture;
     MaterialInfo materialInfo;
+    std::unordered_map<uint64_t, uint64_t> texcoordIndexMapping;
+    std::unordered_map<uint64_t, uint64_t> imageryTexcoordIndexMapping;
 };
 
 struct TileRenderResources {

--- a/src/core/include/cesium/omniverse/FabricResourceManager.h
+++ b/src/core/include/cesium/omniverse/FabricResourceManager.h
@@ -62,7 +62,7 @@ class FabricResourceManager {
         long stageId);
 
     std::shared_ptr<FabricMaterial>
-    acquireMaterial(const MaterialInfo& materialInfo, bool hasImagery, long stageId, int64_t tilesetId);
+    acquireMaterial(const MaterialInfo& materialInfo, uint64_t imageryLayerCount, long stageId, int64_t tilesetId);
 
     std::shared_ptr<FabricTexture> acquireTexture();
 
@@ -140,7 +140,9 @@ class FabricResourceManager {
     std::mutex _poolMutex;
 
     std::unique_ptr<omni::ui::DynamicTextureProvider> _defaultTexture;
+    std::unique_ptr<omni::ui::DynamicTextureProvider> _defaultTransparentTexture;
     pxr::TfToken _defaultTextureAssetPathToken;
+    pxr::TfToken _defaultTransparentTextureAssetPathToken;
 
     std::vector<omni::fabric::Path> _retainedPaths;
 

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -88,4 +88,8 @@ bool hasImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshP
 bool hasVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
 bool hasMaterial(const CesiumGltf::MeshPrimitive& primitive);
 
+std::vector<uint64_t> getTexcoordSetIndexes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+std::vector<uint64_t>
+getImageryTexcoordSetIndexes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+
 } // namespace cesium::omniverse::GltfUtil

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 namespace Cesium3DTilesSelection {
+class RasterOverlay;
 class Tileset;
 class ViewState;
 class ViewUpdateResult;
@@ -72,6 +73,8 @@ class OmniTileset {
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);
+    [[nodiscard]] std::optional<uint64_t> findImageryIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const;
+    [[nodiscard]] uint64_t getImageryLayerCount() const;
     void onUpdateFrame(const std::vector<Viewport>& viewports);
 
   private:

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -13,9 +13,27 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
 // Note: variable names should match the USD token names as closely as possible, with special characters converted to underscores
 
 #define USD_TOKENS \
-    (baseColorTexture) \
+    (base_color_texture) \
+    (base_color_texture_0) \
+    (base_color_texture_1) \
+    (base_color_texture_2) \
+    (base_color_texture_3) \
+    (base_color_texture_4) \
+    (base_color_texture_5) \
+    (base_color_texture_6) \
+    (base_color_texture_7) \
+    (base_color_texture_8) \
+    (base_color_texture_9) \
+    (base_color_texture_10) \
+    (base_color_texture_11) \
+    (base_color_texture_12) \
+    (base_color_texture_13) \
+    (base_color_texture_14) \
+    (base_color_texture_15) \
+    (base_color_texture_array) \
     (cesium) \
     (cesium_material) \
+    (cesium_texture_array_lookup) \
     (cesium_texture_lookup) \
     (constant) \
     (doubleSided) \
@@ -61,6 +79,23 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_scale, "inputs:scale")) \
     ((inputs_tex_coord_index, "inputs:tex_coord_index")) \
     ((inputs_texture, "inputs:texture")) \
+    ((inputs_texture_0, "inputs:texture_0")) \
+    ((inputs_texture_1, "inputs:texture_1")) \
+    ((inputs_texture_2, "inputs:texture_2")) \
+    ((inputs_texture_3, "inputs:texture_3")) \
+    ((inputs_texture_4, "inputs:texture_4")) \
+    ((inputs_texture_5, "inputs:texture_5")) \
+    ((inputs_texture_6, "inputs:texture_6")) \
+    ((inputs_texture_7, "inputs:texture_7")) \
+    ((inputs_texture_8, "inputs:texture_8")) \
+    ((inputs_texture_9, "inputs:texture_9")) \
+    ((inputs_texture_10, "inputs:texture_10")) \
+    ((inputs_texture_11, "inputs:texture_11")) \
+    ((inputs_texture_12, "inputs:texture_12")) \
+    ((inputs_texture_13, "inputs:texture_13")) \
+    ((inputs_texture_14, "inputs:texture_14")) \
+    ((inputs_texture_15, "inputs:texture_15")) \
+    ((inputs_texture_count, "inputs:texture_count")) \
     ((inputs_vertex_color_name, "inputs:vertex_color_name")) \
     ((inputs_wrap_s, "inputs:wrap_s")) \
     ((inputs_wrap_t, "inputs:wrap_t")) \
@@ -72,7 +107,16 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_displayColor, "primvars:displayColor")) \
     ((primvars_displayOpacity, "primvars:displayOpacity")) \
     ((primvars_normals, "primvars:normals")) \
-    ((primvars_st, "primvars:st")) \
+    ((primvars_st_0, "primvars:st_0")) \
+    ((primvars_st_1, "primvars:st_1")) \
+    ((primvars_st_2, "primvars:st_2")) \
+    ((primvars_st_3, "primvars:st_3")) \
+    ((primvars_st_4, "primvars:st_4")) \
+    ((primvars_st_5, "primvars:st_5")) \
+    ((primvars_st_6, "primvars:st_6")) \
+    ((primvars_st_7, "primvars:st_7")) \
+    ((primvars_st_8, "primvars:st_8")) \
+    ((primvars_st_9, "primvars:st_9")) \
     ((primvars_vertexColor, "primvars:vertexColor")) \
     ((xformOp_transform_cesium, "xformOp:transform:cesium"))
 
@@ -104,6 +148,61 @@ __pragma(warning(pop))
 
 namespace cesium::omniverse::FabricTokens {
 FABRIC_DECLARE_TOKENS(USD_TOKENS);
+
+const uint64_t MAX_PRIMVAR_ST_COUNT = 10;
+const uint64_t MAX_TEXTURE_LAYER_COUNT = 16;
+
+const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n = {{
+    primvars_st_0,
+    primvars_st_1,
+    primvars_st_2,
+    primvars_st_3,
+    primvars_st_4,
+    primvars_st_5,
+    primvars_st_6,
+    primvars_st_7,
+    primvars_st_8,
+    primvars_st_9,
+}};
+
+const std::array<const omni::fabric::TokenC, MAX_TEXTURE_LAYER_COUNT> base_color_texture_n = {{
+    base_color_texture_0,
+    base_color_texture_1,
+    base_color_texture_2,
+    base_color_texture_3,
+    base_color_texture_4,
+    base_color_texture_5,
+    base_color_texture_6,
+    base_color_texture_7,
+    base_color_texture_8,
+    base_color_texture_9,
+    base_color_texture_10,
+    base_color_texture_11,
+    base_color_texture_12,
+    base_color_texture_13,
+    base_color_texture_14,
+    base_color_texture_15,
+}};
+
+const std::array<const omni::fabric::TokenC, MAX_TEXTURE_LAYER_COUNT> inputs_texture_n = {{
+    inputs_texture_0,
+    inputs_texture_1,
+    inputs_texture_2,
+    inputs_texture_3,
+    inputs_texture_4,
+    inputs_texture_5,
+    inputs_texture_6,
+    inputs_texture_7,
+    inputs_texture_8,
+    inputs_texture_9,
+    inputs_texture_10,
+    inputs_texture_11,
+    inputs_texture_12,
+    inputs_texture_13,
+    inputs_texture_14,
+    inputs_texture_15,
+}};
+
 }
 
 namespace cesium::omniverse::FabricTypes {
@@ -128,6 +227,7 @@ const omni::fabric::Type inputs_roughness_factor(omni::fabric::BaseDataType::eFl
 const omni::fabric::Type inputs_scale(omni::fabric::BaseDataType::eFloat, 2, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_tex_coord_index(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_texture(omni::fabric::BaseDataType::eAsset, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_texture_count(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_vertex_color_name(omni::fabric::BaseDataType::eUChar, 1, 1, omni::fabric::AttributeRole::eText);
 const omni::fabric::Type inputs_wrap_s(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_wrap_t(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -15,20 +15,12 @@ FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals) {
-
-    const auto hasPrimitiveSt = GltfUtil::hasTexcoords(model, primitive, 0);
-    const auto hasImagerySt = GltfUtil::hasImageryTexcoords(model, primitive, 0);
-
     const auto materialInfo = GltfUtil::getMaterialInfo(model, primitive);
-
-    _hasTexcoords = hasPrimitiveSt || hasImagerySt;
     _hasNormals = GltfUtil::hasNormals(model, primitive, smoothNormals);
     _hasVertexColors = GltfUtil::hasVertexColors(model, primitive, 0);
     _doubleSided = materialInfo.doubleSided;
-}
-
-bool FabricGeometryDefinition::hasTexcoords() const {
-    return _hasTexcoords;
+    _texcoordSetCount = GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
+                        GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size();
 }
 
 bool FabricGeometryDefinition::hasNormals() const {
@@ -43,11 +35,11 @@ bool FabricGeometryDefinition::getDoubleSided() const {
     return _doubleSided;
 }
 
-bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other) const {
-    if (_hasTexcoords != other._hasTexcoords) {
-        return false;
-    }
+[[nodiscard]] uint64_t FabricGeometryDefinition::getTexcoordSetCount() const {
+    return _texcoordSetCount;
+}
 
+bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other) const {
     if (_hasNormals != other._hasNormals) {
         return false;
     }
@@ -57,6 +49,10 @@ bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other)
     }
 
     if (_doubleSided != other._doubleSided) {
+        return false;
+    }
+
+    if (_texcoordSetCount != other._texcoordSetCount) {
         return false;
     }
 

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -2,8 +2,10 @@
 
 #include "cesium/omniverse/Context.h"
 #include "cesium/omniverse/FabricAttributesBuilder.h"
+#include "cesium/omniverse/FabricMaterialDefinition.h"
 #include "cesium/omniverse/FabricResourceManager.h"
 #include "cesium/omniverse/FabricUtil.h"
+#include "cesium/omniverse/LoggerSink.h"
 #include "cesium/omniverse/Tokens.h"
 #include "cesium/omniverse/UsdUtil.h"
 
@@ -12,14 +14,33 @@
 
 namespace cesium::omniverse {
 
+namespace {
+uint64_t getBaseColorTextureCount(const FabricMaterialDefinition& materialDefinition) {
+    auto baseColorTextureCount = materialDefinition.getBaseColorTextureCount();
+
+    if (baseColorTextureCount > FabricTokens::MAX_TEXTURE_LAYER_COUNT) {
+        CESIUM_LOG_WARN(
+            "Number of textures ({}) exceeds maximum texture layer count ({}). Excess textures will be ignored.",
+            baseColorTextureCount,
+            FabricTokens::MAX_TEXTURE_LAYER_COUNT);
+    }
+
+    baseColorTextureCount = glm::min(baseColorTextureCount, FabricTokens::MAX_TEXTURE_LAYER_COUNT);
+
+    return baseColorTextureCount;
+}
+} // namespace
+
 FabricMaterial::FabricMaterial(
     const omni::fabric::Path& path,
     const FabricMaterialDefinition& materialDefinition,
     const pxr::TfToken& defaultTextureAssetPathToken,
+    const pxr::TfToken& defaultTransparentTextureAssetPathToken,
     long stageId)
     : _materialPath(path)
     , _materialDefinition(materialDefinition)
     , _defaultTextureAssetPathToken(defaultTextureAssetPathToken)
+    , _defaultTransparentTextureAssetPathToken(defaultTransparentTextureAssetPathToken)
     , _stageId(stageId) {
 
     if (stageDestroyed()) {
@@ -38,8 +59,12 @@ FabricMaterial::~FabricMaterial() {
     FabricUtil::destroyPrim(_materialPath);
     FabricUtil::destroyPrim(_shaderPath);
 
-    if (_materialDefinition.hasBaseColorTexture()) {
+    if (_materialDefinition.hasBaseColorTextures()) {
         FabricUtil::destroyPrim(_baseColorTexturePath);
+
+        for (const auto& baseColorTextureLayerPath : _baseColorTextureLayerPaths) {
+            FabricUtil::destroyPrim(baseColorTextureLayerPath);
+        }
     }
 }
 
@@ -62,25 +87,39 @@ const FabricMaterialDefinition& FabricMaterial::getMaterialDefinition() const {
 }
 
 void FabricMaterial::initialize() {
-    const auto hasBaseColorTexture = _materialDefinition.hasBaseColorTexture();
-
     const auto& materialPath = _materialPath;
-    const auto shaderPath = FabricUtil::joinPaths(materialPath, FabricTokens::Shader);
-    const auto baseColorTexturePath = FabricUtil::joinPaths(materialPath, FabricTokens::baseColorTexture);
-
-    _materialPath = materialPath;
-    _shaderPath = shaderPath;
-    _baseColorTexturePath = baseColorTexturePath;
-
-    FabricResourceManager::getInstance().retainPath(materialPath);
-    FabricResourceManager::getInstance().retainPath(shaderPath);
-    FabricResourceManager::getInstance().retainPath(baseColorTexturePath);
-
     createMaterial(materialPath);
-    createShader(shaderPath, materialPath);
+    auto& fabricResourceManager = FabricResourceManager::getInstance();
+    fabricResourceManager.retainPath(materialPath);
 
-    if (hasBaseColorTexture) {
+    const auto shaderPath = FabricUtil::joinPaths(materialPath, FabricTokens::Shader);
+    createShader(shaderPath, materialPath);
+    fabricResourceManager.retainPath(shaderPath);
+    _shaderPath = shaderPath;
+
+    const auto baseColorTextureCount = getBaseColorTextureCount(_materialDefinition);
+
+    if (baseColorTextureCount == 1) {
+        const auto baseColorTexturePath = FabricUtil::joinPaths(materialPath, FabricTokens::base_color_texture);
+        fabricResourceManager.retainPath(baseColorTexturePath);
+        _baseColorTexturePath = baseColorTexturePath;
         createTexture(baseColorTexturePath, shaderPath, FabricTokens::inputs_base_color_texture);
+    } else if (baseColorTextureCount > 1) {
+        const auto baseColorTexturePath = FabricUtil::joinPaths(materialPath, FabricTokens::base_color_texture_array);
+        fabricResourceManager.retainPath(baseColorTexturePath);
+        _baseColorTexturePath = baseColorTexturePath;
+        createTextureArray(
+            baseColorTexturePath, shaderPath, FabricTokens::inputs_base_color_texture, baseColorTextureCount);
+
+        _baseColorTextureLayerPaths.reserve(baseColorTextureCount);
+        for (uint64_t i = 0; i < baseColorTextureCount; i++) {
+            const auto& baseColorTextureToken = FabricTokens::base_color_texture_n[i];
+            const auto& inputsBaseColorTextureToken = FabricTokens::inputs_texture_n[i];
+            const auto baseColorTextureLayerPath = FabricUtil::joinPaths(materialPath, baseColorTextureToken);
+            createTexture(baseColorTextureLayerPath, baseColorTexturePath, inputsBaseColorTextureToken);
+            fabricResourceManager.retainPath(baseColorTextureLayerPath);
+            _baseColorTextureLayerPaths.push_back(baseColorTextureLayerPath);
+        }
     }
 }
 
@@ -224,9 +263,53 @@ void FabricMaterial::createTexture(
     srw.createConnection(shaderPath, shaderInput, omni::fabric::Connection{texturePath, FabricTokens::outputs_out});
 }
 
+void FabricMaterial::createTextureArray(
+    const omni::fabric::Path& texturePath,
+    const omni::fabric::Path& shaderPath,
+    const omni::fabric::Token& shaderInput,
+    uint64_t textureCount) {
+    auto srw = UsdUtil::getFabricStageReaderWriter();
+
+    srw.createPrim(texturePath);
+
+    FabricAttributesBuilder attributes;
+
+    // clang-format off
+    attributes.addAttribute(FabricTypes::inputs_texture_count, FabricTokens::inputs_texture_count);
+    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
+    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
+    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
+    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
+    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
+    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
+    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
+    // clang-format on
+
+    attributes.createAttributes(texturePath);
+
+    // clang-format off
+    auto inputsTextureCountFabric = srw.getAttributeWr<int>(texturePath, FabricTokens::inputs_texture_count);
+    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(texturePath, FabricTokens::inputs_excludeFromWhiteMode);
+    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(texturePath, FabricTokens::info_implementationSource);
+    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(texturePath, FabricTokens::info_mdl_sourceAsset);
+    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(texturePath, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    // clang-format on
+
+    *inputsTextureCountFabric = static_cast<int>(textureCount);
+    *inputsExcludeFromWhiteModeFabric = false;
+    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
+    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
+    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
+    *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_texture_array_lookup;
+
+    // Create connection from shader to texture.
+    srw.createConnection(shaderPath, shaderInput, omni::fabric::Connection{texturePath, FabricTokens::outputs_out});
+}
+
 void FabricMaterial::reset() {
     clearMaterial();
-    clearBaseColorTexture();
+    clearBaseColorTextures();
 }
 
 void FabricMaterial::setMaterial(int64_t tilesetId, const MaterialInfo& materialInfo) {
@@ -240,32 +323,64 @@ void FabricMaterial::setMaterial(int64_t tilesetId, const MaterialInfo& material
     setTilesetId(tilesetId);
 }
 
-void FabricMaterial::setBaseColorTexture(const pxr::TfToken& textureAssetPathToken, const TextureInfo& textureInfo) {
+void FabricMaterial::setBaseColorTexture(
+    const pxr::TfToken& textureAssetPathToken,
+    const TextureInfo& textureInfo,
+    uint64_t texcoordIndex,
+    uint64_t textureIndex) {
     if (stageDestroyed()) {
         return;
     }
 
-    if (!_materialDefinition.hasBaseColorTexture()) {
+    if (!_materialDefinition.hasBaseColorTextures()) {
         return;
     }
 
-    setTextureValues(_baseColorTexturePath, textureAssetPathToken, textureInfo);
+    if (textureIndex >= FabricTokens::MAX_TEXTURE_LAYER_COUNT) {
+        return;
+    }
+
+    if (_baseColorTextureLayerPaths.empty()) {
+        assert(textureIndex == 0);
+        setTextureValues(_baseColorTexturePath, textureAssetPathToken, textureInfo, texcoordIndex);
+    } else {
+        setTextureValues(_baseColorTextureLayerPaths[textureIndex], textureAssetPathToken, textureInfo, texcoordIndex);
+    }
 }
 
 void FabricMaterial::clearMaterial() {
     setMaterial(NO_TILESET_ID, GltfUtil::getDefaultMaterialInfo());
 }
 
-void FabricMaterial::clearBaseColorTexture() {
-    setBaseColorTexture(_defaultTextureAssetPathToken, GltfUtil::getDefaultTextureInfo());
+void FabricMaterial::clearBaseColorTextures() {
+    if (!_materialDefinition.hasBaseColorTextures()) {
+        return;
+    }
+
+    if (_baseColorTextureLayerPaths.empty()) {
+        clearBaseColorTexture(0);
+    } else {
+        for (uint64_t i = 0; i < _baseColorTextureLayerPaths.size(); i++) {
+            clearBaseColorTexture(i);
+        }
+    }
+}
+
+void FabricMaterial::clearBaseColorTexture(uint64_t textureIndex) {
+    const auto& token = textureIndex == 0 ? _defaultTextureAssetPathToken : _defaultTransparentTextureAssetPathToken;
+    setBaseColorTexture(token, GltfUtil::getDefaultTextureInfo(), 0, textureIndex);
 }
 
 void FabricMaterial::setTilesetId(int64_t tilesetId) {
     FabricUtil::setTilesetId(_materialPath, tilesetId);
     FabricUtil::setTilesetId(_shaderPath, tilesetId);
 
-    if (_materialDefinition.hasBaseColorTexture()) {
+    if (_materialDefinition.hasBaseColorTextures()) {
         FabricUtil::setTilesetId(_baseColorTexturePath, tilesetId);
+
+        for (const auto& baseColorTextureLayerPath : _baseColorTextureLayerPaths) {
+            FabricUtil::setTilesetId(baseColorTextureLayerPath, tilesetId);
+        }
     }
 }
 
@@ -292,7 +407,13 @@ void FabricMaterial::setShaderValues(const omni::fabric::Path& shaderPath, const
 void FabricMaterial::setTextureValues(
     const omni::fabric::Path& texturePath,
     const pxr::TfToken& textureAssetPathToken,
-    const TextureInfo& textureInfo) {
+    const TextureInfo& textureInfo,
+    uint64_t texcoordIndex) {
+
+    if (texcoordIndex >= FabricTokens::MAX_TEXTURE_LAYER_COUNT) {
+        return;
+    }
+
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
     auto offset = textureInfo.offset;
@@ -317,7 +438,7 @@ void FabricMaterial::setTextureValues(
 
     textureFabric->assetPath = textureAssetPathToken;
     textureFabric->resolvedPath = pxr::TfToken();
-    *texCoordIndexFabric = static_cast<int>(textureInfo.setIndex);
+    *texCoordIndexFabric = static_cast<int>(texcoordIndex);
     *wrapSFabric = textureInfo.wrapS;
     *wrapTFabric = textureInfo.wrapT;
     *offsetFabric = UsdUtil::glmToUsdVector(glm::fvec2(offset));

--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -13,24 +13,29 @@ namespace cesium::omniverse {
 
 FabricMaterialDefinition::FabricMaterialDefinition(
     const MaterialInfo& materialInfo,
-    bool hasImagery,
+    uint64_t imageryLayerCount,
     bool disableTextures) {
 
-    _hasBaseColorTexture = materialInfo.baseColorTexture.has_value();
+    uint64_t baseColorTextureCount = 0;
 
-    if (hasImagery) {
-        _hasBaseColorTexture = true;
-    }
+    if (!disableTextures) {
+        if (materialInfo.baseColorTexture.has_value()) {
+            baseColorTextureCount++;
+        }
 
-    if (disableTextures) {
-        _hasBaseColorTexture = false;
+        baseColorTextureCount += imageryLayerCount;
     }
 
     _hasVertexColors = materialInfo.hasVertexColors;
+    _baseColorTextureCount = baseColorTextureCount;
 }
 
-bool FabricMaterialDefinition::hasBaseColorTexture() const {
-    return _hasBaseColorTexture;
+uint64_t FabricMaterialDefinition::getBaseColorTextureCount() const {
+    return _baseColorTextureCount;
+}
+
+bool FabricMaterialDefinition::hasBaseColorTextures() const {
+    return _baseColorTextureCount > 0;
 }
 
 bool FabricMaterialDefinition::hasVertexColors() const {
@@ -39,11 +44,11 @@ bool FabricMaterialDefinition::hasVertexColors() const {
 
 // In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other) const {
-    if (_hasBaseColorTexture != other._hasBaseColorTexture) {
+    if (_hasVertexColors != other._hasVertexColors) {
         return false;
     }
 
-    if (_hasVertexColors != other._hasVertexColors) {
+    if (_baseColorTextureCount != other._baseColorTextureCount) {
         return false;
     }
 

--- a/src/core/src/FabricMaterialPool.cpp
+++ b/src/core/src/FabricMaterialPool.cpp
@@ -9,11 +9,13 @@ FabricMaterialPool::FabricMaterialPool(
     const FabricMaterialDefinition& materialDefinition,
     uint64_t initialCapacity,
     const pxr::TfToken& defaultTextureAssetPathToken,
+    const pxr::TfToken& defaultTransparentTextureAssetPathToken,
     long stageId)
     : ObjectPool<FabricMaterial>()
     , _poolId(poolId)
     , _materialDefinition(materialDefinition)
     , _defaultTextureAssetPathToken(defaultTextureAssetPathToken)
+    , _defaultTransparentTextureAssetPathToken(defaultTransparentTextureAssetPathToken)
     , _stageId(stageId) {
     setCapacity(initialCapacity);
 }
@@ -25,7 +27,8 @@ const FabricMaterialDefinition& FabricMaterialPool::getMaterialDefinition() cons
 std::shared_ptr<FabricMaterial> FabricMaterialPool::createObject(uint64_t objectId) {
     const auto pathStr = fmt::format("/fabric_material_pool_{}_object_{}", _poolId, objectId);
     const auto path = omni::fabric::Path(pathStr.c_str());
-    return std::make_shared<FabricMaterial>(path, _materialDefinition, _defaultTextureAssetPathToken, _stageId);
+    return std::make_shared<FabricMaterial>(
+        path, _materialDefinition, _defaultTextureAssetPathToken, _defaultTransparentTextureAssetPathToken, _stageId);
 }
 
 void FabricMaterialPool::setActive(std::shared_ptr<FabricMaterial> material, bool active) {

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -411,6 +411,23 @@ void OmniTileset::addImageryIon(const pxr::SdfPath& imageryPath) {
     _tileset->getOverlays().add(ionRasterOverlay);
 }
 
+std::optional<uint64_t> OmniTileset::findImageryIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const {
+    uint64_t overlayIndex = 0;
+    for (const auto& pOverlay : _tileset->getOverlays()) {
+        if (&overlay == pOverlay.get()) {
+            return overlayIndex;
+        }
+
+        overlayIndex++;
+    }
+
+    return std::nullopt;
+}
+
+uint64_t OmniTileset::getImageryLayerCount() const {
+    return _tileset->getOverlays().size();
+}
+
 void OmniTileset::onUpdateFrame(const std::vector<Viewport>& viewports) {
     if (!UsdUtil::primExists(_tilesetPath)) {
         // TfNotice can be slow, and sometimes we get a frame or two before we actually get a chance to react on it.


### PR DESCRIPTION
Fixes #84 

Adds support for multiple raster overlays.

* Works on untextured datasets like CWT and textured datasets like Google 3D Tiles
* Works for geographic and web mercator projections and future projections (i.e. texcoord sets are handled correctly)
* Works for raster overlays with alpha

This required changes in a few places:

* `FabricGeometry` and `FabricGeometryDefinition` now handle texcoord sets in a generic way. There were a few places where the texcoord set was hardcoded to zero. This has been fixed. See related changes in `GltfUtil`.
* `FabricMaterial` supports up to 10 texcoord sets and 16 textures per texture array. Excess texcoord sets and textures are ignored. When there's a single texture it constructs the same shader network as before, so no performance loss. When there's multiple textures it uses the new `cesium_texture_array_lookup` shader which is responsible for blending all the imagery layers together with a simple alpha over blend. See `cesium.mdl`.

Note that the changes to `FabricGeometryDefinition` and `FabricMaterialDefinition` affect pooling - i.e. geometries with the same number of texcoord sets will go to the same geometry pool and materials with the same number of base color textures will go the same material pool.

The main performance TODO is:

* `cesium_texture_array_lookup` is hardcoded for 16 textures which is much higher than the common case. If we procedurally generate the .mdl based on how many textures are in use it could improve performance. Or we could just have 16 versions of `cesium_texture_array_lookup` :shrug:.

Not supported yet:

* Styling, such as controlling the translucency of imagery layers

**Examples:**

[multiple.usda.zip](https://github.com/CesiumGS/cesium-omniverse/files/12922644/multiple.usda.zip)
Washington DC (Web Mercator) above Sentinel II (geographic) above Bing Maps (Web Mercator, not visible) 

![image (11)](https://github.com/CesiumGS/cesium-omniverse/assets/915398/3d1dbe22-b249-48d2-b242-857dffbff365)

[multiple-google.usda.zip](https://github.com/CesiumGS/cesium-omniverse/files/12922646/multiple-google.usda.zip)
Washington DC (Web Meractor) above Google 3D Tiles (textured glTF)

![image (12)](https://github.com/CesiumGS/cesium-omniverse/assets/915398/b9429763-7324-4baf-bc55-038bd87129c2)
