### PR TITLE
Fix `cesium:debug:randomColors` with vertex colors

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -55,8 +55,7 @@ export material cesium_material(
         roughness_factor: roughness_factor,
         emissive_factor: emissive_factor,
         alpha_mode: alpha_mode,
-        alpha_cutoff: alpha_cutoff,
-        vertex_color_name: string("vertexColor")
+        alpha_cutoff: alpha_cutoff
     );
 
 } in material(

--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -15,10 +15,29 @@ float4 alpha_blend(float4 src, float4 dst) {
     return src * float4(src.w, src.w, src.w, 1.0) + dst * (1.0 - src.w);
 }
 
+float4 compute_base_color(
+    gltf_texture_lookup_value imagery_layers_texture,
+    color debug_color,
+    gltf_texture_lookup_value base_color_texture,
+    color base_color_factor,
+    float base_alpha) {
+
+    auto debug_color_float3 = float3(debug_color);
+    auto base_color_factor_float3 = float3(base_color_factor);
+
+    auto base_color = base_color_texture.valid ? base_color_texture.value : float4(1.0);
+    base_color *= float4(base_color_factor_float3.x, base_color_factor_float3.y, base_color_factor_float3.z, base_alpha);
+    base_color = alpha_blend(imagery_layers_texture.value, base_color);
+    base_color *= float4(debug_color_float3.x, debug_color_float3.y, debug_color_float3.z, 1.0);
+
+    return base_color;
+}
+
 export gltf_texture_lookup_value cesium_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();
 
 export material cesium_material(
     gltf_texture_lookup_value imagery_layers_texture = gltf_texture_lookup_value(true, float4(0.0)),
+    uniform color debug_color = color(1.0),
     // gltf_material inputs below
     gltf_texture_lookup_value base_color_texture = gltf_texture_lookup_value(),
     uniform color base_color_factor = color(1.0),
@@ -29,20 +48,15 @@ export material cesium_material(
     uniform float base_alpha = 1.0,
     uniform float alpha_cutoff  = 0.5
 ) [[ anno::hidden() ]] = let {
-    auto base_color_texture_value = base_color_texture.valid ? base_color_texture.value : float4(1.0);
-    auto final_base_color_texture_value = alpha_blend(imagery_layers_texture.value, base_color_texture_value);
-    auto final_base_color_texture = gltf_texture_lookup_value(true, final_base_color_texture_value);
-    auto final_base_color_factor = base_color_factor;
-
+    auto base_color = compute_base_color(imagery_layers_texture, debug_color, base_color_texture, base_color_factor, base_alpha);
     material base = gltf_material(
-        base_color_factor: final_base_color_factor,
-        base_color_texture: final_base_color_texture,
+        base_color_texture: gltf_texture_lookup_value(true, base_color),
         metallic_factor: metallic_factor,
         roughness_factor: roughness_factor,
         emissive_factor: emissive_factor,
         alpha_mode: alpha_mode,
-        base_alpha: base_alpha,
-        alpha_cutoff: alpha_cutoff
+        alpha_cutoff: alpha_cutoff,
+        vertex_color_name: string("vertexColor")
     );
 
 } in material(

--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -15,11 +15,7 @@ namespace cesium::omniverse {
 
 class FabricGeometry {
   public:
-    FabricGeometry(
-        const omni::fabric::Path& path,
-        const FabricGeometryDefinition& geometryDefinition,
-        bool debugRandomColors,
-        long stageId);
+    FabricGeometry(const omni::fabric::Path& path, const FabricGeometryDefinition& geometryDefinition, long stageId);
     ~FabricGeometry();
 
     void setGeometry(
@@ -48,7 +44,6 @@ class FabricGeometry {
 
     const omni::fabric::Path _path;
     const FabricGeometryDefinition _geometryDefinition;
-    const bool _debugRandomColors;
     const long _stageId;
 };
 

--- a/src/core/include/cesium/omniverse/FabricGeometryPool.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryPool.h
@@ -12,7 +12,6 @@ class FabricGeometryPool final : public ObjectPool<FabricGeometry> {
         int64_t poolId,
         const FabricGeometryDefinition& geometryDefinition,
         uint64_t initialCapacity,
-        bool debugRandomColors,
         long stageId);
 
     [[nodiscard]] const FabricGeometryDefinition& getGeometryDefinition() const;
@@ -24,7 +23,6 @@ class FabricGeometryPool final : public ObjectPool<FabricGeometry> {
   private:
     const int64_t _poolId;
     const FabricGeometryDefinition _geometryDefinition;
-    const bool _debugRandomColors;
     const long _stageId;
 };
 

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -21,6 +21,7 @@ class FabricMaterial {
         const FabricMaterialDefinition& materialDefinition,
         const pxr::TfToken& defaultTextureAssetPathToken,
         const pxr::TfToken& defaultTransparentTextureAssetPathToken,
+        bool debugRandomColors,
         long stageId);
     ~FabricMaterial();
 
@@ -72,6 +73,7 @@ class FabricMaterial {
     const FabricMaterialDefinition _materialDefinition;
     const pxr::TfToken _defaultTextureAssetPathToken;
     const pxr::TfToken _defaultTransparentTextureAssetPathToken;
+    const bool _debugRandomColors;
     const long _stageId;
 
     omni::fabric::Path _shaderPath;

--- a/src/core/include/cesium/omniverse/FabricMaterialPool.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialPool.h
@@ -16,6 +16,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
         uint64_t initialCapacity,
         const pxr::TfToken& defaultTextureAssetPathToken,
         const pxr::TfToken& defaultTransparentTextureAssetPathToken,
+        bool debugRandomColors,
         long stageId);
 
     [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
@@ -29,6 +30,7 @@ class FabricMaterialPool final : public ObjectPool<FabricMaterial> {
     const FabricMaterialDefinition _materialDefinition;
     const pxr::TfToken _defaultTextureAssetPathToken;
     const pxr::TfToken _defaultTransparentTextureAssetPathToken;
+    const bool _debugRandomColors;
     const long _stageId;
 };
 

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -70,6 +70,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_base_alpha, "inputs:base_alpha")) \
     ((inputs_base_color_factor, "inputs:base_color_factor")) \
     ((inputs_base_color_texture, "inputs:base_color_texture")) \
+    ((inputs_debug_color, "inputs:debug_color")) \
     ((inputs_emissive_factor, "inputs:emissive_factor")) \
     ((inputs_excludeFromWhiteMode, "inputs:excludeFromWhiteMode")) \
     ((inputs_metallic_factor, "inputs:metallic_factor")) \
@@ -105,8 +106,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((outputs_mdl_surface, "outputs:mdl:surface")) \
     ((outputs_mdl_volume, "outputs:mdl:volume")) \
     ((outputs_out, "outputs:out")) \
-    ((primvars_displayColor, "primvars:displayColor")) \
-    ((primvars_displayOpacity, "primvars:displayOpacity")) \
     ((primvars_normals, "primvars:normals")) \
     ((primvars_st_0, "primvars:st_0")) \
     ((primvars_st_1, "primvars:st_1")) \
@@ -219,6 +218,7 @@ const omni::fabric::Type inputs_alpha_cutoff(omni::fabric::BaseDataType::eFloat,
 const omni::fabric::Type inputs_alpha_mode(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_alpha(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_color_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
+const omni::fabric::Type inputs_debug_color(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_emissive_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type inputs_excludeFromWhiteMode(omni::fabric::BaseDataType::eBool, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_metallic_factor(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
@@ -239,8 +239,6 @@ const omni::fabric::Type outputs_out(omni::fabric::BaseDataType::eToken, 1, 0, o
 const omni::fabric::Type points(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::ePosition);
 const omni::fabric::Type primvarInterpolations(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type primvars(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
-const omni::fabric::Type primvars_displayColor(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eColor);
-const omni::fabric::Type primvars_displayOpacity(omni::fabric::BaseDataType::eFloat, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type primvars_normals(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eNormal);
 const omni::fabric::Type primvars_st(omni::fabric::BaseDataType::eFloat, 2, 1, omni::fabric::AttributeRole::eTexCoord);
 const omni::fabric::Type primvars_vertexColor(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eColor);

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -50,7 +50,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (sourceAsset) \
     (subdivisionScheme) \
     (vertex) \
-    (vertexColor) \
     (_cesium_localToEcefTransform) \
     (_cesium_tilesetId) \
     (_deletedPrims) \
@@ -106,6 +105,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((outputs_mdl_surface, "outputs:mdl:surface")) \
     ((outputs_mdl_volume, "outputs:mdl:volume")) \
     ((outputs_out, "outputs:out")) \
+    ((primvars_displayColor, "primvars:displayColor")) \
     ((primvars_normals, "primvars:normals")) \
     ((primvars_st_0, "primvars:st_0")) \
     ((primvars_st_1, "primvars:st_1")) \
@@ -117,7 +117,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_st_7, "primvars:st_7")) \
     ((primvars_st_8, "primvars:st_8")) \
     ((primvars_st_9, "primvars:st_9")) \
-    ((primvars_vertexColor, "primvars:vertexColor")) \
     ((xformOp_transform_cesium, "xformOp:transform:cesium"))
 
 TF_DECLARE_PUBLIC_TOKENS(UsdTokens, USD_TOKENS);
@@ -218,7 +217,7 @@ const omni::fabric::Type inputs_alpha_cutoff(omni::fabric::BaseDataType::eFloat,
 const omni::fabric::Type inputs_alpha_mode(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_alpha(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_color_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
-const omni::fabric::Type inputs_debug_color(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_debug_color(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type inputs_emissive_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type inputs_excludeFromWhiteMode(omni::fabric::BaseDataType::eBool, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_metallic_factor(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
@@ -239,9 +238,9 @@ const omni::fabric::Type outputs_out(omni::fabric::BaseDataType::eToken, 1, 0, o
 const omni::fabric::Type points(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::ePosition);
 const omni::fabric::Type primvarInterpolations(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type primvars(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type primvars_displayColor(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type primvars_normals(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eNormal);
 const omni::fabric::Type primvars_st(omni::fabric::BaseDataType::eFloat, 2, 1, omni::fabric::AttributeRole::eTexCoord);
-const omni::fabric::Type primvars_vertexColor(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type Shader(omni::fabric::BaseDataType::eTag, 1, 0, omni::fabric::AttributeRole::ePrimTypeName);
 const omni::fabric::Type subdivisionScheme(omni::fabric::BaseDataType::eToken, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _cesium_localToEcefTransform(omni::fabric::BaseDataType::eDouble, 16, 0, omni::fabric::AttributeRole::eMatrix);

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -153,7 +153,7 @@ void FabricGeometry::initialize() {
     }
 
     if (hasVertexColors) {
-        attributes.addAttribute(FabricTypes::primvars_vertexColor, FabricTokens::primvars_vertexColor);
+        attributes.addAttribute(FabricTypes::primvars_displayColor, FabricTokens::primvars_displayColor);
     }
 
     attributes.createAttributes(_path);
@@ -205,7 +205,7 @@ void FabricGeometry::initialize() {
     }
 
     if (hasVertexColors) {
-        primvarsFabric[primvarIndexVertexColor] = FabricTokens::primvars_vertexColor;
+        primvarsFabric[primvarIndexVertexColor] = FabricTokens::primvars_displayColor;
         primvarInterpolationsFabric[primvarIndexVertexColor] = FabricTokens::vertex;
     }
 }
@@ -251,7 +251,7 @@ void FabricGeometry::reset() {
     }
 
     if (hasVertexColors) {
-        srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, 0);
+        srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayColor, 0);
     }
 }
 
@@ -307,9 +307,9 @@ void FabricGeometry::setGeometry(
         gsl::span<glm::fvec3> vertexColorsSpan(vertexColorsData);
         if (hasVertexColors) {
             vertexColors.fill(vertexColorsSpan);
-            srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, numVoxels * 8);
+            srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayColor, numVoxels * 8);
         }
-        auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_path, FabricTokens::primvars_vertexColor);
+        auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_path, FabricTokens::primvars_displayColor);
 
         size_t vertIndex = 0;
         size_t vertexCountsIndex = 0;
@@ -427,9 +427,9 @@ void FabricGeometry::setGeometry(
         }
 
         if (hasVertexColors) {
-            srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, vertexColors.size());
+            srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayColor, vertexColors.size());
 
-            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_path, FabricTokens::primvars_vertexColor);
+            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec3>(_path, FabricTokens::primvars_displayColor);
 
             vertexColors.fill(vertexColorsFabric);
         }

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -17,7 +17,6 @@
 #endif
 
 #include <CesiumGltf/Model.h>
-#include <glm/gtc/random.hpp>
 #include <omni/fabric/FabricUSD.h>
 
 namespace cesium::omniverse {
@@ -54,11 +53,9 @@ uint64_t getTexcoordSetCount(const FabricGeometryDefinition& geometryDefinition)
 FabricGeometry::FabricGeometry(
     const omni::fabric::Path& path,
     const FabricGeometryDefinition& geometryDefinition,
-    bool debugRandomColors,
     long stageId)
     : _path(path)
     , _geometryDefinition(geometryDefinition)
-    , _debugRandomColors(debugRandomColors)
     , _stageId(stageId) {
     if (stageDestroyed()) {
         return;
@@ -137,8 +134,6 @@ void FabricGeometry::initialize() {
     attributes.addAttribute(FabricTypes::_worldVisibility, FabricTokens::_worldVisibility);
     attributes.addAttribute(FabricTypes::primvars, FabricTokens::primvars);
     attributes.addAttribute(FabricTypes::primvarInterpolations, FabricTokens::primvarInterpolations);
-    attributes.addAttribute(FabricTypes::primvars_displayColor, FabricTokens::primvars_displayColor);
-    attributes.addAttribute(FabricTypes::primvars_displayOpacity, FabricTokens::primvars_displayOpacity);
     attributes.addAttribute(FabricTypes::Mesh, FabricTokens::Mesh);
     attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
     attributes.addAttribute(FabricTypes::_cesium_localToEcefTransform, FabricTokens::_cesium_localToEcefTransform);
@@ -176,9 +171,6 @@ void FabricGeometry::initialize() {
     size_t primvarIndexNormal = 0;
     size_t primvarIndexVertexColor = 0;
 
-    const size_t primvarIndexDisplayColor = primvarsCount++;
-    const size_t primvarIndexDisplayOpacity = primvarsCount++;
-
     std::vector<uint64_t> primvarIndexStArray;
     primvarIndexStArray.reserve(texcoordSetCount);
 
@@ -196,19 +188,11 @@ void FabricGeometry::initialize() {
 
     srw.setArrayAttributeSize(_path, FabricTokens::primvars, primvarsCount);
     srw.setArrayAttributeSize(_path, FabricTokens::primvarInterpolations, primvarsCount);
-    srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayColor, 1);
-    srw.setArrayAttributeSize(_path, FabricTokens::primvars_displayOpacity, 1);
 
     // clang-format off
     auto primvarsFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::primvars);
     auto primvarInterpolationsFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::primvarInterpolations);
     // clang-format on
-
-    primvarsFabric[primvarIndexDisplayColor] = FabricTokens::primvars_displayColor;
-    primvarsFabric[primvarIndexDisplayOpacity] = FabricTokens::primvars_displayOpacity;
-
-    primvarInterpolationsFabric[primvarIndexDisplayColor] = FabricTokens::constant;
-    primvarInterpolationsFabric[primvarIndexDisplayOpacity] = FabricTokens::constant;
 
     for (uint64_t i = 0; i < texcoordSetCount; i++) {
         primvarsFabric[primvarIndexStArray[i]] = FabricTokens::primvars_st_n[i];
@@ -241,8 +225,6 @@ void FabricGeometry::reset() {
     auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_path, FabricTokens::_worldPosition);
     auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_path, FabricTokens::_worldOrientation);
     auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_path, FabricTokens::_worldScale);
-    auto displayColorFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_path, FabricTokens::primvars_displayColor);
-    auto displayOpacityFabric = srw.getArrayAttributeWr<float>(_path, FabricTokens::primvars_displayOpacity);
     // clang-format on
 
     *extentFabric = DEFAULT_EXTENT;
@@ -252,8 +234,6 @@ void FabricGeometry::reset() {
     *worldPositionFabric = DEFAULT_POSITION;
     *worldOrientationFabric = DEFAULT_ORIENTATION;
     *worldScaleFabric = DEFAULT_SCALE;
-    displayColorFabric[0] = DEFAULT_VERTEX_COLOR;
-    displayOpacityFabric[0] = DEFAULT_VERTEX_OPACITY;
 
     FabricUtil::setTilesetId(_path, NO_TILESET_ID);
 
@@ -462,8 +442,6 @@ void FabricGeometry::setGeometry(
     auto worldPositionFabric = srw.getAttributeWr<pxr::GfVec3d>(_path, FabricTokens::_worldPosition);
     auto worldOrientationFabric = srw.getAttributeWr<pxr::GfQuatf>(_path, FabricTokens::_worldOrientation);
     auto worldScaleFabric = srw.getAttributeWr<pxr::GfVec3f>(_path, FabricTokens::_worldScale);
-    auto displayColorFabric = srw.getArrayAttributeWr<pxr::GfVec3f>(_path, FabricTokens::primvars_displayColor);
-    auto displayOpacityFabric = srw.getArrayAttributeWr<float>(_path, FabricTokens::primvars_displayOpacity);
     // clang-format on
 
     *extentFabric = localExtent;
@@ -472,17 +450,6 @@ void FabricGeometry::setGeometry(
     *worldPositionFabric = worldPosition;
     *worldOrientationFabric = worldOrientation;
     *worldScaleFabric = worldScale;
-
-    if (_debugRandomColors) {
-        const auto r = glm::linearRand(0.0f, 1.0f);
-        const auto g = glm::linearRand(0.0f, 1.0f);
-        const auto b = glm::linearRand(0.0f, 1.0f);
-        displayColorFabric[0] = pxr::GfVec3f(r, g, b);
-    } else {
-        displayColorFabric[0] = DEFAULT_VERTEX_COLOR;
-    }
-
-    displayOpacityFabric[0] = DEFAULT_VERTEX_OPACITY;
 
     FabricUtil::setTilesetId(_path, tilesetId);
 }

--- a/src/core/src/FabricGeometryPool.cpp
+++ b/src/core/src/FabricGeometryPool.cpp
@@ -8,12 +8,10 @@ FabricGeometryPool::FabricGeometryPool(
     int64_t poolId,
     const FabricGeometryDefinition& geometryDefinition,
     uint64_t initialCapacity,
-    bool debugRandomColors,
     long stageId)
     : ObjectPool<FabricGeometry>()
     , _poolId(poolId)
     , _geometryDefinition(geometryDefinition)
-    , _debugRandomColors(debugRandomColors)
     , _stageId(stageId) {
     setCapacity(initialCapacity);
 }
@@ -25,7 +23,7 @@ const FabricGeometryDefinition& FabricGeometryPool::getGeometryDefinition() cons
 std::shared_ptr<FabricGeometry> FabricGeometryPool::createObject(uint64_t objectId) {
     const auto pathStr = fmt::format("/fabric_geometry_pool_{}_object_{}", _poolId, objectId);
     const auto path = omni::fabric::Path(pathStr.c_str());
-    return std::make_shared<FabricGeometry>(path, _geometryDefinition, _debugRandomColors, _stageId);
+    return std::make_shared<FabricGeometry>(path, _geometryDefinition, _stageId);
 }
 
 void FabricGeometryPool::setActive(std::shared_ptr<FabricGeometry> geometry, bool active) {

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -10,12 +10,16 @@
 #include "cesium/omniverse/Tokens.h"
 #include "cesium/omniverse/UsdUtil.h"
 
+#include <glm/gtc/random.hpp>
 #include <omni/fabric/FabricUSD.h>
 #include <spdlog/fmt/fmt.h>
 
 namespace cesium::omniverse {
 
 namespace {
+
+const auto DEFAULT_DEBUG_COLOR = pxr::GfVec3f(1.0f, 1.0f, 1.0f);
+
 uint64_t getImageryLayerCount(const FabricMaterialDefinition& materialDefinition) {
     uint64_t imageryLayerCount = materialDefinition.getImageryLayerCount();
 
@@ -31,6 +35,7 @@ uint64_t getImageryLayerCount(const FabricMaterialDefinition& materialDefinition
 
     return imageryLayerCount;
 }
+
 } // namespace
 
 FabricMaterial::FabricMaterial(
@@ -38,11 +43,13 @@ FabricMaterial::FabricMaterial(
     const FabricMaterialDefinition& materialDefinition,
     const pxr::TfToken& defaultTextureAssetPathToken,
     const pxr::TfToken& defaultTransparentTextureAssetPathToken,
+    bool debugRandomColors,
     long stageId)
     : _materialPath(path)
     , _materialDefinition(materialDefinition)
     , _defaultTextureAssetPathToken(defaultTextureAssetPathToken)
     , _defaultTransparentTextureAssetPathToken(defaultTransparentTextureAssetPathToken)
+    , _debugRandomColors(debugRandomColors)
     , _stageId(stageId) {
 
     if (stageDestroyed()) {
@@ -140,8 +147,6 @@ void FabricMaterial::createMaterial(const omni::fabric::Path& materialPath) {
 }
 
 void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const omni::fabric::Path& materialPath) {
-    const auto hasVertexColors = _materialDefinition.hasVertexColors();
-
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
     srw.createPrim(shaderPath);
@@ -149,6 +154,7 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
     FabricAttributesBuilder attributes;
 
     // clang-format off
+    attributes.addAttribute(FabricTypes::inputs_debug_color, FabricTokens::inputs_debug_color);
     attributes.addAttribute(FabricTypes::inputs_alpha_cutoff, FabricTokens::inputs_alpha_cutoff);
     attributes.addAttribute(FabricTypes::inputs_alpha_mode, FabricTokens::inputs_alpha_mode);
     attributes.addAttribute(FabricTypes::inputs_base_alpha, FabricTokens::inputs_base_alpha);
@@ -167,10 +173,6 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
     attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
     // clang-format on
 
-    if (hasVertexColors) {
-        attributes.addAttribute(FabricTypes::inputs_vertex_color_name, FabricTokens::inputs_vertex_color_name);
-    }
-
     attributes.createAttributes(shaderPath);
 
     srw.setArrayAttributeSize(shaderPath, FabricTokens::_paramColorSpace, 0);
@@ -188,14 +190,6 @@ void FabricMaterial::createShader(const omni::fabric::Path& shaderPath, const om
     infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
     infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
     *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_material;
-
-    if (hasVertexColors) {
-        const auto vertexColorPrimvarNameSize = pxr::UsdTokens->vertexColor.GetString().size();
-        srw.setArrayAttributeSize(shaderPath, FabricTokens::inputs_vertex_color_name, vertexColorPrimvarNameSize);
-        auto vertexColorNameFabric =
-            srw.getArrayAttributeWr<uint8_t>(shaderPath, FabricTokens::inputs_vertex_color_name);
-        memcpy(vertexColorNameFabric.data(), pxr::UsdTokens->vertexColor.GetText(), vertexColorPrimvarNameSize);
-    }
 
     // Connect the material terminals to the shader.
     srw.createConnection(
@@ -384,6 +378,7 @@ void FabricMaterial::clearImageryLayers() {
 void FabricMaterial::setShaderValues(const omni::fabric::Path& shaderPath, const MaterialInfo& materialInfo) {
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
+    auto debugColorFabric = srw.getAttributeWr<pxr::GfVec3f>(shaderPath, FabricTokens::inputs_debug_color);
     auto alphaCutoffFabric = srw.getAttributeWr<float>(shaderPath, FabricTokens::inputs_alpha_cutoff);
     auto alphaModeFabric = srw.getAttributeWr<int>(shaderPath, FabricTokens::inputs_alpha_mode);
     auto baseAlphaFabric = srw.getAttributeWr<float>(shaderPath, FabricTokens::inputs_base_alpha);
@@ -399,6 +394,15 @@ void FabricMaterial::setShaderValues(const omni::fabric::Path& shaderPath, const
     *emissiveFactorFabric = UsdUtil::glmToUsdVector(glm::fvec3(materialInfo.emissiveFactor));
     *metallicFactorFabric = static_cast<float>(materialInfo.metallicFactor);
     *roughnessFactorFabric = static_cast<float>(materialInfo.roughnessFactor);
+
+    if (_debugRandomColors) {
+        const auto r = glm::linearRand(0.0f, 1.0f);
+        const auto g = glm::linearRand(0.0f, 1.0f);
+        const auto b = glm::linearRand(0.0f, 1.0f);
+        *debugColorFabric = pxr::GfVec3f(r, g, b);
+    } else {
+        *debugColorFabric = DEFAULT_DEBUG_COLOR;
+    }
 }
 
 void FabricMaterial::setTextureValues(

--- a/src/core/src/FabricMaterialPool.cpp
+++ b/src/core/src/FabricMaterialPool.cpp
@@ -10,12 +10,14 @@ FabricMaterialPool::FabricMaterialPool(
     uint64_t initialCapacity,
     const pxr::TfToken& defaultTextureAssetPathToken,
     const pxr::TfToken& defaultTransparentTextureAssetPathToken,
+    bool debugRandomColors,
     long stageId)
     : ObjectPool<FabricMaterial>()
     , _poolId(poolId)
     , _materialDefinition(materialDefinition)
     , _defaultTextureAssetPathToken(defaultTextureAssetPathToken)
     , _defaultTransparentTextureAssetPathToken(defaultTransparentTextureAssetPathToken)
+    , _debugRandomColors(debugRandomColors)
     , _stageId(stageId) {
     setCapacity(initialCapacity);
 }
@@ -28,7 +30,12 @@ std::shared_ptr<FabricMaterial> FabricMaterialPool::createObject(uint64_t object
     const auto pathStr = fmt::format("/fabric_material_pool_{}_object_{}", _poolId, objectId);
     const auto path = omni::fabric::Path(pathStr.c_str());
     return std::make_shared<FabricMaterial>(
-        path, _materialDefinition, _defaultTextureAssetPathToken, _defaultTransparentTextureAssetPathToken, _stageId);
+        path,
+        _materialDefinition,
+        _defaultTextureAssetPathToken,
+        _defaultTransparentTextureAssetPathToken,
+        _debugRandomColors,
+        _stageId);
 }
 
 void FabricMaterialPool::setActive(std::shared_ptr<FabricMaterial> material, bool active) {

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<FabricGeometry> FabricResourceManager::acquireGeometry(
     if (_disableGeometryPool) {
         const auto pathStr = fmt::format("/fabric_geometry_{}", getNextGeometryId());
         const auto path = omni::fabric::Path(pathStr.c_str());
-        return std::make_shared<FabricGeometry>(path, geometryDefinition, _debugRandomColors, stageId);
+        return std::make_shared<FabricGeometry>(path, geometryDefinition, stageId);
     }
 
     std::scoped_lock<std::mutex> lock(_poolMutex);
@@ -102,7 +102,12 @@ FabricResourceManager::createMaterial(const FabricMaterialDefinition& materialDe
     const auto pathStr = fmt::format("/fabric_material_{}", getNextMaterialId());
     const auto path = omni::fabric::Path(pathStr.c_str());
     return std::make_shared<FabricMaterial>(
-        path, materialDefinition, _defaultTextureAssetPathToken, _defaultTransparentTextureAssetPathToken, stageId);
+        path,
+        materialDefinition,
+        _defaultTextureAssetPathToken,
+        _defaultTransparentTextureAssetPathToken,
+        _debugRandomColors,
+        stageId);
 }
 
 void FabricResourceManager::removeSharedMaterial(const SharedMaterial& sharedMaterial) {
@@ -346,7 +351,7 @@ std::shared_ptr<FabricTexturePool> FabricResourceManager::getTexturePool() {
 std::shared_ptr<FabricGeometryPool>
 FabricResourceManager::createGeometryPool(const FabricGeometryDefinition& geometryDefinition, long stageId) {
     return _geometryPools.emplace_back(std::make_shared<FabricGeometryPool>(
-        getNextPoolId(), geometryDefinition, _geometryPoolInitialCapacity, _debugRandomColors, stageId));
+        getNextPoolId(), geometryDefinition, _geometryPoolInitialCapacity, stageId));
 }
 
 std::shared_ptr<FabricMaterialPool>
@@ -357,6 +362,7 @@ FabricResourceManager::createMaterialPool(const FabricMaterialDefinition& materi
         _materialPoolInitialCapacity,
         _defaultTextureAssetPathToken,
         _defaultTransparentTextureAssetPathToken,
+        _debugRandomColors,
         stageId));
 }
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/429. Previously `randomColors` would have no affect for tiles with vertex colors (including point clouds).

Now that we have our own `cesium_material` shader I went with option 1 in https://github.com/CesiumGS/cesium-omniverse/issues/429.

Test data: [vertex-color.zip](https://github.com/CesiumGS/cesium-omniverse/files/13046516/vertex-color.zip)

Without `randomColors`|With `randomColors`
--|--
![without](https://github.com/CesiumGS/cesium-omniverse/assets/915398/567acab8-eb29-4959-b4b5-b0b8fcb4e8b7)|![with](https://github.com/CesiumGS/cesium-omniverse/assets/915398/0dbff879-ee61-4237-a0a9-409e01fbf80c)
