### PR TITLE
Fixing loading Globe Anchors. (again)

### DIFF
--- a/src/core/src/GeospatialUtil.cpp
+++ b/src/core/src/GeospatialUtil.cpp
@@ -131,8 +131,6 @@ void updateAnchorByLatLongHeight(
         anchorApi.GetRotationAttr().Set(
             pxr::GfVec3d(UsdUtil::getEulerAnglesFromQuaternion(fixedTransform.orientation)));
         anchorApi.GetScaleAttr().Set(pxr::GfVec3d(fixedTransform.scale));
-
-        globeAnchor->updateCachedValues();
     }
 
     double usdLatitude = usdGeographicCoordinate[0];

--- a/src/core/src/GlobeAnchorRegistry.cpp
+++ b/src/core/src/GlobeAnchorRegistry.cpp
@@ -19,6 +19,8 @@ std::shared_ptr<OmniGlobeAnchor>
 GlobeAnchorRegistry::createAnchor(const pxr::SdfPath& path, const glm::dmat4& anchorToFixed) {
     auto anchor = std::make_shared<OmniGlobeAnchor>(path, anchorToFixed);
 
+    anchor->updateCachedValues();
+
     _anchors.emplace(path.GetString(), anchor);
 
     return anchor;


### PR DESCRIPTION
Resolves #512.

The same issue that bit us in #494 wasn't fully fixed by that PR. Instead what should have been done, and is now being done, is that the call to recalculate the cache is made in the create call. This guarantees we have all the data we need on the next movement of the anchored prim.