### PR TITLE
Add power tool to save fabric stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,8 @@ tests/include/testUtils.h
 # Tracing files
 cesium-trace-*.json
 
-# Carb settings from Cesium Power Tools extensions
+# Carb settings from Cesium Power Tools extension
 carb_settings.txt
+
+# Fabric stage from Cesium Power Tools extension
+fabric_stage.txt

--- a/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/debug_window.py
@@ -18,7 +18,6 @@ class CesiumOmniverseDebugWindow(ui.Window):
 
         self._logger = logging.getLogger(__name__)
         self._cesium_omniverse_interface = cesium_omniverse_interface
-        self._cesium_message_field: ui.SimpleStringModel = ui.SimpleStringModel("")
         self._statistics_widget: Optional[CesiumOmniverseStatisticsWidget] = None
 
         # Set the function that is called to build widgets when the window is visible
@@ -58,16 +57,8 @@ class CesiumOmniverseDebugWindow(ui.Window):
             for tileset_path in tileset_paths:
                 self._cesium_omniverse_interface.reload_tileset(tileset_path)
 
-        def print_fabric_stage():
-            """Prints the contents of the Fabric stage to a text field."""
-
-            fabric_stage = self._cesium_omniverse_interface.print_fabric_stage()
-            self._cesium_message_field.set_value(fabric_stage)
-
         with ui.VStack(spacing=10):
             with ui.VStack():
                 ui.Button("Remove all Tilesets", height=20, clicked_fn=remove_all_tilesets)
                 ui.Button("Reload all Tilesets", height=20, clicked_fn=reload_all_tilesets)
-                ui.Button("Print Fabric stage", height=20, clicked_fn=print_fabric_stage)
-                ui.StringField(self._cesium_message_field, height=100, multiline=True, read_only=True)
             self._statistics_widget = CesiumOmniverseStatisticsWidget(self._cesium_omniverse_interface)

--- a/exts/cesium.powertools/cesium/powertools/powertools_window.py
+++ b/exts/cesium.powertools/cesium/powertools/powertools_window.py
@@ -3,7 +3,7 @@ import omni.ui as ui
 from typing import Callable, Optional, List
 from cesium.omniverse.ui import CesiumOmniverseDebugWindow
 from .georefhelper.georef_helper_window import CesiumGeorefHelperWindow
-from .utils import extend_far_plane, save_carb_settings, set_sunstudy_from_georef
+from .utils import extend_far_plane, save_carb_settings, save_fabric_stage, set_sunstudy_from_georef
 import os
 from functools import partial
 
@@ -44,6 +44,7 @@ class CesiumPowertoolsWindow(ui.Window):
             PowertoolsAction("Open Cesium Georeference Helper Window", CesiumGeorefHelperWindow.create_window),
             PowertoolsAction("Extend Far Plane", extend_far_plane),
             PowertoolsAction("Save Carb Settings", partial(save_carb_settings, powertools_extension_location)),
+            PowertoolsAction("Save Fabric Stage", partial(save_fabric_stage, powertools_extension_location)),
             PowertoolsAction("Set Sun Study from Georef", set_sunstudy_from_georef),
         ]
 

--- a/exts/cesium.powertools/cesium/powertools/utils/utils.py
+++ b/exts/cesium.powertools/cesium/powertools/utils/utils.py
@@ -4,6 +4,7 @@ from pxr import Gf, UsdGeom, Sdf
 import json
 import carb.settings
 import os
+from cesium.omniverse.utils.cesium_interface import CesiumInterfaceManager
 
 
 # Modified version of ScopedEdit in _build_viewport_cameras in omni.kit.widget.viewport
@@ -47,6 +48,13 @@ def save_carb_settings(powertools_extension_location: str):
     carb_settings_path = os.path.join(powertools_extension_location, "carb_settings.txt")
     with open(carb_settings_path, "w") as fh:
         fh.write(json.dumps(carb.settings.get_settings().get("/"), indent=2))
+
+
+def save_fabric_stage(powertools_extension_location: str):
+    with CesiumInterfaceManager() as interface:
+        fabric_stage_path = os.path.join(powertools_extension_location, "fabric_stage.txt")
+        with open(fabric_stage_path, "w") as fh:
+            fh.write(interface.print_fabric_stage())
 
 
 # Helper function to search for an attribute on a prim, or create it if not present


### PR DESCRIPTION
Omniverse often crashes when saving the Fabric stage and then copying the contents of the textbox to somewhere else. A better workflow is to save the Fabric stage to a file.

I don't think printing the fabric stage needs to be part of the main extension, so I moved it to power tools.


https://github.com/CesiumGS/cesium-omniverse/assets/915398/3d8fc04e-1aed-4555-a109-a091d6a9b3a0

