### PR TITLE
Migrate to AlmaLinux 8 for builds

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -16,7 +16,8 @@ runs:
     # Parallel 2 because github action limited to two cores
     # Linters are turned off because there is no pre-compiled C++20-capable LLVM toolset for CentOS 7. It won't affect the build, it just means there won't be code formatting or linting. It will build fine with GCC.
     # Make sure to configure without sanitizers and any other development options
-    - "cmake -B build -D CMAKE_BUILD_TYPE=${{ inputs.build-type }} -D CESIUM_OMNI_ENABLE_LINTERS=OFF -D CESIUM_OMNI_ENABLE_SANITIZERS=OFF &&
+    - "git config --global --add safe.directory '*' &&
+      cmake -B build -D CMAKE_BUILD_TYPE=${{ inputs.build-type }} -D CESIUM_OMNI_ENABLE_LINTERS=OFF -D CESIUM_OMNI_ENABLE_SANITIZERS=OFF &&
       cmake --build build --parallel 2 &&
       cmake --build build --target install &&
       cmake --build build --target package"

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1,5 +1,5 @@
-name: "CentOS 7 Build"
-description: "Build Cesium for Omniverse in Docker container running a CentOS 7 image"
+name: "AlmaLinux 8 Build"
+description: "Build Cesium for Omniverse in Docker container running a AlmaLinux 8 image"
 inputs:
   build-type:
     description: "Release or debug build"

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -11,10 +11,8 @@ runs:
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE
   args:
-    - "--login"
+    # Tell bash to run a command
     - "-c"
-    # Gets around a Git issue with CI. https://stackoverflow.com/a/73100228
-    - "git config --global --add safe.directory '*'"
     # Parallel 2 because github action limited to two cores
     # Linters are turned off because there is no pre-compiled C++20-capable LLVM toolset for CentOS 7. It won't affect the build, it just means there won't be code formatting or linting. It will build fine with GCC.
     # Make sure to configure without sanitizers and any other development options

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -11,8 +11,6 @@ runs:
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE
   args:
-    # Tell bash to run a command
-    - "-c"
     # Gets around a Git issue with CI. https://stackoverflow.com/a/73100228
     - "git config --global --add safe.directory '*'"
     # Parallel 2 because github action limited to two cores

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -13,6 +13,8 @@ runs:
   args:
     # Tell bash to run a command
     - "-c"
+    # Gets around a Git issue with CI. https://stackoverflow.com/a/73100228
+    - "git config --global --add safe.directory '*'"
     # Parallel 2 because github action limited to two cores
     # Linters are turned off because there is no pre-compiled C++20-capable LLVM toolset for CentOS 7. It won't affect the build, it just means there won't be code formatting or linting. It will build fine with GCC.
     # Make sure to configure without sanitizers and any other development options

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -11,6 +11,8 @@ runs:
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE
   args:
+    - "--login"
+    - "-c"
     # Gets around a Git issue with CI. https://stackoverflow.com/a/73100228
     - "git config --global --add safe.directory '*'"
     # Parallel 2 because github action limited to two cores

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,13 @@ jobs:
               coverage: "false",
             }
           - {
-              name: "CentOS 7 - GCC",
+              name: "AlmaLinux 8 - GCC",
               artifact: "linux-gcc.tar.xz",
               os: ubuntu-latest-m,
               cc: "gcc-11",
               cxx: "g++-11",
               build-type: "Release",
-              build-code: "CentOS7",
+              build-code: "AlmaLinux8",
               generator: "Unix Makefiles",
               coverage: "false",
             }
@@ -82,21 +82,21 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}/.conan
           key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v3
 
-      - name: CentOS Build with Docker
+      - name: AlmaLinux Build with Docker
         uses: ./.github/actions
-        if: matrix.config.name == 'CentOS 7 - GCC'
+        if: matrix.config.name == 'AlmaLinux 8 - GCC'
         with:
           build-type: ${{ matrix.config.build-type }}
 
       # Change the ownership from root to user for all files created by Docker in
       # the Conan build directory so that the files can be cached without permission
       # denied errors
-      - name: CentOS Change Conan directory permissions
-        if: matrix.config.name == 'CentOS 7 - GCC'
+      - name: AlmaLinux Change Conan directory permissions
+        if: matrix.config.name == 'AlmaLinux 8 - GCC'
         run: sudo chown -R $USER:$USER $CONAN_USER_HOME/.conan
 
       - name: Install Linux dependencies
