### PR TITLE
Fixed opening a USD file with saved Globe Anchors

### DIFF
--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -125,5 +125,7 @@ void setGeoreferenceForTileset(const pxr::SdfPath& tilesetPath, const pxr::SdfPa
 
 void addOrUpdateTransformOpForAnchor(const pxr::SdfPath& path, const glm::dmat4& transform);
 std::optional<pxr::GfMatrix4d> getCesiumTransformOpValueForPathIfExists(const pxr::SdfPath& path);
+std::optional<pxr::SdfPath> getAnchorGeoreferencePath(const pxr::SdfPath& path);
+std::optional<CesiumGeospatial::Cartographic> getCartographicOriginForAnchor(const pxr::SdfPath& path);
 
 }; // namespace cesium::omniverse::UsdUtil

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -126,7 +126,7 @@ void UsdNotificationHandler::onObjectsChanged(const pxr::UsdNotice::ObjectsChang
 
 void UsdNotificationHandler::onPrimAdded(const pxr::SdfPath& primPath) {
     const auto type = getType(primPath);
-    if (type != ChangedPrimType::OTHER && type != ChangedPrimType::CESIUM_GLOBE_ANCHOR) {
+    if (type != ChangedPrimType::OTHER) {
         _changedPrims.emplace_back(ChangedPrim{primPath, pxr::TfToken(), type, ChangeType::PRIM_ADDED});
         CESIUM_LOG_INFO("Added prim: {}", primPath.GetText());
     }

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -559,4 +559,29 @@ std::optional<pxr::GfMatrix4d> getCesiumTransformOpValueForPathIfExists(const px
     return std::nullopt;
 }
 
+std::optional<pxr::SdfPath> getAnchorGeoreferencePath(const pxr::SdfPath& path) {
+    if (!hasCesiumGlobeAnchor(path)) {
+        return std::nullopt;
+    }
+
+    auto globeAnchor = getCesiumGlobeAnchor(path);
+    pxr::SdfPathVector targets;
+    if (!globeAnchor.GetGeoreferenceBindingRel().GetForwardedTargets(&targets)) {
+        return std::nullopt;
+    }
+
+    return targets[0];
+}
+
+std::optional<CesiumGeospatial::Cartographic> getCartographicOriginForAnchor(const pxr::SdfPath& path) {
+    auto anchorGeoreferencePath = getAnchorGeoreferencePath(path);
+
+    if (!anchorGeoreferencePath.has_value()) {
+        return std::nullopt;
+    }
+
+    auto georeferenceOrigin = UsdUtil::getCesiumGeoreference(anchorGeoreferencePath.value());
+    return GeospatialUtil::convertGeoreferenceToCartographic(georeferenceOrigin);
+}
+
 } // namespace cesium::omniverse::UsdUtil


### PR DESCRIPTION
Resolves #489.

Opening a USD file with saved Globe Anchors wasn't adding them to the Globe Anchor registry until they were moved the first time. This resolves that issue.