### PR TITLE
Certain tileset properties no longer trigger a tileset reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### v0.13.0 - 2023-11-01
+
+* Changing certain tileset properties no longer triggers a tileset reload.
+
 ### v0.12.1 - 2023-10-26
 
 * Fixed version numbers.

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -35,8 +35,8 @@ class FabricMaterial {
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex,
         uint64_t imageryLayerIndex,
-        float alpha);
-    void setImageryLayerAlpha(uint64_t imageryLayerIndex, float alpha);
+        double alpha);
+    void setImageryLayerAlpha(uint64_t imageryLayerIndex, double alpha);
     void updateShaderInput(const omni::fabric::Path& shaderPath, const omni::fabric::Token& attributeName);
 
     void clearMaterial();
@@ -91,8 +91,8 @@ class FabricMaterial {
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex,
-        float alpha);
-    void setImageryLayerAlphaValue(const omni::fabric::Path& imageryLayerPath, float alpha);
+        double alpha);
+    void setImageryLayerAlphaValue(const omni::fabric::Path& imageryLayerPath, double alpha);
 
     bool stageDestroyed();
 

--- a/src/core/include/cesium/omniverse/OmniImagery.h
+++ b/src/core/include/cesium/omniverse/OmniImagery.h
@@ -13,7 +13,7 @@ class OmniImagery {
     [[nodiscard]] int64_t getIonAssetId() const;
     [[nodiscard]] std::optional<CesiumIonClient::Token> getIonAccessToken() const;
     [[nodiscard]] bool getShowCreditsOnScreen() const;
-    [[nodiscard]] float getAlpha() const;
+    [[nodiscard]] double getAlpha() const;
 
   private:
     pxr::SdfPath _path;

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -50,7 +50,7 @@ class OmniTileset {
     [[nodiscard]] std::string getUrl() const;
     [[nodiscard]] int64_t getIonAssetId() const;
     [[nodiscard]] std::optional<CesiumIonClient::Token> getIonAccessToken() const;
-    [[nodiscard]] float getMaximumScreenSpaceError() const;
+    [[nodiscard]] double getMaximumScreenSpaceError() const;
     [[nodiscard]] bool getPreloadAncestors() const;
     [[nodiscard]] bool getPreloadSiblings() const;
     [[nodiscard]] bool getForbidHoles() const;
@@ -60,10 +60,10 @@ class OmniTileset {
     [[nodiscard]] bool getEnableFrustumCulling() const;
     [[nodiscard]] bool getEnableFogCulling() const;
     [[nodiscard]] bool getEnforceCulledScreenSpaceError() const;
-    [[nodiscard]] float getCulledScreenSpaceError() const;
+    [[nodiscard]] double getCulledScreenSpaceError() const;
     [[nodiscard]] bool getSuspendUpdate() const;
     [[nodiscard]] bool getSmoothNormals() const;
-    [[nodiscard]] float getMainThreadLoadingTimeLimit() const;
+    [[nodiscard]] double getMainThreadLoadingTimeLimit() const;
     [[nodiscard]] bool getShowCreditsOnScreen() const;
     [[nodiscard]] pxr::CesiumGeoreference getGeoreference() const;
     [[nodiscard]] pxr::SdfPath getMaterialPath() const;
@@ -77,7 +77,7 @@ class OmniTileset {
     findImageryLayerIndex(const Cesium3DTilesSelection::RasterOverlay& overlay) const;
     [[nodiscard]] std::optional<uint64_t> findImageryLayerIndex(const pxr::SdfPath& imageryPath) const;
     [[nodiscard]] uint64_t getImageryLayerCount() const;
-    [[nodiscard]] float getImageryLayerAlpha(uint64_t imageryLayerIndex) const;
+    [[nodiscard]] double getImageryLayerAlpha(uint64_t imageryLayerIndex) const;
     void updateImageryLayerAlpha(uint64_t imageryLayerIndex);
     void updateShaderInput(const pxr::SdfPath& shaderPath, const pxr::TfToken& attributeName);
     void onUpdateFrame(const std::vector<Viewport>& viewports);

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -71,6 +71,8 @@ class OmniTileset {
     [[nodiscard]] int64_t getTilesetId() const;
     [[nodiscard]] TilesetStatistics getStatistics() const;
 
+    void updateTilesetOptionsFromProperties();
+
     void reload();
     void addImageryIon(const pxr::SdfPath& imageryPath);
     [[nodiscard]] std::optional<uint64_t>

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -274,11 +274,7 @@ void Context::processCesiumTilesetChanged(const ChangedPrim& changedPrim) {
     }
 
     // clang-format off
-    if (name == pxr::CesiumTokens->cesiumSourceType ||
-        name == pxr::CesiumTokens->cesiumUrl ||
-        name == pxr::CesiumTokens->cesiumIonAssetId ||
-        name == pxr::CesiumTokens->cesiumIonAccessToken ||
-        name == pxr::CesiumTokens->cesiumMaximumScreenSpaceError ||
+    if (name == pxr::CesiumTokens->cesiumMaximumScreenSpaceError ||
         name == pxr::CesiumTokens->cesiumPreloadAncestors ||
         name == pxr::CesiumTokens->cesiumPreloadSiblings ||
         name == pxr::CesiumTokens->cesiumForbidHoles ||
@@ -289,8 +285,17 @@ void Context::processCesiumTilesetChanged(const ChangedPrim& changedPrim) {
         name == pxr::CesiumTokens->cesiumEnableFogCulling ||
         name == pxr::CesiumTokens->cesiumEnforceCulledScreenSpaceError ||
         name == pxr::CesiumTokens->cesiumCulledScreenSpaceError ||
+        name == pxr::CesiumTokens->cesiumMainThreadLoadingTimeLimit) {
+        tileset.value()->updateTilesetOptionsFromProperties();
+    }
+    // clang-format on
+
+    // clang-format off
+    if (name == pxr::CesiumTokens->cesiumSourceType ||
+        name == pxr::CesiumTokens->cesiumUrl ||
+        name == pxr::CesiumTokens->cesiumIonAssetId ||
+        name == pxr::CesiumTokens->cesiumIonAccessToken ||
         name == pxr::CesiumTokens->cesiumSmoothNormals ||
-        name == pxr::CesiumTokens->cesiumMainThreadLoadingTimeLimit ||
         name == pxr::CesiumTokens->cesiumShowCreditsOnScreen ||
         name == pxr::UsdTokens->material_binding) {
         tileset.value()->reload();

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -425,7 +425,7 @@ void FabricMaterial::setImageryLayer(
     const TextureInfo& textureInfo,
     uint64_t texcoordIndex,
     uint64_t imageryLayerIndex,
-    float alpha) {
+    double alpha) {
     if (stageDestroyed()) {
         return;
     }
@@ -439,7 +439,7 @@ void FabricMaterial::setImageryLayer(
     }
 }
 
-void FabricMaterial::setImageryLayerAlpha(uint64_t imageryLayerIndex, float alpha) {
+void FabricMaterial::setImageryLayerAlpha(uint64_t imageryLayerIndex, double alpha) {
     if (stageDestroyed()) {
         return;
     }
@@ -584,15 +584,15 @@ void FabricMaterial::setImageryLayerValues(
     const pxr::TfToken& textureAssetPathToken,
     const TextureInfo& textureInfo,
     uint64_t texcoordIndex,
-    float alpha) {
+    double alpha) {
     setTextureValuesCommon(imageryLayerPath, textureAssetPathToken, textureInfo, texcoordIndex);
     setImageryLayerAlphaValue(imageryLayerPath, alpha);
 }
 
-void FabricMaterial::setImageryLayerAlphaValue(const omni::fabric::Path& imageryLayerPath, float alpha) {
+void FabricMaterial::setImageryLayerAlphaValue(const omni::fabric::Path& imageryLayerPath, double alpha) {
     auto srw = UsdUtil::getFabricStageReaderWriter();
     auto alphaFabric = srw.getAttributeWr<float>(imageryLayerPath, FabricTokens::inputs_alpha);
-    *alphaFabric = alpha;
+    *alphaFabric = static_cast<float>(alpha);
 }
 
 bool FabricMaterial::stageDestroyed() {

--- a/src/core/src/OmniImagery.cpp
+++ b/src/core/src/OmniImagery.cpp
@@ -53,13 +53,13 @@ bool OmniImagery::getShowCreditsOnScreen() const {
     return showCreditsOnScreen;
 }
 
-float OmniImagery::getAlpha() const {
+double OmniImagery::getAlpha() const {
     auto imagery = UsdUtil::getCesiumImagery(_path);
 
     float alpha;
     imagery.GetAlphaAttr().Get<float>(&alpha);
 
-    return alpha;
+    return static_cast<double>(alpha);
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -100,13 +100,13 @@ std::optional<CesiumIonClient::Token> OmniTileset::getIonAccessToken() const {
     return t;
 }
 
-float OmniTileset::getMaximumScreenSpaceError() const {
+double OmniTileset::getMaximumScreenSpaceError() const {
     auto tileset = UsdUtil::getCesiumTileset(_tilesetPath);
 
     float maximumScreenSpaceError;
     tileset.GetMaximumScreenSpaceErrorAttr().Get<float>(&maximumScreenSpaceError);
 
-    return maximumScreenSpaceError;
+    return static_cast<double>(maximumScreenSpaceError);
 }
 
 bool OmniTileset::getPreloadAncestors() const {
@@ -190,13 +190,13 @@ bool OmniTileset::getEnforceCulledScreenSpaceError() const {
     return enforceCulledScreenSpaceError;
 }
 
-float OmniTileset::getCulledScreenSpaceError() const {
+double OmniTileset::getCulledScreenSpaceError() const {
     auto tileset = UsdUtil::getCesiumTileset(_tilesetPath);
 
     float culledScreenSpaceError;
     tileset.GetCulledScreenSpaceErrorAttr().Get<float>(&culledScreenSpaceError);
 
-    return culledScreenSpaceError;
+    return static_cast<double>(culledScreenSpaceError);
 }
 
 bool OmniTileset::getSuspendUpdate() const {
@@ -226,13 +226,13 @@ bool OmniTileset::getShowCreditsOnScreen() const {
     return showCreditsOnScreen;
 }
 
-float OmniTileset::getMainThreadLoadingTimeLimit() const {
+double OmniTileset::getMainThreadLoadingTimeLimit() const {
     auto tileset = UsdUtil::getCesiumTileset(_tilesetPath);
 
     float mainThreadLoadingTimeLimit;
     tileset.GetMainThreadLoadingTimeLimitAttr().Get<float>(&mainThreadLoadingTimeLimit);
 
-    return mainThreadLoadingTimeLimit;
+    return static_cast<double>(mainThreadLoadingTimeLimit);
 }
 
 pxr::CesiumGeoreference OmniTileset::getGeoreference() const {
@@ -488,11 +488,11 @@ void OmniTileset::updateShaderInput(const pxr::SdfPath& shaderPath, const pxr::T
     });
 }
 
-float OmniTileset::getImageryLayerAlpha(uint64_t imageryLayerIndex) const {
+double OmniTileset::getImageryLayerAlpha(uint64_t imageryLayerIndex) const {
     assert(imageryLayerIndex < _imageryPaths.size());
 
     auto alpha = OmniImagery(_imageryPaths[imageryLayerIndex]).getAlpha();
-    alpha = glm::clamp(alpha, 0.0f, 1.0f);
+    alpha = glm::clamp(alpha, 0.0, 1.0);
 
     return alpha;
 }

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -280,6 +280,22 @@ TilesetStatistics OmniTileset::getStatistics() const {
     return statistics;
 }
 
+void OmniTileset::updateTilesetOptionsFromProperties() {
+    auto& options = _tileset->getOptions();
+    options.maximumScreenSpaceError = getMaximumScreenSpaceError();
+    options.preloadAncestors = getPreloadAncestors();
+    options.preloadSiblings = getPreloadSiblings();
+    options.forbidHoles = getForbidHoles();
+    options.maximumSimultaneousTileLoads = getMaximumSimultaneousTileLoads();
+    options.maximumCachedBytes = static_cast<int64_t>(getMaximumCachedBytes());
+    options.loadingDescendantLimit = getLoadingDescendantLimit();
+    options.enableFrustumCulling = getEnableFrustumCulling();
+    options.enableFogCulling = getEnableFogCulling();
+    options.enforceCulledScreenSpaceError = getEnforceCulledScreenSpaceError();
+    options.culledScreenSpaceError = getCulledScreenSpaceError();
+    options.mainThreadLoadingTimeLimit = getMainThreadLoadingTimeLimit();
+}
+
 void OmniTileset::reload() {
     if (_renderResourcesPreparer != nullptr) {
         _renderResourcesPreparer->detachTileset();


### PR DESCRIPTION
Certain tileset properties no longer trigger a tileset reload. This includes:

  * `maximumScreenSpaceError`
  * `preloadAncestors`
  * `preloadSiblings`
  * `forbidHoles`
  * `maximumSimultaneousTileLoads`
  * `maximumCachedBytes`
  * `loadingDescendantLimit`
  * `enableFrustumCulling`
  * `enableFogCulling`
  * `enforceCulledScreenSpaceError`
  * `culledScreenSpaceError`
  * `mainThreadLoadingTimeLimit`

Also switched to using doubles instead of floats internally for a few tileset options. No USD schema changes.

https://github.com/CesiumGS/cesium-omniverse/assets/915398/dfa605f1-3119-4350-a6ff-d302de7a773e