-        if: ${{ runner.os == 'Linux' && matrix.config.name != 'CentOS 7 - GCC' }}
+        if: ${{ runner.os == 'Linux' && matrix.config.name != 'AlmaLinux 8 - GCC' }}
         run: |
           sudo apt update
           sudo apt install -y doxygen clang-tidy-14 gcovr nvidia-driver-535
@@ -118,7 +118,7 @@ jobs:
       # Note: CMAKE_BUILD_TYPE is only used by Linux. It is ignored for Windows.
       # Note: CMAKE_CONFIGURATION_TYPES is used by Windows to generate a single configuration for Release since we don't need Debug, RelWithDebugInfo, and MinSizeRel on CI. It is ignored for Linux.
       - name: Configure
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake -B build -D CESIUM_OMNI_ENABLE_COVERAGE=${{ matrix.config.coverage}} -D CMAKE_C_COMPILER=${{ matrix.config.cc }} -D CMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -D CMAKE_BUILD_TYPE=${{ matrix.config.build-type }} -D CMAKE_CONFIGURATION_TYPES=${{ matrix.config.build-type }} -G "${{ matrix.config.generator }}"
 
       # Change the ownership from root to user for all files in the Conan cache so
@@ -133,19 +133,19 @@ jobs:
           $Acl.SetAccessRule($Ar)
 
       - name: Check C/C++ Formatting
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake --build build --target clang-format-check-all --config ${{ matrix.config.build-type }}
 
       - name: Check Python Formatting
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: black --check --diff .
 
       - name: Check Python Linting
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: flake8
 
       - name: Build
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake --build build --config ${{ matrix.config.build-type }} --parallel ${{ steps.cpu-cores.outputs.count }}
 
       - name: Coverage
@@ -154,19 +154,19 @@ jobs:
 
       - name: Documentation
         # Currently disabled for Windows because `choco install doxygen.install` is flaky
-        if: ${{ matrix.config.name != 'CentOS 7 - GCC' && runner.os != 'Windows' }}
+        if: ${{ matrix.config.name != 'AlmaLinux 8 - GCC' && runner.os != 'Windows' }}
         run: cmake --build build --target generate-documentation --config ${{ matrix.config.build-type }}
 
       - name: Install (Default/Kit)
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake --install build --config ${{ matrix.config.build-type }}
 
       - name: Install (Library)
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake --install build --config ${{ matrix.config.build-type }} --prefix install-library --component library
 
       - name: Package
-        if: matrix.config.name != 'CentOS 7 - GCC'
+        if: matrix.config.name != 'AlmaLinux 8 - GCC'
         run: cmake --build build --target package --config ${{ matrix.config.build-type }}
 
       - name: Capture Git info (not Windows)
@@ -198,6 +198,6 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload to S3
-        if: ${{ matrix.config.name == 'CentOS 7 - GCC' || runner.os == 'Windows' }}
+        if: ${{ matrix.config.name == 'AlmaLinux 8 - GCC' || runner.os == 'Windows' }}
         run: |
           aws s3 cp build/${{ env.zip_name }} s3://cesium-builds/cesium-omniverse/${{ env.branch }}/${{ env.us_date }}/${{ env.sha_short }}/${{ matrix.config.build-code }}/

--- a/cmake/conan-0.17.0.cmake
+++ b/cmake/conan-0.17.0.cmake
@@ -95,7 +95,7 @@ macro(_conan_check_system_name)
         endif()
         if(${CMAKE_SYSTEM_NAME} STREQUAL "QNX")
             set(CONAN_SYSTEM_NAME Neutrino)
-        endif()        
+        endif()
         set(CONAN_SUPPORTED_PLATFORMS Windows Linux Macos Android iOS FreeBSD WindowsStore WindowsCE watchOS tvOS FreeBSD SunOS AIX Arduino Emscripten Neutrino)
         list (FIND CONAN_SUPPORTED_PLATFORMS "${CONAN_SYSTEM_NAME}" _index)
         if (${_index} GREATER -1)
