### PR TITLE
0.12.0 Release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### v0.12.0 - 2023-10-25
 
-* Added a quick add button for Google Photorealistic Tiles through ion.
+* Added a quick add button for Google Photorealistic 3D Tiles through ion.
 * Added support for globe anchors.
 * Added support for multiple imagery layers.
 * Added alpha property to imagery layers.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Change Log
 
-### v0.12.0 - 2023-11-01
+### v0.12.0 - 2023-10-25
 
+* Added a quick add button for Google Photorealistic Tiles through ion.
 * Added support for globe anchors.
 * Added support for multiple imagery layers.
 * Added alpha property to imagery layers.


### PR DESCRIPTION
* Added a quick add button for Google Photorealistic 3D Tiles through ion.
* Added support for globe anchors.
* Added support for multiple imagery layers.
* Added alpha property to imagery layers.
* Added support for reading textures and imagery layers in MDL.
* Added Cesium for Omniverse Python API, see the `cesium.omniverse.api` module.
* Fixed debug colors not working for tiles with vertex colors.
* Fixed hangs when loading tilesets by setting `omnihydra.parallelHydraSprimSync` to `false`.
* Basis Universal textures are now decoded to the native BCn texture format instead of RGBA8 in Kit 105.1 and above.