### PR TITLE
Update tileset material values dynamically

### DIFF
--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -127,6 +127,7 @@ class Context {
     void processCesiumImageryChanged(const ChangedPrim& changedPrim);
     void processCesiumGeoreferenceChanged(const ChangedPrim& changedPrim);
     void processCesiumGlobeAnchorChanged(const ChangedPrim& changedPrim);
+    void processUsdShaderChanged(const ChangedPrim& changedPrim);
     void processPrimRemoved(const ChangedPrim& changedPrim);
     void processPrimAdded(const ChangedPrim& changedPrim);
     void processUsdNotifications();

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -37,6 +37,7 @@ class FabricMaterial {
         uint64_t imageryLayerIndex,
         float alpha);
     void setImageryLayerAlpha(uint64_t imageryLayerIndex, float alpha);
+    void updateShaderInput(const omni::fabric::Path& shaderPath, const omni::fabric::Token& attributeName);
 
     void clearMaterial();
     void clearBaseColorTexture();

--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -33,11 +33,14 @@ void destroyPrim(const omni::fabric::Path& path);
 void setTilesetTransform(int64_t tilesetId, const glm::dmat4& ecefToUsdTransform);
 void setTilesetId(const omni::fabric::Path& path, int64_t tilesetId);
 omni::fabric::Path toFabricPath(const pxr::SdfPath& path);
+omni::fabric::Token toFabricToken(const pxr::TfToken& token);
 omni::fabric::Path joinPaths(const omni::fabric::Path& absolutePath, const omni::fabric::Token& relativePath);
+omni::fabric::Path getCopiedShaderPath(const omni::fabric::Path& materialPath, const omni::fabric::Path& shaderPath);
 std::vector<omni::fabric::Path>
 copyMaterial(const omni::fabric::Path& srcMaterialPath, const omni::fabric::Path& dstMaterialPath);
 bool materialHasCesiumNodes(const omni::fabric::Path& path);
 bool isCesiumNode(const omni::fabric::Token& mdlIdentifier);
+bool isShaderConnectedToMaterial(const omni::fabric::Path& materialPath, const omni::fabric::Path& shaderPath);
 omni::fabric::Token getMdlIdentifier(const omni::fabric::Path& path);
 
 } // namespace cesium::omniverse::FabricUtil

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -77,8 +77,9 @@ class OmniTileset {
     findImageryLayerIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const;
     [[nodiscard]] std::optional<uint64_t> findImageryLayerIndex(const pxr::SdfPath& imageryPath) const;
     [[nodiscard]] uint64_t getImageryLayerCount() const;
-    float getImageryLayerAlpha(uint64_t imageryLayerIndex) const;
+    [[nodiscard]] float getImageryLayerAlpha(uint64_t imageryLayerIndex) const;
     void updateImageryLayerAlpha(uint64_t imageryLayerIndex);
+    void updateShaderInput(const pxr::SdfPath& shaderPath, const pxr::TfToken& attributeName);
     void onUpdateFrame(const std::vector<Viewport>& viewports);
 
   private:

--- a/src/core/include/cesium/omniverse/UsdNotificationHandler.h
+++ b/src/core/include/cesium/omniverse/UsdNotificationHandler.h
@@ -12,6 +12,7 @@ enum class ChangedPrimType {
     CESIUM_DATA,
     CESIUM_GEOREFERENCE,
     CESIUM_GLOBE_ANCHOR,
+    USD_SHADER,
     OTHER,
 };
 

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -15,6 +15,7 @@
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/common.h>
+#include <pxr/usd/usdShade/shader.h>
 
 namespace CesiumGeospatial {
 class Cartographic;
@@ -111,6 +112,7 @@ pxr::CesiumTileset getCesiumTileset(const pxr::SdfPath& path);
 pxr::CesiumImagery getCesiumImagery(const pxr::SdfPath& path);
 std::vector<pxr::CesiumImagery> getChildCesiumImageryPrims(const pxr::SdfPath& path);
 pxr::CesiumGlobeAnchorAPI getCesiumGlobeAnchor(const pxr::SdfPath& path);
+pxr::UsdShadeShader getUsdShader(const pxr::SdfPath& path);
 
 bool isCesiumData(const pxr::SdfPath& path);
 bool isCesiumSession(const pxr::SdfPath& path);
@@ -118,6 +120,9 @@ bool isCesiumGeoreference(const pxr::SdfPath& path);
 bool isCesiumTileset(const pxr::SdfPath& path);
 bool isCesiumImagery(const pxr::SdfPath& path);
 bool hasCesiumGlobeAnchor(const pxr::SdfPath& path);
+
+bool isUsdShader(const pxr::SdfPath& path);
+bool isUsdMaterial(const pxr::SdfPath& path);
 
 bool primExists(const pxr::SdfPath& path);
 

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -230,6 +230,8 @@ void Context::processPropertyChanged(const ChangedPrim& changedPrim) {
             return processCesiumGeoreferenceChanged(changedPrim);
         case ChangedPrimType::CESIUM_GLOBE_ANCHOR:
             return processCesiumGlobeAnchorChanged(changedPrim);
+        case ChangedPrimType::USD_SHADER:
+            return processUsdShaderChanged(changedPrim);
         default:
             return;
     }
@@ -378,6 +380,61 @@ void Context::processCesiumGlobeAnchorChanged(const cesium::omniverse::ChangedPr
     }
 }
 
+void Context::processUsdShaderChanged(const cesium::omniverse::ChangedPrim& changedPrim) {
+    const auto& [path, name, primType, changeType] = changedPrim;
+
+    const auto shader = UsdUtil::getUsdShader(path);
+    const auto shaderPathFabric = FabricUtil::toFabricPath(path);
+    const auto materialPath = path.GetParentPath();
+    const auto materialPathFabric = FabricUtil::toFabricPath(materialPath);
+
+    if (!UsdUtil::isUsdMaterial(materialPath)) {
+        // Skip if parent path is not a material
+        return;
+    }
+
+    const auto inputNamespace = std::string("inputs:");
+
+    const auto& attributeName = name.GetString();
+
+    if (attributeName.rfind(inputNamespace) != 0) {
+        // Skip if changed attribute is not a shader input
+        return;
+    }
+
+    const auto inputName = pxr::TfToken(attributeName.substr(inputNamespace.size()));
+
+    auto shaderInput = shader.GetInput(inputName);
+    if (!shaderInput.IsDefined()) {
+        // Skip if changed attribute is not a shader input
+        return;
+    }
+
+    if (shaderInput.HasConnectedSource()) {
+        // Skip if shader input is connected to something else
+        return;
+    }
+
+    if (!FabricUtil::materialHasCesiumNodes(materialPathFabric)) {
+        // Simple materials can be skipped. We only need to handle materials that have been copied to each tile.
+        return;
+    }
+
+    if (!FabricUtil::isShaderConnectedToMaterial(materialPathFabric, shaderPathFabric)) {
+        // Skip if shader is not connected to the material
+        return;
+    }
+
+    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
+    for (const auto& tileset : tilesets) {
+        if (tileset->getMaterialPath() != materialPath) {
+            continue;
+        }
+
+        tileset->updateShaderInput(path, name);
+    }
+}
+
 void Context::processPrimRemoved(const ChangedPrim& changedPrim) {
     switch (changedPrim.primType) {
         case ChangedPrimType::CESIUM_TILESET: {
@@ -399,6 +456,7 @@ void Context::processPrimRemoved(const ChangedPrim& changedPrim) {
         } break;
         case ChangedPrimType::CESIUM_GEOREFERENCE:
         case ChangedPrimType::CESIUM_DATA:
+        case ChangedPrimType::USD_SHADER:
         case ChangedPrimType::OTHER:
             break;
     }

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -453,6 +453,29 @@ void FabricMaterial::setImageryLayerAlpha(uint64_t imageryLayerIndex, float alph
     }
 }
 
+void FabricMaterial::updateShaderInput(const omni::fabric::Path& shaderPath, const omni::fabric::Token& attributeName) {
+    if (stageDestroyed()) {
+        return;
+    }
+
+    const auto srw = UsdUtil::getFabricStageReaderWriter();
+    const auto isrw = carb::getCachedInterface<omni::fabric::IStageReaderWriter>();
+
+    const auto copiedShaderPath = FabricUtil::getCopiedShaderPath(_materialPath, shaderPath);
+    const auto attributesToCopy = std::vector<omni::fabric::TokenC>{attributeName};
+
+    assert(isrw->primExists(srw.getId(), copiedShaderPath));
+    assert(isrw->attributeExists(srw.getId(), copiedShaderPath, attributeName));
+
+    isrw->copySpecifiedAttributes(
+        srw.getId(),
+        shaderPath,
+        attributesToCopy.data(),
+        copiedShaderPath,
+        attributesToCopy.data(),
+        attributesToCopy.size());
+}
+
 void FabricMaterial::clearMaterial() {
     setMaterial(NO_TILESET_ID, GltfUtil::getDefaultMaterialInfo());
 }

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -444,12 +444,11 @@ uint64_t OmniTileset::getImageryLayerCount() const {
     return _tileset->getOverlays().size();
 }
 
-void OmniTileset::updateImageryLayerAlpha(uint64_t imageryLayerIndex) {
-    assert(imageryLayerIndex < _imageryPaths.size());
-
-    const auto alpha = getImageryLayerAlpha(imageryLayerIndex);
-
-    _tileset->forEachLoadedTile([imageryLayerIndex, alpha](Cesium3DTilesSelection::Tile& tile) {
+namespace {
+void forEachFabricMaterial(
+    const std::unique_ptr<Cesium3DTilesSelection::Tileset>& tileset,
+    const std::function<void(FabricMaterial& fabricMaterial)>& callback) {
+    tileset->forEachLoadedTile([&callback](Cesium3DTilesSelection::Tile& tile) {
         if (tile.getState() != Cesium3DTilesSelection::TileLoadState::Done) {
             return;
         }
@@ -466,8 +465,25 @@ void OmniTileset::updateImageryLayerAlpha(uint64_t imageryLayerIndex) {
             if (!fabricMesh.material) {
                 continue;
             }
-            fabricMesh.material->setImageryLayerAlpha(imageryLayerIndex, alpha);
+            callback(*fabricMesh.material.get());
         }
+    });
+}
+} // namespace
+
+void OmniTileset::updateImageryLayerAlpha(uint64_t imageryLayerIndex) {
+    assert(imageryLayerIndex < _imageryPaths.size());
+
+    const auto alpha = getImageryLayerAlpha(imageryLayerIndex);
+
+    forEachFabricMaterial(_tileset, [imageryLayerIndex, alpha](FabricMaterial& fabricMaterial) {
+        fabricMaterial.setImageryLayerAlpha(imageryLayerIndex, alpha);
+    });
+}
+
+void OmniTileset::updateShaderInput(const pxr::SdfPath& shaderPath, const pxr::TfToken& attributeName) {
+    forEachFabricMaterial(_tileset, [&shaderPath, &attributeName](FabricMaterial& fabricMaterial) {
+        fabricMaterial.updateShaderInput(FabricUtil::toFabricPath(shaderPath), FabricUtil::toFabricToken(attributeName));
     });
 }
 

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -483,7 +483,8 @@ void OmniTileset::updateImageryLayerAlpha(uint64_t imageryLayerIndex) {
 
 void OmniTileset::updateShaderInput(const pxr::SdfPath& shaderPath, const pxr::TfToken& attributeName) {
     forEachFabricMaterial(_tileset, [&shaderPath, &attributeName](FabricMaterial& fabricMaterial) {
-        fabricMaterial.updateShaderInput(FabricUtil::toFabricPath(shaderPath), FabricUtil::toFabricToken(attributeName));
+        fabricMaterial.updateShaderInput(
+            FabricUtil::toFabricPath(shaderPath), FabricUtil::toFabricToken(attributeName));
     });
 }
 

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -24,6 +24,8 @@ ChangedPrimType getType(const pxr::SdfPath& path) {
             return ChangedPrimType::CESIUM_GEOREFERENCE;
         } else if (UsdUtil::hasCesiumGlobeAnchor(path)) {
             return ChangedPrimType::CESIUM_GLOBE_ANCHOR;
+        } else if (UsdUtil::isUsdShader(path)) {
+            return ChangedPrimType::USD_SHADER;
         }
     } else {
         // If the prim doesn't exist (because it was removed from the stage already) we can get the type from the asset registry
@@ -148,7 +150,7 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
     for (const auto& tileset : tilesets) {
         const auto tilesetPath = tileset->getPath();
         const auto type = getType(tilesetPath);
-        if (type != ChangedPrimType::OTHER && type != ChangedPrimType::CESIUM_GLOBE_ANCHOR) {
+        if (type == ChangedPrimType::CESIUM_TILESET) {
             if (inSubtree(primPath, tilesetPath)) {
                 _changedPrims.emplace_back(ChangedPrim{tilesetPath, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
                 CESIUM_LOG_INFO("Removed prim: {}", tilesetPath.GetText());
@@ -160,7 +162,7 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
     for (const auto& imagery : imageries) {
         const auto imageryPath = imagery->getPath();
         const auto type = getType(imageryPath);
-        if (type != ChangedPrimType::OTHER && type != ChangedPrimType::CESIUM_GLOBE_ANCHOR) {
+        if (type == ChangedPrimType::CESIUM_IMAGERY) {
             if (inSubtree(primPath, imageryPath)) {
                 _changedPrims.emplace_back(ChangedPrim{imageryPath, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
                 CESIUM_LOG_INFO("Removed prim: {}", imageryPath.GetText());

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -21,6 +21,8 @@
 #include <pxr/usd/usdGeom/metrics.h>
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
+#include <pxr/usd/usdShade/material.h>
+#include <pxr/usd/usdShade/shader.h>
 #include <spdlog/fmt/fmt.h>
 
 #include <regex>
@@ -431,6 +433,13 @@ pxr::CesiumGlobeAnchorAPI getCesiumGlobeAnchor(const pxr::SdfPath& path) {
     return globeAnchor;
 }
 
+pxr::UsdShadeShader getUsdShader(const pxr::SdfPath& path) {
+    auto stage = getUsdStage();
+    auto shader = pxr::UsdShadeShader::Get(stage, path);
+    assert(shader.GetPrim().IsValid());
+    return shader;
+}
+
 bool isCesiumData(const pxr::SdfPath& path) {
     auto stage = getUsdStage();
     auto prim = stage->GetPrimAtPath(path);
@@ -489,6 +498,26 @@ bool hasCesiumGlobeAnchor(const pxr::SdfPath& path) {
     }
 
     return prim.HasAPI<pxr::CesiumGlobeAnchorAPI>();
+}
+
+bool isUsdShader(const pxr::SdfPath& path) {
+    auto stage = getUsdStage();
+    auto prim = stage->GetPrimAtPath(path);
+    if (!prim.IsValid()) {
+        return false;
+    }
+
+    return prim.IsA<pxr::UsdShadeShader>();
+}
+
+bool isUsdMaterial(const pxr::SdfPath& path) {
+    auto stage = getUsdStage();
+    auto prim = stage->GetPrimAtPath(path);
+    if (!prim.IsValid()) {
+        return false;
+    }
+
+    return prim.IsA<pxr::UsdShadeMaterial>();
 }
 
 bool primExists(const pxr::SdfPath& path) {


### PR DESCRIPTION
Fixes the first bullet in https://github.com/CesiumGS/cesium-omniverse/issues/504:

> * Changing individual material values - this could be implemented by watching for USD notifications and updating Fabric prims (a bit like https://github.com/CesiumGS/cesium-omniverse/pull/498).


https://github.com/CesiumGS/cesium-omniverse/assets/915398/2cea2f34-ee0c-4048-b447-06519bad5c77

[imagery-layer-blending-test.usda.zip](https://github.com/CesiumGS/cesium-omniverse/files/13170731/imagery-layer-blending-test.usda.zip)