@@ -281,7 +281,7 @@ function(conan_cmake_settings result)
         string(REGEX MATCH "[^=]*" MANUAL_SETTING "${ARG}")
         message(STATUS "Conan: ${MANUAL_SETTING} was added as an argument. Not using the autodetected one.")
         list(REMOVE_ITEM ARGUMENTS_PROFILE_AUTO "${MANUAL_SETTING}")
-    endforeach()    
+    endforeach()
 
     # Automatic from CMake
     foreach(ARG ${ARGUMENTS_PROFILE_AUTO})
@@ -377,7 +377,7 @@ function(conan_cmake_detect_unix_libcxx result)
         else()
             # Either the compiler is missing the define because it is old, and so
             # it can't use the new abi, or the compiler was configured to use the
-            # old abi by the user or distro (e.g. devtoolset on RHEL/CentOS)
+            # old abi by the user or distro (e.g. devtoolset on RHEL/AlmaLinux)
             set(${result} libstdc++ PARENT_SCOPE)
         endif()
     else()
@@ -398,7 +398,7 @@ function(conan_cmake_detect_vs_runtime result)
 
     if(build_type)
         string(TOUPPER "${build_type}" build_type)
-    endif() 
+    endif()
     set(variables CMAKE_CXX_FLAGS_${build_type} CMAKE_C_FLAGS_${build_type} CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
     foreach(variable ${variables})
         if(NOT "${${variable}}" STREQUAL "")
@@ -612,12 +612,12 @@ function(conan_cmake_install)
         set(NO_IMPORTS --no-imports)
     endif()
     set(install_args install ${PATH_OR_REFERENCE} ${REFERENCE} ${UPDATE} ${NO_IMPORTS} ${REMOTE} ${LOCKFILE} ${LOCKFILE_OUT} ${LOCKFILE_NODE_ID} ${INSTALL_FOLDER}
-                                ${GENERATOR} ${BUILD} ${ENV} ${ENV_HOST} ${ENV_BUILD} ${OPTIONS} ${OPTIONS_HOST} ${OPTIONS_BUILD} 
+                                ${GENERATOR} ${BUILD} ${ENV} ${ENV_HOST} ${ENV_BUILD} ${OPTIONS} ${OPTIONS_HOST} ${OPTIONS_BUILD}
                                 ${PROFILE} ${PROFILE_HOST} ${PROFILE_BUILD} ${SETTINGS} ${SETTINGS_HOST} ${SETTINGS_BUILD})
 
     string(REPLACE ";" " " _install_args "${install_args}")
     message(STATUS "Conan executing: ${CONAN_CMD} ${_install_args}")
-    
+
     if(ARGS_OUTPUT_QUIET)
       set(OUTPUT_OPT OUTPUT_QUIET)
     endif()
@@ -734,7 +734,7 @@ endmacro()
 
 macro(conan_cmake_run)
     conan_parse_arguments(${ARGV})
-    
+
     if(ARGUMENTS_CONFIGURATION_TYPES AND NOT CMAKE_CONFIGURATION_TYPES)
         message(WARNING "CONFIGURATION_TYPES should only be specified for multi-configuration generators")
     elseif(ARGUMENTS_CONFIGURATION_TYPES AND ARGUMENTS_BUILD_TYPE)
@@ -812,7 +812,7 @@ macro(conan_check)
     if(NOT "${return_code}" STREQUAL "0")
       message(FATAL_ERROR "Conan --version failed='${return_code}'")
     endif()
-              
+
     if(NOT CONAN_DETECT_QUIET)
         string(STRIP "${CONAN_VERSION_OUTPUT}" _CONAN_VERSION_OUTPUT)
         message(STATUS "Conan: Version found ${_CONAN_VERSION_OUTPUT}")

--- a/docker/AlmaLinux8.Dockerfile
+++ b/docker/AlmaLinux8.Dockerfile
@@ -35,9 +35,18 @@ RUN dnf install -y -q \
 # Install the nvidia driver.
 RUN dnf module install -y -q nvidia-driver:535-dkms
 
-# Enables gcc 11 for use within the docker image.
-RUN echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/bashrc
-SHELL ["/bin/bash", "--login", "-c"]
+# /bin/gcc, /bin/gcov, /bin/ranlib and /bin/ar are old versions and not
+# symbolic links, which prevents alternatives from working properly, so
+# rename them
+RUN mv /bin/gcc /bin/gcc-8 && \
+    mv /bin/gcov /bin/gcov-8
+
+# Create links to some of the custom packages
+RUN alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-11/root/usr/bin/gcc 100 && \
+    alternatives --install /usr/bin/gcov gcov /opt/rh/gcc-toolset-11/root/usr/bin/gcov 100 && \
+    alternatives --install /usr/bin/g++ g++ /opt/rh/gcc-toolset-11/root/usr/bin/g++ 100 && \
+    alternatives --install /usr/bin/cc cc /opt/rh/gcc-toolset-11/root/usr/bin/gcc 100 && \
+    alternatives --install /usr/bin/c++ c++ /opt/rh/gcc-toolset-11/root/usr/bin/g++ 100
 
 # Install newer version of CMake
 RUN wget https://cmake.org/files/v3.24/cmake-3.24.2.tar.gz && \
@@ -58,4 +67,4 @@ RUN pip3 install conan==1.58.0 && \
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash", "--login", "-c"]
+ENTRYPOINT ["/bin/bash"]

--- a/docker/AlmaLinux8.Dockerfile
+++ b/docker/AlmaLinux8.Dockerfile
@@ -58,4 +58,4 @@ RUN pip3 install conan==1.58.0 && \
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "--login", "-c"]

