### PR TITLE
Multiple raster overlays cleanup

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -11,64 +11,95 @@ module [[
     anno::display_name("Cesium MDL functions")
 ]];
 
-// For internal use only
-export gltf_texture_lookup_value cesium_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();
-export material cesium_material(*) [[ anno::hidden() ]] = gltf_material();
+float4 alpha_blend(float4 src, float4 dst) {
+    return src * float4(src.w, src.w, src.w, 1.0) + dst * (1.0 - src.w);
+}
 
-export gltf_texture_lookup_value cesium_texture_array_lookup(
-    uniform int texture_count = 0,
-    gltf_texture_lookup_value texture_0 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_1 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_2 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_3 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_4 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_5 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_6 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_7 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_8 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_9 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_10 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_11 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_12 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_13 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_14 = gltf_texture_lookup(),
-    gltf_texture_lookup_value texture_15 = gltf_texture_lookup()
-) [[ anno::hidden() ]]
-{
-    // The array length should match MAX_TEXTURE_LAYER_COUNT in Tokens.h
-    gltf_texture_lookup_value[16] texture_values(
-        texture_0,
-        texture_1,
-        texture_2,
-        texture_3,
-        texture_4,
-        texture_5,
-        texture_6,
-        texture_7,
-        texture_8,
-        texture_9,
-        texture_10,
-        texture_11,
-        texture_12,
-        texture_13,
-        texture_14,
-        texture_15,
+export gltf_texture_lookup_value cesium_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();
+
+export material cesium_material(
+    gltf_texture_lookup_value imagery_layers_texture = gltf_texture_lookup_value(true, float4(0.0)),
+    // gltf_material inputs below
+    gltf_texture_lookup_value base_color_texture = gltf_texture_lookup_value(),
+    uniform color base_color_factor = color(1.0),
+    uniform float metallic_factor = 1.0,
+    uniform float roughness_factor = 1.0,
+    uniform color emissive_factor = color(0.0),
+    uniform gltf_alpha_mode alpha_mode = opaque,
+    uniform float base_alpha = 1.0,
+    uniform float alpha_cutoff  = 0.5
+) [[ anno::hidden() ]] = let {
+    auto base_color_texture_value = base_color_texture.valid ? base_color_texture.value : float4(1.0);
+    auto final_base_color_texture_value = alpha_blend(imagery_layers_texture.value, base_color_texture_value);
+    auto final_base_color_texture = gltf_texture_lookup_value(true, final_base_color_texture_value);
+    auto final_base_color_factor = base_color_factor;
+
+    material base = gltf_material(
+        base_color_factor: final_base_color_factor,
+        base_color_texture: final_base_color_texture,
+        metallic_factor: metallic_factor,
+        roughness_factor: roughness_factor,
+        emissive_factor: emissive_factor,
+        alpha_mode: alpha_mode,
+        base_alpha: base_alpha,
+        alpha_cutoff: alpha_cutoff
     );
 
-    float3 final = float3(1.0, 1.0, 1.0);
+} in material(
+    thin_walled: base.thin_walled,
+    surface: base.surface,
+    volume: base.volume,
+    ior: base.ior,
+    geometry: base.geometry
+);
 
-    for (int i = 0; i < texture_count; i++) {
-        gltf_texture_lookup_value value = texture_values[i];
-        if (value.valid) {
-            float3 rgb = float3(value.value[0], value.value[1], value.value[2]);
-            float alpha = value.value[3];
-            final = alpha * rgb + (1.0 - alpha) * final;
+export gltf_texture_lookup_value cesium_imagery_layer_resolver(
+    uniform int imagery_layers_count = 0,
+    gltf_texture_lookup_value imagery_layer_0 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_1 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_2 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_3 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_4 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_5 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_6 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_7 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_8 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_9 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_10 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_11 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_12 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_13 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_14 = gltf_texture_lookup(),
+    gltf_texture_lookup_value imagery_layer_15 = gltf_texture_lookup()
+) [[ anno::hidden() ]] {
+    // The array length should match MAX_IMAGERY_LAYERS_COUNT in Tokens.h
+    gltf_texture_lookup_value[16] imagery_layers(
+        imagery_layer_0,
+        imagery_layer_1,
+        imagery_layer_2,
+        imagery_layer_3,
+        imagery_layer_4,
+        imagery_layer_5,
+        imagery_layer_6,
+        imagery_layer_7,
+        imagery_layer_8,
+        imagery_layer_9,
+        imagery_layer_10,
+        imagery_layer_11,
+        imagery_layer_12,
+        imagery_layer_13,
+        imagery_layer_14,
+        imagery_layer_15,
+    );
+
+    auto resolved_value = float4(0.0);
+
+    for (int i = 0; i < imagery_layers_count; i++) {
+        auto imagery_layer = imagery_layers[i];
+        if (imagery_layer.valid) {
+            resolved_value = alpha_blend(imagery_layer.value, resolved_value);
         }
     }
 
-    gltf_texture_lookup_value tex_ret;
-    tex_ret.value = float4(final[0], final[1], final[2], 1.0);
-    tex_ret.valid = true;
-
-    return tex_ret;
+    return gltf_texture_lookup_value(true, resolved_value);
 }

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -28,11 +28,17 @@ class FabricMaterial {
     void setBaseColorTexture(
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
+        uint64_t texcoordIndex);
+    void setImageryLayer(
+        const pxr::TfToken& textureAssetPathToken,
+        const TextureInfo& textureInfo,
         uint64_t texcoordIndex,
-        uint64_t textureIndex);
+        uint64_t imageryLayerIndex);
 
     void clearMaterial();
-    void clearBaseColorTexture(uint64_t textureIndex);
+    void clearBaseColorTexture();
+    void clearImageryLayer(uint64_t imageryLayerIndex);
+    void clearImageryLayers();
 
     void setActive(bool active);
 
@@ -48,8 +54,8 @@ class FabricMaterial {
         const omni::fabric::Path& texturePath,
         const omni::fabric::Path& shaderPath,
         const omni::fabric::Token& shaderInput);
-    void createTextureArray(
-        const omni::fabric::Path& texturePath,
+    void createImageryLayerResolver(
+        const omni::fabric::Path& imageryLayerResolverPath,
         const omni::fabric::Path& shaderPath,
         const omni::fabric::Token& shaderInput,
         uint64_t textureCount);
@@ -60,9 +66,7 @@ class FabricMaterial {
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex);
-    void setTilesetId(int64_t tilesetId);
     bool stageDestroyed();
-    void clearBaseColorTextures();
 
     omni::fabric::Path _materialPath;
     const FabricMaterialDefinition _materialDefinition;
@@ -72,7 +76,9 @@ class FabricMaterial {
 
     omni::fabric::Path _shaderPath;
     omni::fabric::Path _baseColorTexturePath;
-    std::vector<omni::fabric::Path> _baseColorTextureLayerPaths;
+    std::vector<omni::fabric::Path> _imageryLayerPaths;
+
+    std::vector<omni::fabric::Path> _allPaths;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -13,15 +13,16 @@ class FabricMaterialDefinition {
     FabricMaterialDefinition(const MaterialInfo& materialInfo, uint64_t imageryLayerCount, bool disableTextures);
 
     [[nodiscard]] bool hasVertexColors() const;
-    [[nodiscard]] uint64_t getBaseColorTextureCount() const;
-    [[nodiscard]] bool hasBaseColorTextures() const;
+    [[nodiscard]] bool hasBaseColorTexture() const;
+    [[nodiscard]] uint64_t getImageryLayerCount() const;
 
     // Make sure to update this function when adding new fields to the class
     bool operator==(const FabricMaterialDefinition& other) const;
 
   private:
     bool _hasVertexColors;
-    uint64_t _baseColorTextureCount;
+    bool _hasBaseColorTexture;
+    uint64_t _imageryLayerCount;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -34,5 +34,6 @@ void setTilesetTransform(int64_t tilesetId, const glm::dmat4& ecefToUsdTransform
 void setTilesetId(const omni::fabric::Path& path, int64_t tilesetId);
 omni::fabric::Path toFabricPath(const pxr::SdfPath& path);
 omni::fabric::Path joinPaths(const omni::fabric::Path& absolutePath, const omni::fabric::Token& relativePath);
+bool isEmpty(const omni::fabric::Path& path);
 
 } // namespace cesium::omniverse::FabricUtil

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -73,7 +73,8 @@ class OmniTileset {
 
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);
-    [[nodiscard]] std::optional<uint64_t> findImageryIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const;
+    [[nodiscard]] std::optional<uint64_t>
+    findImageryLayerIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const;
     [[nodiscard]] uint64_t getImageryLayerCount() const;
     void onUpdateFrame(const std::vector<Viewport>& viewports);
 

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -14,32 +14,32 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
 
 #define USD_TOKENS \
     (base_color_texture) \
-    (base_color_texture_0) \
-    (base_color_texture_1) \
-    (base_color_texture_2) \
-    (base_color_texture_3) \
-    (base_color_texture_4) \
-    (base_color_texture_5) \
-    (base_color_texture_6) \
-    (base_color_texture_7) \
-    (base_color_texture_8) \
-    (base_color_texture_9) \
-    (base_color_texture_10) \
-    (base_color_texture_11) \
-    (base_color_texture_12) \
-    (base_color_texture_13) \
-    (base_color_texture_14) \
-    (base_color_texture_15) \
-    (base_color_texture_array) \
     (cesium) \
+    (cesium_imagery_layer_resolver) \
     (cesium_material) \
-    (cesium_texture_array_lookup) \
     (cesium_texture_lookup) \
     (constant) \
     (doubleSided) \
     (extent) \
     (faceVertexCounts) \
     (faceVertexIndices) \
+    (imagery_layer_0) \
+    (imagery_layer_1) \
+    (imagery_layer_2) \
+    (imagery_layer_3) \
+    (imagery_layer_4) \
+    (imagery_layer_5) \
+    (imagery_layer_6) \
+    (imagery_layer_7) \
+    (imagery_layer_8) \
+    (imagery_layer_9) \
+    (imagery_layer_10) \
+    (imagery_layer_11) \
+    (imagery_layer_12) \
+    (imagery_layer_13) \
+    (imagery_layer_14) \
+    (imagery_layer_15) \
+    (imagery_layer_resolver) \
     (Material) \
     (Mesh) \
     (none) \
@@ -79,23 +79,24 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_scale, "inputs:scale")) \
     ((inputs_tex_coord_index, "inputs:tex_coord_index")) \
     ((inputs_texture, "inputs:texture")) \
-    ((inputs_texture_0, "inputs:texture_0")) \
-    ((inputs_texture_1, "inputs:texture_1")) \
-    ((inputs_texture_2, "inputs:texture_2")) \
-    ((inputs_texture_3, "inputs:texture_3")) \
-    ((inputs_texture_4, "inputs:texture_4")) \
-    ((inputs_texture_5, "inputs:texture_5")) \
-    ((inputs_texture_6, "inputs:texture_6")) \
-    ((inputs_texture_7, "inputs:texture_7")) \
-    ((inputs_texture_8, "inputs:texture_8")) \
-    ((inputs_texture_9, "inputs:texture_9")) \
-    ((inputs_texture_10, "inputs:texture_10")) \
-    ((inputs_texture_11, "inputs:texture_11")) \
-    ((inputs_texture_12, "inputs:texture_12")) \
-    ((inputs_texture_13, "inputs:texture_13")) \
-    ((inputs_texture_14, "inputs:texture_14")) \
-    ((inputs_texture_15, "inputs:texture_15")) \
-    ((inputs_texture_count, "inputs:texture_count")) \
+    ((inputs_imagery_layer_0, "inputs:imagery_layer_0")) \
+    ((inputs_imagery_layer_1, "inputs:imagery_layer_1")) \
+    ((inputs_imagery_layer_2, "inputs:imagery_layer_2")) \
+    ((inputs_imagery_layer_3, "inputs:imagery_layer_3")) \
+    ((inputs_imagery_layer_4, "inputs:imagery_layer_4")) \
+    ((inputs_imagery_layer_5, "inputs:imagery_layer_5")) \
+    ((inputs_imagery_layer_6, "inputs:imagery_layer_6")) \
+    ((inputs_imagery_layer_7, "inputs:imagery_layer_7")) \
+    ((inputs_imagery_layer_8, "inputs:imagery_layer_8")) \
+    ((inputs_imagery_layer_9, "inputs:imagery_layer_9")) \
+    ((inputs_imagery_layer_10, "inputs:imagery_layer_10")) \
+    ((inputs_imagery_layer_11, "inputs:imagery_layer_11")) \
+    ((inputs_imagery_layer_12, "inputs:imagery_layer_12")) \
+    ((inputs_imagery_layer_13, "inputs:imagery_layer_13")) \
+    ((inputs_imagery_layer_14, "inputs:imagery_layer_14")) \
+    ((inputs_imagery_layer_15, "inputs:imagery_layer_15")) \
+    ((inputs_imagery_layers_count, "inputs:imagery_layers_count")) \
+    ((inputs_imagery_layers_texture, "inputs:imagery_layers_texture")) \
     ((inputs_vertex_color_name, "inputs:vertex_color_name")) \
     ((inputs_wrap_s, "inputs:wrap_s")) \
     ((inputs_wrap_t, "inputs:wrap_t")) \
@@ -150,7 +151,7 @@ namespace cesium::omniverse::FabricTokens {
 FABRIC_DECLARE_TOKENS(USD_TOKENS);
 
 const uint64_t MAX_PRIMVAR_ST_COUNT = 10;
-const uint64_t MAX_TEXTURE_LAYER_COUNT = 16;
+const uint64_t MAX_IMAGERY_LAYERS_COUNT = 16;
 
 const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n = {{
     primvars_st_0,
@@ -165,42 +166,42 @@ const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n
     primvars_st_9,
 }};
 
-const std::array<const omni::fabric::TokenC, MAX_TEXTURE_LAYER_COUNT> base_color_texture_n = {{
-    base_color_texture_0,
-    base_color_texture_1,
-    base_color_texture_2,
-    base_color_texture_3,
-    base_color_texture_4,
-    base_color_texture_5,
-    base_color_texture_6,
-    base_color_texture_7,
-    base_color_texture_8,
-    base_color_texture_9,
-    base_color_texture_10,
-    base_color_texture_11,
-    base_color_texture_12,
-    base_color_texture_13,
-    base_color_texture_14,
-    base_color_texture_15,
+const std::array<const omni::fabric::TokenC, MAX_IMAGERY_LAYERS_COUNT> imagery_layer_n = {{
+    imagery_layer_0,
+    imagery_layer_1,
+    imagery_layer_2,
+    imagery_layer_3,
+    imagery_layer_4,
+    imagery_layer_5,
+    imagery_layer_6,
+    imagery_layer_7,
+    imagery_layer_8,
+    imagery_layer_9,
+    imagery_layer_10,
+    imagery_layer_11,
+    imagery_layer_12,
+    imagery_layer_13,
+    imagery_layer_14,
+    imagery_layer_15,
 }};
 
-const std::array<const omni::fabric::TokenC, MAX_TEXTURE_LAYER_COUNT> inputs_texture_n = {{
-    inputs_texture_0,
-    inputs_texture_1,
-    inputs_texture_2,
-    inputs_texture_3,
-    inputs_texture_4,
-    inputs_texture_5,
-    inputs_texture_6,
-    inputs_texture_7,
-    inputs_texture_8,
-    inputs_texture_9,
-    inputs_texture_10,
-    inputs_texture_11,
-    inputs_texture_12,
-    inputs_texture_13,
-    inputs_texture_14,
-    inputs_texture_15,
+const std::array<const omni::fabric::TokenC, MAX_IMAGERY_LAYERS_COUNT> inputs_imagery_layer_n = {{
+    inputs_imagery_layer_0,
+    inputs_imagery_layer_1,
+    inputs_imagery_layer_2,
+    inputs_imagery_layer_3,
+    inputs_imagery_layer_4,
+    inputs_imagery_layer_5,
+    inputs_imagery_layer_6,
+    inputs_imagery_layer_7,
+    inputs_imagery_layer_8,
+    inputs_imagery_layer_9,
+    inputs_imagery_layer_10,
+    inputs_imagery_layer_11,
+    inputs_imagery_layer_12,
+    inputs_imagery_layer_13,
+    inputs_imagery_layer_14,
+    inputs_imagery_layer_15,
 }};
 
 }
@@ -227,7 +228,7 @@ const omni::fabric::Type inputs_roughness_factor(omni::fabric::BaseDataType::eFl
 const omni::fabric::Type inputs_scale(omni::fabric::BaseDataType::eFloat, 2, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_tex_coord_index(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_texture(omni::fabric::BaseDataType::eAsset, 1, 0, omni::fabric::AttributeRole::eNone);
-const omni::fabric::Type inputs_texture_count(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_imagery_layers_count(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_vertex_color_name(omni::fabric::BaseDataType::eUChar, 1, 1, omni::fabric::AttributeRole::eText);
 const omni::fabric::Type inputs_wrap_s(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_wrap_t(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);

--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -16,30 +16,28 @@ FabricMaterialDefinition::FabricMaterialDefinition(
     uint64_t imageryLayerCount,
     bool disableTextures) {
 
-    uint64_t baseColorTextureCount = 0;
+    auto hasBaseColorTexture = materialInfo.baseColorTexture.has_value();
 
-    if (!disableTextures) {
-        if (materialInfo.baseColorTexture.has_value()) {
-            baseColorTextureCount++;
-        }
-
-        baseColorTextureCount += imageryLayerCount;
+    if (disableTextures) {
+        hasBaseColorTexture = false;
+        imageryLayerCount = 0;
     }
 
     _hasVertexColors = materialInfo.hasVertexColors;
-    _baseColorTextureCount = baseColorTextureCount;
-}
-
-uint64_t FabricMaterialDefinition::getBaseColorTextureCount() const {
-    return _baseColorTextureCount;
-}
-
-bool FabricMaterialDefinition::hasBaseColorTextures() const {
-    return _baseColorTextureCount > 0;
+    _hasBaseColorTexture = hasBaseColorTexture;
+    _imageryLayerCount = imageryLayerCount;
 }
 
 bool FabricMaterialDefinition::hasVertexColors() const {
     return _hasVertexColors;
+}
+
+bool FabricMaterialDefinition::hasBaseColorTexture() const {
+    return _hasBaseColorTexture;
+}
+
+uint64_t FabricMaterialDefinition::getImageryLayerCount() const {
+    return _imageryLayerCount;
 }
 
 // In C++ 20 we can use the default equality comparison (= default)
@@ -48,7 +46,11 @@ bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other)
         return false;
     }
 
-    if (_baseColorTextureCount != other._baseColorTextureCount) {
+    if (_hasBaseColorTexture != other._hasBaseColorTexture) {
+        return false;
+    }
+
+    if (_imageryLayerCount != other._imageryLayerCount) {
         return false;
     }
 

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -56,7 +56,7 @@ struct TileLoadThreadResult {
 };
 
 bool hasBaseColorTextureGltf(const FabricMesh& fabricMesh) {
-    return fabricMesh.material->getMaterialDefinition().hasBaseColorTextures() &&
+    return fabricMesh.material != nullptr && fabricMesh.material->getMaterialDefinition().hasBaseColorTextures() &&
            fabricMesh.materialInfo.baseColorTexture.has_value();
 }
 

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -56,20 +56,8 @@ struct TileLoadThreadResult {
 };
 
 bool hasBaseColorTextureGltf(const FabricMesh& fabricMesh) {
-    return fabricMesh.material != nullptr && fabricMesh.material->getMaterialDefinition().hasBaseColorTextures() &&
+    return fabricMesh.material != nullptr && fabricMesh.material->getMaterialDefinition().hasBaseColorTexture() &&
            fabricMesh.materialInfo.baseColorTexture.has_value();
-}
-
-uint64_t getBaseColorTextureIndexForGltf() {
-    return 0;
-}
-
-uint64_t getBaseColorTextureIndexForImagery(const FabricMesh& fabricMesh, uint64_t imageryIndex) {
-    if (hasBaseColorTextureGltf(fabricMesh)) {
-        return imageryIndex + 1;
-    }
-
-    return imageryIndex;
 }
 
 std::vector<MeshInfo>
@@ -219,9 +207,8 @@ void setFabricMeshes(
             if (hasBaseColorTextureGltf(mesh)) {
                 const auto& textureInfo = materialInfo.baseColorTexture.value();
                 const auto texcoordIndex = mesh.texcoordIndexMapping[textureInfo.setIndex];
-                const auto textureIndex = getBaseColorTextureIndexForGltf();
                 const auto& textureAssetPath = baseColorTexture->getAssetPathToken();
-                material->setBaseColorTexture(textureAssetPath, textureInfo, texcoordIndex, textureIndex);
+                material->setBaseColorTexture(textureAssetPath, textureInfo, texcoordIndex);
             }
         } else if (!tilesetMaterialPath.IsEmpty()) {
             geometry->setMaterial(FabricUtil::toFabricPath(tilesetMaterialPath));
@@ -459,8 +446,8 @@ void FabricPrepareRenderResources::attachRasterInMainThread(
         return;
     }
 
-    auto imageryIndex = _tileset->findImageryIndex(rasterTile.getOverlay());
-    if (!imageryIndex.has_value()) {
+    auto imageryLayerIndex = _tileset->findImageryLayerIndex(rasterTile.getOverlay());
+    if (!imageryLayerIndex.has_value()) {
         return;
     }
 
@@ -479,9 +466,8 @@ void FabricPrepareRenderResources::attachRasterInMainThread(
             };
 
             const auto texcoordIndex = mesh.imageryTexcoordIndexMapping.at(gltfSetIndex);
-            const auto textureIndex = getBaseColorTextureIndexForImagery(mesh, imageryIndex.value());
             const auto& textureAssetPath = texture->getAssetPathToken();
-            material->setBaseColorTexture(textureAssetPath, textureInfo, texcoordIndex, textureIndex);
+            material->setImageryLayer(textureAssetPath, textureInfo, texcoordIndex, imageryLayerIndex.value());
         }
     }
 }
@@ -507,16 +493,15 @@ void FabricPrepareRenderResources::detachRasterInMainThread(
         return;
     }
 
-    auto imageryIndex = _tileset->findImageryIndex(rasterTile.getOverlay());
-    if (!imageryIndex.has_value()) {
+    auto imageryLayerIndex = _tileset->findImageryLayerIndex(rasterTile.getOverlay());
+    if (!imageryLayerIndex.has_value()) {
         return;
     }
 
     for (const auto& mesh : pTileRenderResources->fabricMeshes) {
         auto& material = mesh.material;
         if (material != nullptr) {
-            const auto textureIndex = getBaseColorTextureIndexForImagery(mesh, imageryIndex.value());
-            material->clearBaseColorTexture(textureIndex);
+            material->clearImageryLayer(imageryLayerIndex.value());
         }
     }
 }

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<FabricGeometry> FabricResourceManager::acquireGeometry(
 }
 
 bool useSharedMaterial(const FabricMaterialDefinition& materialDefinition) {
-    if (materialDefinition.hasBaseColorTextures()) {
+    if (materialDefinition.hasBaseColorTexture() || materialDefinition.getImageryLayerCount() > 0) {
         return false;
     }
 

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -680,4 +680,8 @@ omni::fabric::Path joinPaths(const omni::fabric::Path& absolutePath, const omni:
     return {fmt::format("{}/{}", absolutePath.getText(), relativePath.getText()).c_str()};
 }
 
+bool isEmpty(const omni::fabric::Path& path) {
+    return omni::fabric::PathC(path) == omni::fabric::kUninitializedPath;
+}
+
 } // namespace cesium::omniverse::FabricUtil

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -411,7 +411,7 @@ void OmniTileset::addImageryIon(const pxr::SdfPath& imageryPath) {
     _tileset->getOverlays().add(ionRasterOverlay);
 }
 
-std::optional<uint64_t> OmniTileset::findImageryIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const {
+std::optional<uint64_t> OmniTileset::findImageryLayerIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const {
     uint64_t overlayIndex = 0;
     for (const auto& pOverlay : _tileset->getOverlays()) {
         if (&overlay == pOverlay.get()) {


### PR DESCRIPTION
As I was integrating multiple raster overlays ([#492](https://github.com/CesiumGS/cesium-omniverse/pull/492)) into tileset material nodes ([#406](https://github.com/CesiumGS/cesium-omniverse/pull/406)) I realized it would be much simpler to treat glTF base color textures and raster overlays as separate things instead of all being treated as base color textures.

The main change is in `cesium.mdl` where `cesium_imagery_layer_resolver` is responsible for blending imagery layers together and `cesium_material` is responsible for blending the final imagery layer color with the glTF base color texture. As a result `cesium_material` is no longer an exact copy of `gltf_material`, but does some simple calculations first.

In the case where there's a single imagery layer performance should still be good because it skips `cesium_imagery_layer_resolver`.