### PR TITLE
Add the performance app to docs

### DIFF
--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -4,7 +4,7 @@ Omniverse is a tool that provides an interface for various other tools to intera
 To better understand extensions and how they're defined, check out the [official Omniverse extension template](https://github.com/NVIDIA-Omniverse/kit-extension-template) for a "hello world" extension.
 There is also a similar [C++ extension template](https://github.com/NVIDIA-Omniverse/kit-extension-template-cpp).
 
-### Our Extensions
+### Our Extensions/Apps
 - Cesium for Omniverse ("The main extension")
     - Responsible for streaming geospatial data onto the stages, and providing the user interface.
 - Cesium Usd plugins
@@ -13,6 +13,8 @@ There is also a similar [C++ extension template](https://github.com/NVIDIA-Omniv
     - Helpful additions for developers, such as one-click ways to open debug interfaces and print the fabric stage.
 - Cesium Cpp Tests
     - Tests of the C++ code underlying the main extension. For more info see [the testing guide](../testing-guide/README.md)
+- The Performance App
+    - Used to get general timing of an interactive session. See [the testing guide](../testing-guide/README.md) for how to run.
 
 ## Project File Structure
 Some self-explanatory directories have been ommitted.

--- a/docs/testing-guide/README.md
+++ b/docs/testing-guide/README.md
@@ -1,8 +1,18 @@
 # Testing Guide
 
+## Performance Test App
+Provides some general metrics for how long it takes to load tiles. Can be run with:
+```bash
+extern/nvidia/_build/target-deps/kit-sdk/kit ./apps/cesium.performance.kit
+```
+The is intentionally no vs code launch configuration out of concern that debug related setting could slow the app down.
+
 ## Python Tests
-Python tests are run through `pytest` (see full documentation [here](https://docs.pytest.org/en/latest/)). To run these tests with the proper sourcing and environment, simpy run `scripts/run_python_unit_tests.(bat|sh)`. You can also run these
-tests via the app. Open the extensions window while running omniverse. Find and select the Cesium for Omniverse Extension, then navigate to its Tests tab. The "Run Extension Tests" button will run the python tests (not the C++ tests).
+Python tests are run through `pytest` (see full documentation [here](https://docs.pytest.org/en/latest/)). To run these tests with the proper sourcing and environment, simpy run:
+```bash
+scripts/run_python_unit_tests.(bat|sh)
+```
+You can also run these tests via the app. Open the extensions window while running omniverse. Find and select the Cesium for Omniverse Extension, then navigate to its Tests tab. The "Run Extension Tests" button will run the python tests (not the C++ tests).
 
 ## C++ Tests (The Tests Extension)
 C++ tests are run through `doctest`, which is set up and run via the Tests Extension.
@@ -10,7 +20,10 @@ Normally `doctest` can be run via the command line, but since much of the code w
 can only run properly inside omniverse, we run the tests there too.
 The easiest way to run the tests extension is via the launch configuration in vs code. Simply go to the `run and debug` dropdown and launch the `Tests Extension`. The testing output is provided in the terminal used to launch everything. Failed tests will be caught by the debugger, though you may need to go one level up in the execution stack to see the `CHECK` being called.
 
-To run the extension via the command line, simply pass the tests extension's kit config file to kit with `extern/nvidia/_build/target-deps/kit-sdk/kit ./apps/cesium.omniverse.cpp.tests.runner.kit`
+To run the extension via the command line, simply pass the tests extension's kit config file to kit with
+```bash
+extern/nvidia/_build/target-deps/kit-sdk/kit ./apps/cesium.omniverse.cpp.tests.runner.kit
+```
 
 [doctest documentation](https://bit.ly/doctest-docs) can be found here.
 


### PR DESCRIPTION
It looks like how to run the performance app wasn't documented anywhere. 