### PR TITLE
Replace regex attr name parsing with string parsing

### DIFF
--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -317,7 +317,7 @@ const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, co
 }
 
 std::pair<std::string, uint64_t> parseAttributeName(const std::string& attributeName) {
-    std::string semantic = "";
+    std::string semantic{};
     uint64_t setIndexU64 = 0;
 
     if (attributeName[0] != '_') {

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -335,7 +335,10 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
         semantic = attributeName;
     } else {
         semantic = attributeName.substr(0, lastUnderscorePosition);
-        std::from_chars(attributeName.data() + lastUnderscorePosition + 1, attributeName.data() + attributeName.size() - 1, setIndexU64);
+        std::from_chars(
+            attributeName.data() + lastUnderscorePosition + 1,
+            attributeName.data() + attributeName.size(),
+            setIndexU64);
     }
 
     return std::make_pair(semantic, setIndexU64);

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -317,16 +317,23 @@ const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, co
 }
 
 std::pair<std::string, uint64_t> parseAttributeName(const std::string& attributeName) {
-    std::string semantic{};
-    uint64_t setIndexU64 = 0;
+    int searchPosition = static_cast<int>(attributeName.size()) - 1;
+    int lastUnderscorePosition{-1};
+    while (searchPosition > 0) {
+        if (!isdigit(attributeName[searchPosition])) {
+            break;
+        }
+        lastUnderscorePosition = searchPosition;
+        searchPosition--;
+    }
 
-    if (attributeName[0] != '_') {
+    std::string semantic{};
+    uint64_t setIndexU64{0};
+    if (lastUnderscorePosition == -1) {
         semantic = attributeName;
     } else {
-        auto lastUnderscorePosition = attributeName.rfind('_');
-        semantic = attributeName.substr(0, lastUnderscorePosition);
-        auto setIndex =
-            attributeName.substr(lastUnderscorePosition + 1, attributeName.size() - lastUnderscorePosition + 1);
+        semantic = attributeName.substr(0, lastUnderscorePosition - 1);
+        auto setIndex = attributeName.substr(lastUnderscorePosition);
         std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
     }
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -325,7 +325,8 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
     } else {
         auto lastUnderscorePosition = attributeName.rfind('_');
         semantic = attributeName.substr(0, lastUnderscorePosition);
-        auto setIndex = attributeName.substr(lastUnderscorePosition + 1, attributeName.size() - lastUnderscorePosition + 1);
+        auto setIndex =
+            attributeName.substr(lastUnderscorePosition + 1, attributeName.size() - lastUnderscorePosition + 1);
         std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
     }
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -16,7 +16,6 @@
 
 #include <charconv>
 #include <numeric>
-#include <regex>
 
 namespace cesium::omniverse::GltfUtil {
 
@@ -321,9 +320,12 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
     int lastUnderscorePosition{-1};
     while (searchPosition > 0) {
         if (!isdigit(attributeName[searchPosition])) {
+            if (attributeName[searchPosition] == '_') {
+                lastUnderscorePosition = searchPosition;
+            }
+
             break;
         }
-        lastUnderscorePosition = searchPosition;
         searchPosition--;
     }
 
@@ -332,8 +334,8 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
     if (lastUnderscorePosition == -1) {
         semantic = attributeName;
     } else {
-        semantic = attributeName.substr(0, lastUnderscorePosition - 1);
-        auto setIndex = attributeName.substr(lastUnderscorePosition);
+        semantic = attributeName.substr(0, lastUnderscorePosition);
+        auto setIndex = attributeName.substr(lastUnderscorePosition + 1);
         std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
     }
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -335,8 +335,7 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
         semantic = attributeName;
     } else {
         semantic = attributeName.substr(0, lastUnderscorePosition);
-        auto setIndex = attributeName.substr(lastUnderscorePosition + 1);
-        std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
+        std::from_chars(attributeName.data() + lastUnderscorePosition + 1, attributeName.data() + attributeName.size() - 1, setIndexU64);
     }
 
     return std::make_pair(semantic, setIndexU64);

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -317,20 +317,17 @@ const CesiumGltf::ImageCesium& getImageCesium(const CesiumGltf::Model& model, co
 }
 
 std::pair<std::string, uint64_t> parseAttributeName(const std::string& attributeName) {
-    const auto regex = std::regex("^([a-zA-Z_]*)(_([1-9]\\d*|0))?$");
-
-    std::string semantic;
-    std::string setIndex;
-
-    std::smatch matches;
-
-    if (std::regex_match(attributeName, matches, regex)) {
-        semantic = matches[1];
-        setIndex = matches[3];
-    }
-
+    std::string semantic = "";
     uint64_t setIndexU64 = 0;
-    std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
+
+    if (attributeName[0] != '_') {
+        semantic = attributeName;
+    } else {
+        auto lastUnderscorePosition = attributeName.rfind('_');
+        semantic = attributeName.substr(0, lastUnderscorePosition);
+        auto setIndex = attributeName.substr(lastUnderscorePosition + 1, attributeName.size() - lastUnderscorePosition + 1);
+        std::from_chars(setIndex.data(), setIndex.data() + setIndex.size(), setIndexU64);
+    }
 
     return std::make_pair(semantic, setIndexU64);
 }


### PR DESCRIPTION
When acquiring Fabric geometry, we were previously parsing attribute names with a regex. This costs a median of 244 microseconds. Replacing with string parsing drops the median to 107 microseconds. Stats via Superluminal for the FabricGeometryDefinition constructor:

Regex:

![image](https://github.com/CesiumGS/cesium-omniverse/assets/1040194/4d57609d-1f00-454d-bd75-484d2fec8be7)


string:

![image](https://github.com/CesiumGS/cesium-omniverse/assets/1040194/d70b0ff8-5bf8-43a7-9caf-34e374ec0bb8)