--- a/docker/AlmaLinux8.Dockerfile
+++ b/docker/AlmaLinux8.Dockerfile
@@ -35,18 +35,9 @@ RUN dnf install -y -q \
 # Install the nvidia driver.
 RUN dnf module install -y -q nvidia-driver:535-dkms
 
-# /bin/gcc, /bin/gcov, /bin/ranlib and /bin/ar are old versions and not
-# symbolic links, which prevents alternatives from working properly, so
-# rename them
-RUN mv /bin/gcc /bin/gcc-8 && \
-    mv /bin/gcov /bin/gcov-8
-
-# Create links to some of the custom packages
-RUN alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-11/root/usr/bin/gcc 100 && \
-    alternatives --install /usr/bin/gcov gcov /opt/rh/gcc-toolset-11/root/usr/bin/gcov 100 && \
-    alternatives --install /usr/bin/g++ g++ /opt/rh/gcc-toolset-11/root/usr/bin/g++ 100 && \
-    alternatives --install /usr/bin/cc cc /opt/rh/gcc-toolset-11/root/usr/bin/gcc 100 && \
-    alternatives --install /usr/bin/c++ c++ /opt/rh/gcc-toolset-11/root/usr/bin/g++ 100
+# Enables gcc 11 for use within the docker image.
+RUN echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/bashrc
+SHELL ["/bin/bash", "--login", "-c"]
 
 # Install newer version of CMake
 RUN wget https://cmake.org/files/v3.24/cmake-3.24.2.tar.gz && \
@@ -67,4 +58,4 @@ RUN pip3 install conan==1.58.0 && \
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "--login", "-c"]

--- a/docker/AlmaLinux8.Dockerfile
+++ b/docker/AlmaLinux8.Dockerfile
@@ -1,0 +1,61 @@
+# This is used to generate the image with dependencies that CI.Dockerfile relies on.
+# For instructions for deploying this, check docs/release-guide/push-docker-image.md.
+FROM almalinux:8
+
+RUN dnf upgrade -y --refresh
+RUN dnf install -y 'dnf-command(config-manager)'
+
+RUN dnf config-manager --add-repo=https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+
+# Extra repositories that have newer versions of some packages
+RUN dnf install -y -q epel-release
+RUN dnf config-manager --set-enabled powertools
+
+RUN dnf install -y -q \
+    git \
+    git-lfs \
+    python39 \
+    wget \
+    gcc-toolset-11 \
+    gcc-toolset-11-libubsan-devel \
+    make \
+    doxygen \
+    curl-devel \
+    zlib-devel \
+    perl-Data-Dumper \
+    perl-Thread-Queue \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    libffi-devel \
+    zlib-devel \
+    sqlite-devel \
+    xz-devel
+
+# Install the nvidia driver.
+RUN dnf module install -y -q nvidia-driver:535-dkms
+
+# Enables gcc 11 for use within the docker image.
+RUN echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Install newer version of CMake
+RUN wget https://cmake.org/files/v3.24/cmake-3.24.2.tar.gz && \
+    tar xzf cmake-3.24.2.tar.gz && \
+    cd cmake-3.24.2 && \
+    ./bootstrap --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm cmake-3.24.2.tar.gz && \
+    rm -rf cmake-3.24.2 && \
+    ln -sf /usr/local/bin/cmake /usr/bin/cmake && \
+    ln -sf /usr/local/bin/ctest /usr/bin/ctest && \
+    ln -sf /usr/local/bin/cpack /usr/bin/cpack
+
+RUN pip3 install conan==1.58.0 && \
+    pip3 install gcovr
+
+WORKDIR /var/app
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -2,4 +2,4 @@ FROM cesiumgs/omniverse-almalinux8-build:2023-11-02
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "--login", "-c"]

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -2,6 +2,4 @@ FROM cesiumgs/omniverse-almalinux8-build:2023-11-02
 
 WORKDIR /var/app
 
