### PR TITLE
Remove doubleSided from FabricGeometryDefinition

### DIFF
--- a/src/core/include/cesium/omniverse/FabricGeometry.h
+++ b/src/core/include/cesium/omniverse/FabricGeometry.h
@@ -13,6 +13,8 @@ struct Model;
 
 namespace cesium::omniverse {
 
+struct MaterialInfo;
+
 class FabricGeometry {
   public:
     FabricGeometry(const omni::fabric::Path& path, const FabricGeometryDefinition& geometryDefinition, long stageId);
@@ -25,6 +27,7 @@ class FabricGeometry {
         const glm::dmat4& nodeTransform,
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
+        const MaterialInfo& materialInfo,
         bool smoothNormals,
         const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping,
         const std::unordered_map<uint64_t, uint64_t>& imageryTexcoordIndexMapping);

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -18,7 +18,6 @@ class FabricGeometryDefinition {
 
     [[nodiscard]] bool hasNormals() const;
     [[nodiscard]] bool hasVertexColors() const;
-    [[nodiscard]] bool getDoubleSided() const;
     [[nodiscard]] uint64_t getTexcoordSetCount() const;
 
     bool operator==(const FabricGeometryDefinition& other) const;
@@ -26,7 +25,6 @@ class FabricGeometryDefinition {
   private:
     bool _hasNormals{false};
     bool _hasVertexColors{false};
-    bool _doubleSided{false};
     uint64_t _texcoordSetCount{0};
 };
 

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -15,10 +15,8 @@ FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
     bool smoothNormals) {
-    const auto materialInfo = GltfUtil::getMaterialInfo(model, primitive);
     _hasNormals = GltfUtil::hasNormals(model, primitive, smoothNormals);
     _hasVertexColors = GltfUtil::hasVertexColors(model, primitive, 0);
-    _doubleSided = materialInfo.doubleSided;
     _texcoordSetCount = GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
                         GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size();
 }
@@ -31,10 +29,6 @@ bool FabricGeometryDefinition::hasVertexColors() const {
     return _hasVertexColors;
 }
 
-bool FabricGeometryDefinition::getDoubleSided() const {
-    return _doubleSided;
-}
-
 [[nodiscard]] uint64_t FabricGeometryDefinition::getTexcoordSetCount() const {
     return _texcoordSetCount;
 }
@@ -45,10 +39,6 @@ bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other)
     }
 
     if (_hasVertexColors != other._hasVertexColors) {
-        return false;
-    }
-
-    if (_doubleSided != other._doubleSided) {
         return false;
     }
 

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -200,6 +200,7 @@ void setFabricMeshes(
             meshInfo.nodeTransform,
             model,
             primitive,
+            materialInfo,
             meshInfo.smoothNormals,
             mesh.texcoordIndexMapping,
             mesh.imageryTexcoordIndexMapping);


### PR DESCRIPTION
This is a cleanup thing I've been meaning to fix for a while.

`doubleSided` doesn't really belong in `FabricGeometryDefinition`. The purpose of `FabricGeometryDefinition` is to prevent geometry with different attributes from sharing the same pool. Important for things like vertex colors, normals, and texcoords which affect the prim's topology, but not important for `doubleSided` which always exists on the prim.