-RUN git config --global --add safe.directory '*'
-
 ENTRYPOINT ["/bin/bash", "--login"]

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -2,4 +2,4 @@ FROM cesiumgs/omniverse-almalinux8-build:2023-11-02
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash", "--login", "-c"]
+ENTRYPOINT ["/bin/bash"]

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -1,4 +1,4 @@
-FROM cesiumgs/omniverse-centos7-build:2023-09-05
+FROM cesiumgs/omniverse-almalinux8-build:2023-11-02
 
 WORKDIR /var/app
 

--- a/docker/CI.Dockerfile
+++ b/docker/CI.Dockerfile
@@ -2,4 +2,6 @@ FROM cesiumgs/omniverse-almalinux8-build:2023-11-02
 
 WORKDIR /var/app
 
-ENTRYPOINT ["/bin/bash"]
+RUN git config --global --add safe.directory '*'
+
+ENTRYPOINT ["/bin/bash", "--login"]

--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -234,11 +234,11 @@ Install [Docker Engine CE For Ubuntu](https://docs.docker.com/engine/install/ubu
 Enter the container:
 
 ```sh
-docker build --tag cesiumgs/cesium-omniverse:centos7 -f docker/CentOS7.Dockerfile .
-docker run --rm --interactive --tty --volume $PWD:/var/app cesiumgs/cesium-omniverse:centos7
+docker build --tag cesiumgs/cesium-omniverse:almalinux8 -f docker/AlmaLinux8.Dockerfile .
+docker run --rm --interactive --tty --volume $PWD:/var/app cesiumgs/cesium-omniverse:almalinux8
 ```
 
-Once inside the container, build like usual. Note that linters are turned off because there is no pre-compiled C++17-capable LLVM toolset for CentOS 7. It won't affect the build, it just means there won't be code formatting or linting. It will build fine with GCC.
+Once inside the container, build like usual. Note that linters are turned off. It won't affect the build, it just means there won't be code formatting or linting. It will build fine with GCC.
 
 ```sh
 cmake -B build -D CESIUM_OMNI_ENABLE_LINTERS=OFF
@@ -447,14 +447,14 @@ cmake --build build --target clang-tidy
 
 ### Build Linux Package (Local)
 
-Linux packages are built in the CentOS 7 Docker container. CentOS 7 is the [minimum OS required by Omniverse](https://docs.omniverse.nvidia.com/app_view/common/technical-requirements.html#suggested-minimums-by-product) and uses glibc 2.18 which is compatible with nearly all modern Linux distributions.
+Linux packages are built in the AlmaLinux 8 Docker container. A Red Hat Enterprise Linux 8 compatible OS is the [minimum OS required by Omniverse](https://docs.omniverse.nvidia.com/app_view/common/technical-requirements.html#suggested-minimums-by-product) and uses glibc 2.18 which is compatible with nearly all modern Linux distributions.
 
-It's recommended to build CentOS 7 packages in a separate clone of cesium-omniverse since the Docker container will overwrite files in the `extern/nvidia/_build` and `exts` folders.
+It's recommended to build AlmaLinux 8 packages in a separate clone of cesium-omniverse since the Docker container will overwrite files in the `extern/nvidia/_build` and `exts` folders.
 
 Run the following shell script from the root cesium-omniverse directory:
 
 ```sh
-./scripts/build_package_centos7.sh
+./scripts/build_package_almalinux8.sh
 ```
 
 The resulting `.zip` file will be written to the `build-package` directory (e.g. `CesiumGS-cesium-omniverse-linux-x86_64-v0.0.0.zip`)

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -20,7 +20,7 @@ There is also a similar [C++ extension template](https://github.com/NVIDIA-Omniv
 Some self-explanatory directories have been ommitted.
 
 - `apps` - Tools that use the extensions, such as the performance testing app, but are not themselves extensions
-- `docker` - Docker configuration for CentOS CI builds
+- `docker` - Docker configuration for AlmaLinux 8 CI builds
 - `exts` - This is where extension code is kept. The file structure follows the pattern:
     ```
     exts

--- a/docs/release-guide/README.md
+++ b/docs/release-guide/README.md
@@ -4,7 +4,7 @@ This is the process we follow when releasing a new version of Cesium for Omniver
 
 1. [Release a new version of Cesium for Omniverse Samples](#releasing-a-new-version-of-cesium-for-omniverse-samples).
 2. Make sure the latest commit in `main` is passing CI.
-3. Download the latest build from S3. In the AWS management console (InternalServices AWS account), go to the bucket [`cesium-builds/cesium-omniverse/main`](https://s3.console.aws.amazon.com/s3/buckets/cesium-builds?region=us-east-1&prefix=cesium-omniverse/main/&showversions=false), find the appropriate date and commit hash to download the CentOS and Windows zip files (e.g. `CesiumGS-cesium-omniverse-linux-x86_64-xxxxxxx.zip` and `CesiumGS-cesium-omniverse-windows-x86_64-xxxxxxx.zip`)
+3. Download the latest build from S3. In the AWS management console (InternalServices AWS account), go to the bucket [`cesium-builds/cesium-omniverse/main`](https://s3.console.aws.amazon.com/s3/buckets/cesium-builds?region=us-east-1&prefix=cesium-omniverse/main/&showversions=false), find the appropriate date and commit hash to download the AlmaLinux and Windows zip files (e.g. `CesiumGS-cesium-omniverse-linux-x86_64-xxxxxxx.zip` and `CesiumGS-cesium-omniverse-windows-x86_64-xxxxxxx.zip`)
 4. Verify that the Linux package loads in USD Composer (see instructions below).
 5. Verify that the Windows package loads in USD Composer (see instructions below).
 6. Update the project `VERSION` in [CMakeLists.txt](../../CMakeLists.txt).
@@ -18,7 +18,7 @@ This is the process we follow when releasing a new version of Cesium for Omniver
 14. Tag the release, e.g. `git tag -a v0.0.0 -m "0.0.0 release"`.
 15. Push the tag, e.g. `git push origin v0.0.0`.
 16. Wait for CI to pass.
-17. Download the latest build from S3. In the AWS management console (InternalServices AWS account), go to the bucket [`cesium-builds/cesium-omniverse`](https://s3.console.aws.amazon.com/s3/buckets/cesium-builds?prefix=cesium-omniverse/&region=us-east-1), find the folder with the new tag and download the CentOS and Windows zip files (e.g. `CesiumGS-cesium-omniverse-linux-x86_64-v0.0.0.zip` and `CesiumGS-cesium-omniverse-windows-x86_64-v0.0.0.zip` )
+17. Download the latest build from S3. In the AWS management console (InternalServices AWS account), go to the bucket [`cesium-builds/cesium-omniverse`](https://s3.console.aws.amazon.com/s3/buckets/cesium-builds?prefix=cesium-omniverse/&region=us-east-1), find the folder with the new tag and download the AlmaLinux and Windows zip files (e.g. `CesiumGS-cesium-omniverse-linux-x86_64-v0.0.0.zip` and `CesiumGS-cesium-omniverse-windows-x86_64-v0.0.0.zip` )
 18. Create a new release on GitHub: https://github.com/CesiumGS/cesium-omniverse/releases/new.
     * Chose the new tag.
     * Copy the changelog into the description. Follow the format used in previous releases.

--- a/docs/release-guide/push-docker-image.md
+++ b/docs/release-guide/push-docker-image.md
@@ -1,6 +1,6 @@
-# Pushing the Docker Image for CentOS 7 builds.
+# Pushing the Docker Image for AlmaLinux 8 builds.
 
-We use a docker image for our CentOS 7 builds that contains all of our build dependencies, so we don't have to build the image from scratch on each build. This document outlines how to build and push this to Docker Hub.
+We use a docker image for our AlmaLinux 8 builds that contains all of our build dependencies, so we don't have to build the image from scratch on each build. This document outlines how to build and push this to Docker Hub.
 
 ## Installing Docker
 
@@ -14,7 +14,7 @@ sudo usermod -aG docker $USER
 
 ## Building the container
 
-Confirm that you have push access to the [container repo](https://hub.docker.com/r/cesiumgs/omniverse-centos7-build).
+Confirm that you have push access to the [container repo](https://hub.docker.com/r/cesiumgs/omniverse-almalinux8-build).
 
 ### Log in
 
@@ -29,7 +29,7 @@ docker login
 After making your changes to the docker file, execute:
 
 ```shell
-docker build --tag cesiumgs/omniverse-centos7-build:$TAGNAME -f docker/CentOS7.Dockerfile . --no-cache
+docker build --tag cesiumgs/omniverse-almalinux8-build:$TAGNAME -f docker/AlmaLinux8.Dockerfile . --no-cache
 ```
 
 You should replace `TAGNAME` with the current date in `YYYY-MM-DD` format. So if it's the 29th of August, 2023, you would use `2023-08-29`.
@@ -39,11 +39,11 @@ You should replace `TAGNAME` with the current date in `YYYY-MM-DD` format. So if
 The build will take some time. Once it is finished, execute the following to push the image to Docker Hub:
 
 ```shell
-docker push cesiumgs/omniverse-centos7-build:$TAGNAME
+docker push cesiumgs/omniverse-almalinux8-build:$TAGNAME
 ```
 
 Again, you should replace `$TAGNAME` with the current date in `YYYY-MM-DD` format. So if it's the 29th of August, 2023, you would use `2023-08-29`.
 
 ### Update CI.Dockerfile
 
-The `docker/CI.Dockerfile` file is used as part of the CentOS build step in our GitHub actions. You will need to update the version of the Docker image used to the tagged version you just uploaded.
+The `docker/CI.Dockerfile` file is used as part of the AlmaLinux 8 build step in our GitHub actions. You will need to update the version of the Docker image used to the tagged version you just uploaded.

--- a/scripts/build_package_almalinux8.sh
+++ b/scripts/build_package_almalinux8.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Make sure to run this script from the root cesium-omniverse directory
+
+# Delete existing build folder
+sudo rm -rf build-package
+
+# Start the docker container
+docker build --tag cesiumgs/cesium-omniverse:almalinux8 -f docker/AlmaLinux8.Dockerfile .
+container_id=$(docker run -it -d --volume $PWD:/var/app cesiumgs/cesium-omniverse:almalinux8)
+
+# Run package commands inside docker container
+package_cmd="
+cmake -B build-package -D CMAKE_BUILD_TYPE=Release CESIUM_OMNI_ENABLE_TESTS=OFF -D CESIUM_OMNI_ENABLE_DOCUMENTATION=OFF -D CESIUM_OMNI_ENABLE_SANITIZERS=OFF -D CESIUM_OMNI_ENABLE_LINTERS=OFF &&
+cmake --build build-package --parallel 8 &&
+cmake --build build-package --target install &&
+cmake --build build-package --target package
+"
+
+docker exec ${container_id} /bin/sh -c "${package_cmd}"
+
+# Clean up
+docker stop ${container_id}
+docker rm ${container_id}


### PR DESCRIPTION
Resolves #464.

Moves CI builds to using our new AlmaLinux 8 based images.

There's been a few changes to how our OS Dockerfile is configured. Most of these are related to moving from CentOS 7 to AlmaLinux 8, such as using `dnf`, and how to select the 535 branch of the Nvidia drivers. However one important one is this:

```
# Enables gcc 11 for use within the docker image.
RUN echo "source /opt/rh/gcc-toolset-11/enable" >> /etc/bashrc
SHELL ["/bin/bash", "--login", "-c"]
```

Within the RHEL ecosystem `update-alternatives` doesn't exist (it was added in RHEL 7 as a helpful alias to `alternatives`, which is similar but not the same as the Ubuntu alternatives system), and it's generally considered not great to use within RHEL. The right way to enable the `gcc-toolset` is to source `enable`. Docker makes this a bit more difficult but you can just set `SHELL` to be a login shell and it should all work okay.

Python 3.9 is already the default in AlmaLinux 8, so we don't need to install it anymore as well.