### PR TITLE
Add support for custom vertex attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### v0.14.0 - 2023-12-01
+
+* Added support for custom vertex attributes. Custom attributes can be accessed by their glTF attribute name with the primvar lookup functions in MDL, e.g. `data_lookup_int` and `data_lookup_float`.
+
 ### v0.13.0 - 2023-11-01
 
 * Changing certain tileset properties no longer triggers a tileset reload.

--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -213,7 +213,7 @@ float4 compute_base_color(
 
     auto base_color = base_color_texture.valid ? base_color_texture.value : float4(1.0);
     base_color *= float4(base_color_factor_float3.x, base_color_factor_float3.y, base_color_factor_float3.z, base_alpha);
-    base_color *= ::scene::data_lookup_float4("vertexColor", float4(1.0));
+    base_color *= ::scene::data_lookup_float4("COLOR_0", float4(1.0));
     base_color = alpha_blend(imagery_layers_texture.value, base_color);
     base_color *= tile_color;
 

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "cesium/omniverse/GltfUtil.h"
+
 #include <cstdint>
+#include <set>
 
 namespace CesiumGltf {
 struct MeshPrimitive;
@@ -19,6 +22,7 @@ class FabricGeometryDefinition {
     [[nodiscard]] bool hasNormals() const;
     [[nodiscard]] bool hasVertexColors() const;
     [[nodiscard]] uint64_t getTexcoordSetCount() const;
+    [[nodiscard]] const std::set<VertexAttributeInfo>& getCustomVertexAttributes() const;
 
     bool operator==(const FabricGeometryDefinition& other) const;
 
@@ -26,6 +30,9 @@ class FabricGeometryDefinition {
     bool _hasNormals{false};
     bool _hasVertexColors{false};
     uint64_t _texcoordSetCount{0};
+
+    // std::set is sorted which is important for checking FabricGeometryDefinition equality
+    std::set<VertexAttributeInfo> _customVertexAttributes;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cesium/omniverse/VertexAttributeType.h"
+
 #ifdef CESIUM_OMNI_MSVC
 #pragma push_macro("OPAQUE")
 #undef OPAQUE
@@ -89,7 +91,7 @@ class VertexColorsAccessor {
     VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& float32Vec3View);
     VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec4>& float32Vec4View);
 
-    void fill(const gsl::span<glm::fvec4>& values) const;
+    void fill(const gsl::span<glm::fvec4>& values, uint64_t repeat = 1) const;
     [[nodiscard]] uint64_t size() const;
 
   private:
@@ -112,6 +114,20 @@ class FaceVertexCountsAccessor {
     [[nodiscard]] uint64_t size() const;
 
   private:
+    uint64_t _size;
+};
+
+template <VertexAttributeType T> class VertexAttributeAccessor {
+  public:
+    VertexAttributeAccessor();
+    VertexAttributeAccessor(const CesiumGltf::AccessorView<GetNativeType<T>>& view);
+
+    void fill(const gsl::span<GetFabricType<T>>& values, uint64_t repeat = 1) const;
+
+    [[nodiscard]] uint64_t size() const;
+
+  private:
+    CesiumGltf::AccessorView<GetNativeType<T>> _view;
     uint64_t _size;
 };
 

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -91,7 +91,14 @@ class VertexColorsAccessor {
     VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& float32Vec3View);
     VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec4>& float32Vec4View);
 
+    /**
+     * @brief Copy accessor values to the given output values, including any data transformations.
+     *
+     * @param values The output values.
+     * @param repeat Indicates how many times each value in the accessor should be repeated in the output. Typically repeat is 1, but for voxel point clouds repeat is 8.
+     */
     void fill(const gsl::span<glm::fvec4>& values, uint64_t repeat = 1) const;
+
     [[nodiscard]] uint64_t size() const;
 
   private:

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -127,7 +127,7 @@ class FaceVertexCountsAccessor {
 template <VertexAttributeType T> class VertexAttributeAccessor {
   public:
     VertexAttributeAccessor();
-    VertexAttributeAccessor(const CesiumGltf::AccessorView<GetNativeType<T>>& view);
+    VertexAttributeAccessor(const CesiumGltf::AccessorView<GetNativeType<T>>& view, bool normalized);
 
     void fill(const gsl::span<GetFabricType<T>>& values, uint64_t repeat = 1) const;
 
@@ -136,6 +136,7 @@ template <VertexAttributeType T> class VertexAttributeAccessor {
   private:
     CesiumGltf::AccessorView<GetNativeType<T>> _view;
     uint64_t _size;
+    bool _normalized;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -58,6 +58,7 @@ struct VertexAttributeInfo {
     VertexAttributeType type;
     omni::fabric::Token fabricAttributeName;
     std::string gltfAttributeName;
+    bool normalized;
 
     // Make sure to update this function when adding new fields to the struct
     bool operator==(const VertexAttributeInfo& other) const;

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -58,7 +58,6 @@ struct VertexAttributeInfo {
     VertexAttributeType type;
     omni::fabric::Token fabricAttributeName;
     std::string gltfAttributeName;
-    bool normalized;
 
     // Make sure to update this function when adding new fields to the struct
     bool operator==(const VertexAttributeInfo& other) const;

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include "cesium/omniverse/GltfAccessors.h"
+#include "cesium/omniverse/VertexAttributeType.h"
 
+#include <CesiumGltf/Accessor.h>
 #include <glm/glm.hpp>
+#include <omni/fabric/core/FabricTypes.h>
+
+#include <set>
 
 namespace CesiumGltf {
 struct ImageCesium;
@@ -49,6 +54,16 @@ struct MaterialInfo {
     bool operator==(const MaterialInfo& other) const;
 };
 
+struct VertexAttributeInfo {
+    VertexAttributeType type;
+    omni::fabric::Token fabricAttributeName;
+    std::string gltfAttributeName;
+
+    // Make sure to update this function when adding new fields to the struct
+    bool operator==(const VertexAttributeInfo& other) const;
+    bool operator<(const VertexAttributeInfo& other) const;
+};
+
 } // namespace cesium::omniverse
 
 namespace cesium::omniverse::GltfUtil {
@@ -81,10 +96,19 @@ getImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimit
 VertexColorsAccessor
 getVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
 
+template <VertexAttributeType T>
+VertexAttributeAccessor<T> getVertexAttributeValues(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const std::string& attributeName);
+
 const CesiumGltf::ImageCesium*
 getBaseColorTextureImage(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
 MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+
+std::set<VertexAttributeInfo>
+getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
 MaterialInfo getDefaultMaterialInfo();
 TextureInfo getDefaultTextureInfo();

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -125,7 +125,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_st_7, "primvars:st_7")) \
     ((primvars_st_8, "primvars:st_8")) \
     ((primvars_st_9, "primvars:st_9")) \
-    ((primvars_vertexColor, "primvars:vertexColor")) \
+    ((primvars_COLOR_0, "primvars:COLOR_0")) \
     ((xformOp_transform_cesium, "xformOp:transform:cesium"))
 
 TF_DECLARE_PUBLIC_TOKENS(UsdTokens, USD_TOKENS);
@@ -250,7 +250,7 @@ const omni::fabric::Type primvarInterpolations(omni::fabric::BaseDataType::eToke
 const omni::fabric::Type primvars(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type primvars_normals(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eNormal);
 const omni::fabric::Type primvars_st(omni::fabric::BaseDataType::eFloat, 2, 1, omni::fabric::AttributeRole::eTexCoord);
-const omni::fabric::Type primvars_vertexColor(omni::fabric::BaseDataType::eFloat, 4, 1, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type primvars_COLOR_0(omni::fabric::BaseDataType::eFloat, 4, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type Shader(omni::fabric::BaseDataType::eTag, 1, 0, omni::fabric::AttributeRole::ePrimTypeName);
 const omni::fabric::Type subdivisionScheme(omni::fabric::BaseDataType::eToken, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _cesium_localToEcefTransform(omni::fabric::BaseDataType::eDouble, 16, 0, omni::fabric::AttributeRole::eMatrix);

--- a/src/core/include/cesium/omniverse/VertexAttributeType.h
+++ b/src/core/include/cesium/omniverse/VertexAttributeType.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <omni/fabric/FabricTypes.h>
+
+#include <optional>
+#include <string>
+
+namespace cesium::omniverse {
+
+enum class VertexAttributeType {
+    UINT8,
+    INT8,
+    UINT16,
+    INT16,
+    FLOAT32,
+    VEC2_UINT8,
+    VEC2_INT8,
+    VEC2_UINT16,
+    VEC2_INT16,
+    VEC2_FLOAT32,
+    VEC3_UINT8,
+    VEC3_INT8,
+    VEC3_UINT16,
+    VEC3_INT16,
+    VEC3_FLOAT32,
+    VEC4_UINT8,
+    VEC4_INT8,
+    VEC4_UINT16,
+    VEC4_INT16,
+    VEC4_FLOAT32,
+};
+
+std::optional<VertexAttributeType> getVertexAttributeTypeFromGltf(const std::string& type, int32_t componentType);
+omni::fabric::Type getFabricType(VertexAttributeType type);
+
+template <VertexAttributeType T> struct GetNativeTypeImpl;
+template <> struct GetNativeTypeImpl<VertexAttributeType::UINT8> { using Type = uint8_t; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::INT8> { using Type = int8_t; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::UINT16> { using Type = uint16_t; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::INT16> { using Type = int16_t; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::FLOAT32> { using Type = float; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_UINT8> { using Type = glm::u8vec2; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_INT8> { using Type = glm::i8vec2; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_UINT16> { using Type = glm::u16vec2; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_INT16> { using Type = glm::i16vec2; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_FLOAT32> { using Type = glm::f32vec2; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC3_UINT8> { using Type = glm::u8vec3; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC3_INT8> { using Type = glm::i8vec3; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC3_UINT16> { using Type = glm::u16vec3; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC3_INT16> { using Type = glm::i16vec3; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC3_FLOAT32> { using Type = glm::f32vec3; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_UINT8> { using Type = glm::u8vec4; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_INT8> { using Type = glm::i8vec4; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_UINT16> { using Type = glm::u16vec4; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_INT16> { using Type = glm::i16vec4; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_FLOAT32> { using Type = glm::f32vec4; };
+
+// Integer primvar lookup doesn't seem to work so cast all data types to float. This is safe to do since
+// FLOAT32 can represent all possible UINT8, INT8, UINT16, and INT16 values. Also not a significant memory
+// overhead since Fabric doesn't support INT8, UINT16, and INT16 types anyways.
+template <VertexAttributeType T> struct GetFabricTypeImpl;
+template <> struct GetFabricTypeImpl<VertexAttributeType::UINT8> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::INT8> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::UINT16> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::INT16> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::FLOAT32> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_UINT8> { using Type = glm::f32vec2; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_INT8> { using Type = glm::f32vec2; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_UINT16> { using Type = glm::f32vec2; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_INT16> { using Type = glm::f32vec2; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_FLOAT32> { using Type = glm::f32vec2; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC3_UINT8> { using Type = glm::f32vec3; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC3_INT8> { using Type = glm::f32vec3; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC3_UINT16> { using Type = glm::f32vec3; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC3_INT16> { using Type = glm::f32vec3; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC3_FLOAT32> { using Type = glm::f32vec3; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC4_UINT8> { using Type = glm::f32vec4; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC4_INT8> { using Type = glm::f32vec4; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC4_UINT16> { using Type = glm::f32vec4; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC4_INT16> { using Type = glm::f32vec4; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::VEC4_FLOAT32> { using Type = glm::f32vec4; };
+
+template <VertexAttributeType T> using GetNativeType = typename GetNativeTypeImpl<T>::Type;
+template <VertexAttributeType T> using GetFabricType = typename GetFabricTypeImpl<T>::Type;
+
+} // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/VertexAttributeType.h
+++ b/src/core/include/cesium/omniverse/VertexAttributeType.h
@@ -35,11 +35,11 @@ std::optional<VertexAttributeType> getVertexAttributeTypeFromGltf(const std::str
 omni::fabric::Type getFabricType(VertexAttributeType type);
 
 template <VertexAttributeType T> struct GetNativeTypeImpl;
-template <> struct GetNativeTypeImpl<VertexAttributeType::UINT8> { using Type = uint8_t; };
-template <> struct GetNativeTypeImpl<VertexAttributeType::INT8> { using Type = int8_t; };
-template <> struct GetNativeTypeImpl<VertexAttributeType::UINT16> { using Type = uint16_t; };
-template <> struct GetNativeTypeImpl<VertexAttributeType::INT16> { using Type = int16_t; };
-template <> struct GetNativeTypeImpl<VertexAttributeType::FLOAT32> { using Type = float; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::UINT8> { using Type = glm::u8vec1; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::INT8> { using Type = glm::i8vec1; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::UINT16> { using Type = glm::u16vec1; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::INT16> { using Type = glm::i16vec1; };
+template <> struct GetNativeTypeImpl<VertexAttributeType::FLOAT32> { using Type = glm::f32vec1; };
 template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_UINT8> { using Type = glm::u8vec2; };
 template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_INT8> { using Type = glm::i8vec2; };
 template <> struct GetNativeTypeImpl<VertexAttributeType::VEC2_UINT16> { using Type = glm::u16vec2; };
@@ -59,12 +59,14 @@ template <> struct GetNativeTypeImpl<VertexAttributeType::VEC4_FLOAT32> { using 
 // Integer primvar lookup doesn't seem to work so cast all data types to float. This is safe to do since
 // FLOAT32 can represent all possible UINT8, INT8, UINT16, and INT16 values. Also not a significant memory
 // overhead since Fabric doesn't support INT8, UINT16, and INT16 types anyways.
+//
+// Float is also a convenient data type for storing normalized attributes, which are normalized prior to Fabric upload
 template <VertexAttributeType T> struct GetFabricTypeImpl;
-template <> struct GetFabricTypeImpl<VertexAttributeType::UINT8> { using Type = float; };
-template <> struct GetFabricTypeImpl<VertexAttributeType::INT8> { using Type = float; };
-template <> struct GetFabricTypeImpl<VertexAttributeType::UINT16> { using Type = float; };
-template <> struct GetFabricTypeImpl<VertexAttributeType::INT16> { using Type = float; };
-template <> struct GetFabricTypeImpl<VertexAttributeType::FLOAT32> { using Type = float; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::UINT8> { using Type = glm::f32vec1; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::INT8> { using Type = glm::f32vec1; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::UINT16> { using Type = glm::f32vec1; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::INT16> { using Type = glm::f32vec1; };
+template <> struct GetFabricTypeImpl<VertexAttributeType::FLOAT32> { using Type = glm::f32vec1; };
 template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_UINT8> { using Type = glm::f32vec2; };
 template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_INT8> { using Type = glm::f32vec2; };
 template <> struct GetFabricTypeImpl<VertexAttributeType::VEC2_UINT16> { using Type = glm::f32vec2; };

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -47,6 +47,93 @@ uint64_t getTexcoordSetCount(const FabricGeometryDefinition& geometryDefinition)
     return texcoordSetCount;
 }
 
+template <VertexAttributeType T>
+void setVertexAttributeValues(
+    omni::fabric::StageReaderWriter& srw,
+    const omni::fabric::Path& path,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const VertexAttributeInfo& attribute,
+    uint64_t repeat) {
+
+    const auto accessor = GltfUtil::getVertexAttributeValues<T>(model, primitive, attribute.gltfAttributeName);
+    assert(accessor.size() > 0);
+    srw.setArrayAttributeSize(path, attribute.fabricAttributeName, accessor.size() * repeat);
+    auto fabricValues = srw.getArrayAttributeWr<GetFabricType<T>>(path, attribute.fabricAttributeName);
+    accessor.fill(fabricValues, repeat);
+}
+
+void setVertexAttributeValues(
+    omni::fabric::StageReaderWriter& srw,
+    const omni::fabric::Path& path,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const VertexAttributeInfo& attribute,
+    uint64_t repeat) {
+    switch (attribute.type) {
+        case VertexAttributeType::UINT8:
+            setVertexAttributeValues<VertexAttributeType::UINT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::INT8:
+            setVertexAttributeValues<VertexAttributeType::INT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::UINT16:
+            setVertexAttributeValues<VertexAttributeType::UINT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::INT16:
+            setVertexAttributeValues<VertexAttributeType::INT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::FLOAT32:
+            setVertexAttributeValues<VertexAttributeType::FLOAT32>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC2_UINT8:
+            setVertexAttributeValues<VertexAttributeType::VEC2_UINT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC2_INT8:
+            setVertexAttributeValues<VertexAttributeType::VEC2_INT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC2_UINT16:
+            setVertexAttributeValues<VertexAttributeType::VEC2_UINT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC2_INT16:
+            setVertexAttributeValues<VertexAttributeType::VEC2_INT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC2_FLOAT32:
+            setVertexAttributeValues<VertexAttributeType::VEC2_FLOAT32>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC3_UINT8:
+            setVertexAttributeValues<VertexAttributeType::VEC3_UINT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC3_INT8:
+            setVertexAttributeValues<VertexAttributeType::VEC3_INT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC3_UINT16:
+            setVertexAttributeValues<VertexAttributeType::VEC3_UINT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC3_INT16:
+            setVertexAttributeValues<VertexAttributeType::VEC3_INT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC3_FLOAT32:
+            setVertexAttributeValues<VertexAttributeType::VEC3_FLOAT32>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC4_UINT8:
+            setVertexAttributeValues<VertexAttributeType::VEC4_UINT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC4_INT8:
+            setVertexAttributeValues<VertexAttributeType::VEC4_INT8>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC4_UINT16:
+            setVertexAttributeValues<VertexAttributeType::VEC4_UINT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC4_INT16:
+            setVertexAttributeValues<VertexAttributeType::VEC4_INT16>(srw, path, model, primitive, attribute, repeat);
+            break;
+        case VertexAttributeType::VEC4_FLOAT32:
+            setVertexAttributeValues<VertexAttributeType::VEC4_FLOAT32>(srw, path, model, primitive, attribute, repeat);
+            break;
+    }
+}
+
 } // namespace
 
 FabricGeometry::FabricGeometry(
@@ -118,6 +205,8 @@ void FabricGeometry::initialize() {
     const auto hasNormals = _geometryDefinition.hasNormals();
     const auto hasVertexColors = _geometryDefinition.hasVertexColors();
     const auto texcoordSetCount = getTexcoordSetCount(_geometryDefinition);
+    const auto& customVertexAttributes = _geometryDefinition.getCustomVertexAttributes();
+    const auto customVertexAttributesCount = customVertexAttributes.size();
 
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
@@ -154,6 +243,10 @@ void FabricGeometry::initialize() {
         attributes.addAttribute(FabricTypes::primvars_vertexColor, FabricTokens::primvars_vertexColor);
     }
 
+    for (const auto& customVertexAttribute : customVertexAttributes) {
+        attributes.addAttribute(getFabricType(customVertexAttribute.type), customVertexAttribute.fabricAttributeName);
+    }
+
     attributes.createAttributes(_path);
 
     auto subdivisionSchemeFabric = srw.getAttributeWr<omni::fabric::TokenC>(_path, FabricTokens::subdivisionScheme);
@@ -169,6 +262,13 @@ void FabricGeometry::initialize() {
 
     for (uint64_t i = 0; i < texcoordSetCount; i++) {
         primvarIndexStArray.push_back(primvarsCount++);
+    }
+
+    std::vector<uint64_t> primvarIndexCustomVertexAttributesArray;
+    primvarIndexCustomVertexAttributesArray.reserve(customVertexAttributesCount);
+
+    for (uint64_t i = 0; i < customVertexAttributesCount; i++) {
+        primvarIndexCustomVertexAttributesArray.push_back(primvarsCount++);
     }
 
     if (hasNormals) {
@@ -192,6 +292,12 @@ void FabricGeometry::initialize() {
         primvarInterpolationsFabric[primvarIndexStArray[i]] = FabricTokens::vertex;
     }
 
+    for (uint64_t i = 0; i < customVertexAttributesCount; i++) {
+        const auto& customVertexAttribute = *std::next(customVertexAttributes.begin(), static_cast<int>(i));
+        primvarsFabric[primvarIndexCustomVertexAttributesArray[i]] = customVertexAttribute.fabricAttributeName;
+        primvarInterpolationsFabric[primvarIndexCustomVertexAttributesArray[i]] = FabricTokens::vertex;
+    }
+
     if (hasNormals) {
         primvarsFabric[primvarIndexNormal] = FabricTokens::primvars_normals;
         primvarInterpolationsFabric[primvarIndexNormal] = FabricTokens::vertex;
@@ -207,6 +313,7 @@ void FabricGeometry::reset() {
     const auto hasNormals = _geometryDefinition.hasNormals();
     const auto hasVertexColors = _geometryDefinition.hasVertexColors();
     const auto texcoordSetCount = getTexcoordSetCount(_geometryDefinition);
+    const auto& customVertexAttributes = _geometryDefinition.getCustomVertexAttributes();
 
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
@@ -241,6 +348,10 @@ void FabricGeometry::reset() {
         srw.setArrayAttributeSize(_path, FabricTokens::primvars_st_n[i], 0);
     }
 
+    for (const auto& customVertexAttribute : customVertexAttributes) {
+        srw.setArrayAttributeSize(_path, customVertexAttribute.fabricAttributeName, 0);
+    }
+
     if (hasNormals) {
         srw.setArrayAttributeSize(_path, FabricTokens::primvars_normals, 0);
     }
@@ -268,6 +379,7 @@ void FabricGeometry::setGeometry(
 
     const auto hasNormals = _geometryDefinition.hasNormals();
     const auto hasVertexColors = _geometryDefinition.hasVertexColors();
+    const auto& customVertexAttributes = _geometryDefinition.getCustomVertexAttributes();
 
     auto srw = UsdUtil::getFabricStageReaderWriter();
 
@@ -300,18 +412,19 @@ void FabricGeometry::setGeometry(
         auto faceVertexCountsFabric = srw.getArrayAttributeWr<int>(_path, FabricTokens::faceVertexCounts);
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_path, FabricTokens::faceVertexIndices);
 
-        std::vector<glm::fvec4> vertexColorsData(numVoxels);
-        gsl::span<glm::fvec4> vertexColorsSpan(vertexColorsData);
         if (hasVertexColors) {
-            vertexColors.fill(vertexColorsSpan);
             srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, numVoxels * 8);
+            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_vertexColor);
+            vertexColors.fill(vertexColorsFabric, 8);
         }
-        auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_vertexColor);
+
+        for (const auto& customVertexAttribute : customVertexAttributes) {
+            setVertexAttributeValues(srw, _path, model, primitive, customVertexAttribute, 8);
+        }
 
         size_t vertIndex = 0;
         size_t vertexCountsIndex = 0;
         size_t faceVertexIndex = 0;
-        size_t vertexColorsIndex = 0;
         for (size_t voxelIndex = 0; voxelIndex < numVoxels; voxelIndex++) {
             const auto& center = positions.get(voxelIndex);
 
@@ -371,13 +484,6 @@ void FabricGeometry::setGeometry(
             faceVertexIndicesFabric[faceVertexIndex++] = 7 + static_cast<int>(voxelIndex * 8);
             faceVertexIndicesFabric[faceVertexIndex++] = 5 + static_cast<int>(voxelIndex * 8);
             faceVertexIndicesFabric[faceVertexIndex++] = 4 + static_cast<int>(voxelIndex * 8);
-
-            if (hasVertexColors) {
-                const auto& color = vertexColorsSpan[voxelIndex];
-                for (int i = 0; i < 8; i++) {
-                    vertexColorsFabric[vertexColorsIndex++] = color;
-                }
-            }
         }
     } else {
         srw.setArrayAttributeSize(_path, FabricTokens::faceVertexCounts, faceVertexCounts.size());
@@ -429,6 +535,10 @@ void FabricGeometry::setGeometry(
             auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_vertexColor);
 
             vertexColors.fill(vertexColorsFabric);
+        }
+
+        for (const auto& customVertexAttribute : customVertexAttributes) {
+            setVertexAttributeValues(srw, _path, model, primitive, customVertexAttribute, 1);
         }
     }
 

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -240,7 +240,7 @@ void FabricGeometry::initialize() {
     }
 
     if (hasVertexColors) {
-        attributes.addAttribute(FabricTypes::primvars_vertexColor, FabricTokens::primvars_vertexColor);
+        attributes.addAttribute(FabricTypes::primvars_COLOR_0, FabricTokens::primvars_COLOR_0);
     }
 
     for (const auto& customVertexAttribute : customVertexAttributes) {
@@ -304,7 +304,7 @@ void FabricGeometry::initialize() {
     }
 
     if (hasVertexColors) {
-        primvarsFabric[primvarIndexVertexColor] = FabricTokens::primvars_vertexColor;
+        primvarsFabric[primvarIndexVertexColor] = FabricTokens::primvars_COLOR_0;
         primvarInterpolationsFabric[primvarIndexVertexColor] = FabricTokens::vertex;
     }
 }
@@ -357,7 +357,7 @@ void FabricGeometry::reset() {
     }
 
     if (hasVertexColors) {
-        srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, 0);
+        srw.setArrayAttributeSize(_path, FabricTokens::primvars_COLOR_0, 0);
     }
 }
 
@@ -413,8 +413,8 @@ void FabricGeometry::setGeometry(
         auto faceVertexIndicesFabric = srw.getArrayAttributeWr<int>(_path, FabricTokens::faceVertexIndices);
 
         if (hasVertexColors) {
-            srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, numVoxels * 8);
-            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_vertexColor);
+            srw.setArrayAttributeSize(_path, FabricTokens::primvars_COLOR_0, numVoxels * 8);
+            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_COLOR_0);
             vertexColors.fill(vertexColorsFabric, 8);
         }
 
@@ -530,9 +530,9 @@ void FabricGeometry::setGeometry(
         }
 
         if (hasVertexColors) {
-            srw.setArrayAttributeSize(_path, FabricTokens::primvars_vertexColor, vertexColors.size());
+            srw.setArrayAttributeSize(_path, FabricTokens::primvars_COLOR_0, vertexColors.size());
 
-            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_vertexColor);
+            auto vertexColorsFabric = srw.getArrayAttributeWr<glm::fvec4>(_path, FabricTokens::primvars_COLOR_0);
 
             vertexColors.fill(vertexColorsFabric);
         }

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -39,23 +39,8 @@ const std::set<VertexAttributeInfo>& FabricGeometryDefinition::getCustomVertexAt
 }
 
 bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other) const {
-    if (_hasNormals != other._hasNormals) {
-        return false;
-    }
-
-    if (_hasVertexColors != other._hasVertexColors) {
-        return false;
-    }
-
-    if (_texcoordSetCount != other._texcoordSetCount) {
-        return false;
-    }
-
-    if (_customVertexAttributes != other._customVertexAttributes) {
-        return false;
-    }
-
-    return true;
+    return _hasNormals == other._hasNormals && _hasVertexColors == other._hasVertexColors &&
+           _texcoordSetCount == other._texcoordSetCount && _customVertexAttributes == other._customVertexAttributes;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -14,12 +14,13 @@ namespace cesium::omniverse {
 FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    bool smoothNormals) {
-    _hasNormals = GltfUtil::hasNormals(model, primitive, smoothNormals);
-    _hasVertexColors = GltfUtil::hasVertexColors(model, primitive, 0);
-    _texcoordSetCount = GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
-                        GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size();
-}
+    bool smoothNormals)
+    : _hasNormals(GltfUtil::hasNormals(model, primitive, smoothNormals))
+    , _hasVertexColors(GltfUtil::hasVertexColors(model, primitive, 0))
+    , _texcoordSetCount(
+          GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
+          GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size())
+    , _customVertexAttributes(GltfUtil::getCustomVertexAttributes(model, primitive)) {}
 
 bool FabricGeometryDefinition::hasNormals() const {
     return _hasNormals;
@@ -29,8 +30,12 @@ bool FabricGeometryDefinition::hasVertexColors() const {
     return _hasVertexColors;
 }
 
-[[nodiscard]] uint64_t FabricGeometryDefinition::getTexcoordSetCount() const {
+uint64_t FabricGeometryDefinition::getTexcoordSetCount() const {
     return _texcoordSetCount;
+}
+
+const std::set<VertexAttributeInfo>& FabricGeometryDefinition::getCustomVertexAttributes() const {
+    return _customVertexAttributes;
 }
 
 bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other) const {
@@ -43,6 +48,10 @@ bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other)
     }
 
     if (_texcoordSetCount != other._texcoordSetCount) {
+        return false;
+    }
+
+    if (_customVertexAttributes != other._customVertexAttributes) {
         return false;
     }
 

--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -43,23 +43,8 @@ const pxr::SdfPath& FabricMaterialDefinition::getTilesetMaterialPath() const {
 
 // In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other) const {
-    if (_hasVertexColors != other._hasVertexColors) {
-        return false;
-    }
-
-    if (_hasBaseColorTexture != other._hasBaseColorTexture) {
-        return false;
-    }
-
-    if (_imageryLayerCount != other._imageryLayerCount) {
-        return false;
-    }
-
-    if (_tilesetMaterialPath != other._tilesetMaterialPath) {
-        return false;
-    }
-
-    return true;
+    return _hasVertexColors == other._hasVertexColors && _hasBaseColorTexture == other._hasBaseColorTexture &&
+           _imageryLayerCount == other._imageryLayerCount && _tilesetMaterialPath == other._tilesetMaterialPath;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -6,7 +6,7 @@ PositionsAccessor::PositionsAccessor()
 
 PositionsAccessor::PositionsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view)
     : _view(view)
-    , _size(view.size()) {}
+    , _size(static_cast<uint64_t>(view.size())) {}
 
 void PositionsAccessor::fill(const gsl::span<glm::fvec3>& values) const {
     for (uint64_t i = 0; i < _size; i++) {
@@ -30,15 +30,15 @@ IndicesAccessor::IndicesAccessor(uint64_t size)
 
 IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint8_t>& uint8View)
     : _uint8View(uint8View)
-    , _size(uint8View.size()) {}
+    , _size(static_cast<uint64_t>(uint8View.size())) {}
 
 IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint16_t>& uint16View)
     : _uint16View(uint16View)
-    , _size(uint16View.size()) {}
+    , _size(static_cast<uint64_t>(uint16View.size())) {}
 
 IndicesAccessor::IndicesAccessor(const CesiumGltf::AccessorView<uint32_t>& uint32View)
     : _uint32View(uint32View)
-    , _size(uint32View.size()) {}
+    , _size(static_cast<uint64_t>(uint32View.size())) {}
 
 template <typename T> IndicesAccessor IndicesAccessor::FromTriangleStrips(const CesiumGltf::AccessorView<T>& view) {
     auto indices = std::vector<uint32_t>();
@@ -89,24 +89,27 @@ template IndicesAccessor IndicesAccessor::FromTriangleFans<uint16_t>(const Cesiu
 template IndicesAccessor IndicesAccessor::FromTriangleFans<uint32_t>(const CesiumGltf::AccessorView<uint32_t>& view);
 
 void IndicesAccessor::fill(const gsl::span<int>& values) const {
+    const auto size = values.size();
+    assert(size == _size);
+
     if (!_computed.empty()) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = static_cast<int>(_computed[i]);
         }
     } else if (_uint8View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = static_cast<int>(_uint8View[static_cast<int64_t>(i)]);
         }
     } else if (_uint16View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = static_cast<int>(_uint16View[static_cast<int64_t>(i)]);
         }
     } else if (_uint32View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = static_cast<int>(_uint32View[static_cast<int64_t>(i)]);
         }
     } else {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = static_cast<int>(i);
         }
     }
@@ -135,7 +138,7 @@ NormalsAccessor::NormalsAccessor()
 
 NormalsAccessor::NormalsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& view)
     : _view(view)
-    , _size(view.size()) {}
+    , _size(static_cast<uint64_t>(view.size())) {}
 
 NormalsAccessor NormalsAccessor::GenerateSmooth(const PositionsAccessor& positions, const IndicesAccessor& indices) {
     auto normals = std::vector<glm::fvec3>(positions.size(), glm::fvec3(0.0f));
@@ -166,12 +169,15 @@ NormalsAccessor NormalsAccessor::GenerateSmooth(const PositionsAccessor& positio
 }
 
 void NormalsAccessor::fill(const gsl::span<glm::fvec3>& values) const {
+    const auto size = values.size();
+    assert(size == _size);
+
     if (!_computed.empty()) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = _computed[i];
         }
     } else {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = _view[static_cast<int64_t>(i)];
         }
     }
@@ -187,15 +193,18 @@ TexcoordsAccessor::TexcoordsAccessor()
 TexcoordsAccessor::TexcoordsAccessor(const CesiumGltf::AccessorView<glm::fvec2>& view, bool flipVertical)
     : _view(view)
     , _flipVertical(flipVertical)
-    , _size(view.size()) {}
+    , _size(static_cast<uint64_t>(view.size())) {}
 
 void TexcoordsAccessor::fill(const gsl::span<glm::fvec2>& values) const {
-    for (uint64_t i = 0; i < _size; i++) {
+    const auto size = values.size();
+    assert(size == _size);
+
+    for (uint64_t i = 0; i < size; i++) {
         values[i] = _view[static_cast<int64_t>(i)];
     }
 
     if (_flipVertical) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i][1] = 1.0f - values[i][1];
         }
     }
@@ -210,72 +219,75 @@ VertexColorsAccessor::VertexColorsAccessor()
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::u8vec3>& uint8Vec3View)
     : _uint8Vec3View(uint8Vec3View)
-    , _size(uint8Vec3View.size()) {}
+    , _size(static_cast<uint64_t>(uint8Vec3View.size())) {}
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::u8vec4>& uint8Vec4View)
     : _uint8Vec4View(uint8Vec4View)
-    , _size(uint8Vec4View.size()) {}
+    , _size(static_cast<uint64_t>(uint8Vec4View.size())) {}
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::u16vec3>& uint16Vec3View)
     : _uint16Vec3View(uint16Vec3View)
-    , _size(uint16Vec3View.size()) {}
+    , _size(static_cast<uint64_t>(uint16Vec3View.size())) {}
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::u16vec4>& uint16Vec4View)
     : _uint16Vec4View(uint16Vec4View)
-    , _size(uint16Vec4View.size()) {}
+    , _size(static_cast<uint64_t>(uint16Vec4View.size())) {}
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec3>& float32Vec3View)
     : _float32Vec3View(float32Vec3View)
-    , _size(float32Vec3View.size()) {}
+    , _size(static_cast<uint64_t>(float32Vec3View.size())) {}
 
 VertexColorsAccessor::VertexColorsAccessor(const CesiumGltf::AccessorView<glm::fvec4>& float32Vec4View)
     : _float32Vec4View(float32Vec4View)
-    , _size(float32Vec4View.size()) {}
+    , _size(static_cast<uint64_t>(float32Vec4View.size())) {}
 
-void VertexColorsAccessor::fill(const gsl::span<glm::fvec4>& values) const {
-    constexpr auto MAX_UINT8 = std::numeric_limits<uint8_t>::max();
-    constexpr auto MAX_UINT16 = std::numeric_limits<uint16_t>::max();
+void VertexColorsAccessor::fill(const gsl::span<glm::fvec4>& values, uint64_t repeat) const {
+    constexpr auto MAX_UINT8 = static_cast<float>(std::numeric_limits<uint8_t>::max());
+    constexpr auto MAX_UINT16 = static_cast<float>(std::numeric_limits<uint16_t>::max());
+
+    const auto size = values.size();
+    assert(size == _size * repeat);
 
     if (_uint8Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = glm::fvec4(
-                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT8),
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i / repeat)].x) / MAX_UINT8,
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i / repeat)].y) / MAX_UINT8,
+                static_cast<float>(_uint8Vec3View[static_cast<int64_t>(i / repeat)].z) / MAX_UINT8,
                 1.0);
         }
     } else if (_uint8Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = glm::fvec4(
-                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT8),
-                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i)].w) / static_cast<float>(MAX_UINT8));
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i / repeat)].x) / MAX_UINT8,
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i / repeat)].y) / MAX_UINT8,
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i / repeat)].z) / MAX_UINT8,
+                static_cast<float>(_uint8Vec4View[static_cast<int64_t>(i / repeat)].w) / MAX_UINT8);
         }
     } else if (_uint16Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = glm::fvec4(
-                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT16),
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i / repeat)].x) / MAX_UINT16,
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i / repeat)].y) / MAX_UINT16,
+                static_cast<float>(_uint16Vec3View[static_cast<int64_t>(i / repeat)].z) / MAX_UINT16,
                 1.0);
         }
     } else if (_uint16Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
+        for (uint64_t i = 0; i < size; i++) {
             values[i] = glm::fvec4(
-                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].x) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].y) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].z) / static_cast<float>(MAX_UINT16),
-                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i)].w) / static_cast<float>(MAX_UINT16));
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i / repeat)].x) / MAX_UINT16,
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i / repeat)].y) / MAX_UINT16,
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i / repeat)].z) / MAX_UINT16,
+                static_cast<float>(_uint16Vec4View[static_cast<int64_t>(i / repeat)].w) / MAX_UINT16);
         }
     } else if (_float32Vec3View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
-            values[i] = glm::fvec4(_float32Vec3View[static_cast<int64_t>(i)], 1.0f);
+        for (uint64_t i = 0; i < size; i++) {
+            values[i] = glm::fvec4(_float32Vec3View[static_cast<int64_t>(i / repeat)], 1.0f);
         }
 
     } else if (_float32Vec4View.status() == CesiumGltf::AccessorViewStatus::Valid) {
-        for (uint64_t i = 0; i < _size; i++) {
-            values[i] = _float32Vec4View[static_cast<int64_t>(i)];
+        for (uint64_t i = 0; i < size; i++) {
+            values[i] = _float32Vec4View[static_cast<int64_t>(i / repeat)];
         }
     }
 }
@@ -291,7 +303,10 @@ FaceVertexCountsAccessor::FaceVertexCountsAccessor(uint64_t size)
     : _size(size) {}
 
 void FaceVertexCountsAccessor::fill(const gsl::span<int>& values) const {
-    for (uint64_t i = 0; i < _size; i++) {
+    const auto size = values.size();
+    assert(size == _size);
+
+    for (uint64_t i = 0; i < size; i++) {
         values[i] = 3;
     }
 }
@@ -299,5 +314,51 @@ void FaceVertexCountsAccessor::fill(const gsl::span<int>& values) const {
 uint64_t FaceVertexCountsAccessor::size() const {
     return _size;
 }
+
+template <VertexAttributeType T>
+VertexAttributeAccessor<T>::VertexAttributeAccessor()
+    : _size(0) {}
+
+template <VertexAttributeType T>
+VertexAttributeAccessor<T>::VertexAttributeAccessor(const CesiumGltf::AccessorView<GetNativeType<T>>& view)
+    : _view(view)
+    , _size(static_cast<uint64_t>(view.size())) {}
+
+template <VertexAttributeType T>
+void VertexAttributeAccessor<T>::fill(const gsl::span<GetFabricType<T>>& values, uint64_t repeat) const {
+    const auto size = values.size();
+    assert(size == _size * repeat);
+
+    for (uint64_t i = 0; i < size; i++) {
+        // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+        values[i] = static_cast<GetFabricType<T>>(_view[static_cast<int64_t>(i / repeat)]);
+    }
+}
+
+template <VertexAttributeType T> uint64_t VertexAttributeAccessor<T>::size() const {
+    return _size;
+}
+
+// Explicit template instantiation
+template class VertexAttributeAccessor<VertexAttributeType::UINT8>;
+template class VertexAttributeAccessor<VertexAttributeType::INT8>;
+template class VertexAttributeAccessor<VertexAttributeType::UINT16>;
+template class VertexAttributeAccessor<VertexAttributeType::INT16>;
+template class VertexAttributeAccessor<VertexAttributeType::FLOAT32>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC2_UINT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC2_INT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC2_UINT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC2_INT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC2_FLOAT32>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC3_UINT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC3_INT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC3_UINT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC3_INT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC3_FLOAT32>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC4_UINT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC4_INT8>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC4_UINT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC4_INT16>;
+template class VertexAttributeAccessor<VertexAttributeType::VEC4_FLOAT32>;
 
 } // namespace cesium::omniverse

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -493,7 +493,7 @@ VertexAttributeAccessor<T> getVertexAttributeValues(
         return {};
     }
 
-    return VertexAttributeAccessor<T>(view);
+    return VertexAttributeAccessor<T>(view, accessor->normalized);
 }
 
 // Explicit template instantiation
@@ -627,6 +627,7 @@ getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::Mesh
             type.value(),
             fabricAttributeName,
             attributeName,
+            accessor->normalized,
         });
     }
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -580,7 +580,7 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
 
 std::set<VertexAttributeInfo>
 getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive) {
-    constexpr std::array<const char*, 9> knownSemantics = {{
+    constexpr std::array<const char*, 8> knownSemantics = {{
         "POSITION",
         "NORMAL",
         "TANGENT",
@@ -589,7 +589,6 @@ getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::Mesh
         "JOINTS",
         "WEIGHTS",
         "_CESIUMOVERLAY",
-        "_FEATURE_ID",
     }};
 
     std::set<VertexAttributeInfo> customVertexAttributes;

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -627,7 +627,6 @@ getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::Mesh
             type.value(),
             fabricAttributeName,
             attributeName,
-            accessor->normalized,
         });
     }
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -722,97 +722,23 @@ namespace cesium::omniverse {
 
 // In C++ 20 we can use the default equality comparison (= default)
 bool TextureInfo::operator==(const TextureInfo& other) const {
-    if (offset != other.offset) {
-        return false;
-    }
-
-    if (rotation != other.rotation) {
-        return false;
-    }
-
-    if (scale != other.scale) {
-        return false;
-    }
-
-    if (setIndex != other.setIndex) {
-        return false;
-    }
-
-    if (wrapS != other.wrapS) {
-        return false;
-    }
-
-    if (wrapT != other.wrapT) {
-        return false;
-    }
-
-    if (flipVertical != other.flipVertical) {
-        return false;
-    }
-    return true;
+    return offset == other.offset && rotation == other.rotation && scale == other.scale && setIndex == other.setIndex &&
+           wrapS == other.wrapS && wrapT == other.wrapT && flipVertical == other.flipVertical;
 }
 
 // In C++ 20 we can use the default equality comparison (= default)
 bool MaterialInfo::operator==(const MaterialInfo& other) const {
-    if (alphaCutoff != other.alphaCutoff) {
-        return false;
-    }
-
-    if (alphaMode != other.alphaMode) {
-        return false;
-    }
-
-    if (baseAlpha != other.baseAlpha) {
-        return false;
-    }
-
-    if (baseColorFactor != other.baseColorFactor) {
-        return false;
-    }
-
-    if (emissiveFactor != other.emissiveFactor) {
-        return false;
-    }
-
-    if (metallicFactor != other.metallicFactor) {
-        return false;
-    }
-
-    if (roughnessFactor != other.roughnessFactor) {
-        return false;
-    }
-
-    if (doubleSided != other.doubleSided) {
-        return false;
-    }
-
-    if (hasVertexColors != other.hasVertexColors) {
-        return false;
-    }
-
-    // != operator doesn't compile for some reason
-    if (!(baseColorTexture == other.baseColorTexture)) {
-        return false;
-    }
-
-    return true;
+    return alphaCutoff == other.alphaCutoff && alphaMode == other.alphaMode && baseAlpha == other.baseAlpha &&
+           baseColorFactor == other.baseColorFactor && emissiveFactor == other.emissiveFactor &&
+           metallicFactor == other.metallicFactor && roughnessFactor == other.roughnessFactor &&
+           doubleSided == other.doubleSided && hasVertexColors == other.hasVertexColors &&
+           baseColorTexture == other.baseColorTexture;
 }
 
 // In C++ 20 we can use the default equality comparison (= default)
 bool VertexAttributeInfo::operator==(const VertexAttributeInfo& other) const {
-    if (type != other.type) {
-        return false;
-    }
-
-    if (fabricAttributeName != other.fabricAttributeName) {
-        return false;
-    }
-
-    if (gltfAttributeName != other.gltfAttributeName) {
-        return false;
-    }
-
-    return true;
+    return type == other.type && fabricAttributeName == other.fabricAttributeName &&
+           gltfAttributeName == other.gltfAttributeName;
 }
 
 // This is needed for std::set to be sorted

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -1,6 +1,7 @@
 #include "cesium/omniverse/GltfUtil.h"
 
 #include "cesium/omniverse/LoggerSink.h"
+#include "cesium/omniverse/VertexAttributeType.h"
 
 #ifdef CESIUM_OMNI_MSVC
 #pragma push_macro("OPAQUE")
@@ -471,6 +472,54 @@ getVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive&
     return {};
 }
 
+template <VertexAttributeType T>
+VertexAttributeAccessor<T> getVertexAttributeValues(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const std::string& attributeName) {
+    const auto attribute = primitive.attributes.find(attributeName);
+    if (attribute == primitive.attributes.end()) {
+        return {};
+    }
+
+    auto accessor = model.getSafe<CesiumGltf::Accessor>(&model.accessors, attribute->second);
+    if (!accessor) {
+        return {};
+    }
+
+    auto view = CesiumGltf::AccessorView<GetNativeType<T>>(model, *accessor);
+
+    if (view.status() != CesiumGltf::AccessorViewStatus::Valid) {
+        return {};
+    }
+
+    return VertexAttributeAccessor<T>(view);
+}
+
+// Explicit template instantiation
+// clang-format off
+template VertexAttributeAccessor<VertexAttributeType::UINT8> getVertexAttributeValues<VertexAttributeType::UINT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::INT8> getVertexAttributeValues<VertexAttributeType::INT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::UINT16> getVertexAttributeValues<VertexAttributeType::UINT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::INT16> getVertexAttributeValues<VertexAttributeType::INT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::FLOAT32> getVertexAttributeValues<VertexAttributeType::FLOAT32>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC2_UINT8> getVertexAttributeValues<VertexAttributeType::VEC2_UINT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC2_INT8> getVertexAttributeValues<VertexAttributeType::VEC2_INT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC2_UINT16> getVertexAttributeValues<VertexAttributeType::VEC2_UINT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC2_INT16> getVertexAttributeValues<VertexAttributeType::VEC2_INT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC2_FLOAT32> getVertexAttributeValues<VertexAttributeType::VEC2_FLOAT32>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC3_UINT8> getVertexAttributeValues<VertexAttributeType::VEC3_UINT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC3_INT8> getVertexAttributeValues<VertexAttributeType::VEC3_INT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC3_UINT16> getVertexAttributeValues<VertexAttributeType::VEC3_UINT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC3_INT16> getVertexAttributeValues<VertexAttributeType::VEC3_INT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC3_FLOAT32> getVertexAttributeValues<VertexAttributeType::VEC3_FLOAT32>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC4_UINT8> getVertexAttributeValues<VertexAttributeType::VEC4_UINT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC4_INT8> getVertexAttributeValues<VertexAttributeType::VEC4_INT8>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC4_UINT16> getVertexAttributeValues<VertexAttributeType::VEC4_UINT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC4_INT16> getVertexAttributeValues<VertexAttributeType::VEC4_INT16>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+template VertexAttributeAccessor<VertexAttributeType::VEC4_FLOAT32> getVertexAttributeValues<VertexAttributeType::VEC4_FLOAT32>(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, const std::string& attributeName);
+// clang-format on
+
 const CesiumGltf::ImageCesium*
 getBaseColorTextureImage(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive) {
     if (!hasMaterial(primitive)) {
@@ -527,6 +576,61 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
     materialInfo.hasVertexColors = hasVertexColors(model, primitive, 0);
 
     return materialInfo;
+}
+
+std::set<VertexAttributeInfo>
+getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive) {
+    constexpr std::array<const char*, 9> knownSemantics = {{
+        "POSITION",
+        "NORMAL",
+        "TANGENT",
+        "TEXCOORD",
+        "COLOR",
+        "JOINTS",
+        "WEIGHTS",
+        "_CESIUMOVERLAY",
+        "_FEATURE_ID",
+    }};
+
+    std::set<VertexAttributeInfo> customVertexAttributes;
+
+    for (const auto& attribute : primitive.attributes) {
+        const auto& attributeName = attribute.first;
+        const auto [semantic, setIndex] = parseAttributeName(attributeName);
+        if (std::find(knownSemantics.begin(), knownSemantics.end(), semantic) != knownSemantics.end()) {
+            continue;
+        }
+
+        auto accessor = model.getSafe<CesiumGltf::Accessor>(&model.accessors, static_cast<int32_t>(attribute.second));
+        if (!accessor) {
+            continue;
+        }
+
+        const auto valid = createAccessorView(model, *accessor, [](const auto& accessorView) {
+            return accessorView.status() == CesiumGltf::AccessorViewStatus::Valid;
+        });
+
+        if (!valid) {
+            continue;
+        }
+
+        const auto type = getVertexAttributeTypeFromGltf(accessor->type, accessor->componentType);
+
+        if (!type.has_value()) {
+            continue;
+        }
+
+        const auto fabricAttributeNameStr = fmt::format("primvars:{}", attributeName);
+        const auto fabricAttributeName = omni::fabric::Token(fabricAttributeNameStr.c_str());
+
+        customVertexAttributes.insert(VertexAttributeInfo{
+            type.value(),
+            fabricAttributeName,
+            attributeName,
+        });
+    }
+
+    return customVertexAttributes;
 }
 
 MaterialInfo getDefaultMaterialInfo() {
@@ -692,6 +796,28 @@ bool MaterialInfo::operator==(const MaterialInfo& other) const {
     }
 
     return true;
+}
+
+// In C++ 20 we can use the default equality comparison (= default)
+bool VertexAttributeInfo::operator==(const VertexAttributeInfo& other) const {
+    if (type != other.type) {
+        return false;
+    }
+
+    if (fabricAttributeName != other.fabricAttributeName) {
+        return false;
+    }
+
+    if (gltfAttributeName != other.gltfAttributeName) {
+        return false;
+    }
+
+    return true;
+}
+
+// This is needed for std::set to be sorted
+bool VertexAttributeInfo::operator<(const VertexAttributeInfo& other) const {
+    return fabricAttributeName < other.fabricAttributeName;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/VertexAttributeType.cpp
+++ b/src/core/src/VertexAttributeType.cpp
@@ -1,0 +1,113 @@
+#include "cesium/omniverse/VertexAttributeType.h"
+
+#include <CesiumGltf/Accessor.h>
+
+namespace cesium::omniverse {
+
+namespace {
+
+uint64_t getComponentCount(VertexAttributeType type) {
+    switch (type) {
+        case VertexAttributeType::UINT8:
+        case VertexAttributeType::INT8:
+        case VertexAttributeType::UINT16:
+        case VertexAttributeType::INT16:
+        case VertexAttributeType::FLOAT32:
+            return 1;
+        case VertexAttributeType::VEC2_UINT8:
+        case VertexAttributeType::VEC2_INT8:
+        case VertexAttributeType::VEC2_UINT16:
+        case VertexAttributeType::VEC2_INT16:
+        case VertexAttributeType::VEC2_FLOAT32:
+            return 2;
+        case VertexAttributeType::VEC3_UINT8:
+        case VertexAttributeType::VEC3_INT8:
+        case VertexAttributeType::VEC3_UINT16:
+        case VertexAttributeType::VEC3_INT16:
+        case VertexAttributeType::VEC3_FLOAT32:
+            return 3;
+        case VertexAttributeType::VEC4_UINT8:
+        case VertexAttributeType::VEC4_INT8:
+        case VertexAttributeType::VEC4_UINT16:
+        case VertexAttributeType::VEC4_INT16:
+        case VertexAttributeType::VEC4_FLOAT32:
+            return 4;
+        default:
+            assert(false);
+            return 0;
+    }
+}
+
+omni::fabric::BaseDataType getFabricBaseDataType() {
+    // Integer primvar lookup doesn't seem to work so cast all data types to float. This is safe to do since
+    // FLOAT32 can represent all possible UINT8, INT8, UINT16, and INT16 values. Also not a significant memory
+    // overhead since Fabric doesn't support INT8, UINT16, and INT16 types anyways.
+    return omni::fabric::BaseDataType::eFloat;
+}
+
+} // namespace
+
+std::optional<VertexAttributeType> getVertexAttributeTypeFromGltf(const std::string& type, int32_t componentType) {
+    if (type == CesiumGltf::Accessor::Type::SCALAR) {
+        if (componentType == CesiumGltf::Accessor::ComponentType::BYTE) {
+            return VertexAttributeType::INT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE) {
+            return VertexAttributeType::UINT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::SHORT) {
+            return VertexAttributeType::INT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
+            return VertexAttributeType::UINT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::FLOAT) {
+            return VertexAttributeType::FLOAT32;
+        }
+    } else if (type == CesiumGltf::Accessor::Type::VEC2) {
+        if (componentType == CesiumGltf::Accessor::ComponentType::BYTE) {
+            return VertexAttributeType::VEC2_INT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE) {
+            return VertexAttributeType::VEC2_UINT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::SHORT) {
+            return VertexAttributeType::VEC2_INT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
+            return VertexAttributeType::VEC2_UINT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::FLOAT) {
+            return VertexAttributeType::VEC2_FLOAT32;
+        }
+    } else if (type == CesiumGltf::Accessor::Type::VEC3) {
+        if (componentType == CesiumGltf::Accessor::ComponentType::BYTE) {
+            return VertexAttributeType::VEC3_INT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE) {
+            return VertexAttributeType::VEC3_UINT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::SHORT) {
+            return VertexAttributeType::VEC3_INT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
+            return VertexAttributeType::VEC3_UINT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::FLOAT) {
+            return VertexAttributeType::VEC3_FLOAT32;
+        }
+    } else if (type == CesiumGltf::Accessor::Type::VEC4) {
+        if (componentType == CesiumGltf::Accessor::ComponentType::BYTE) {
+            return VertexAttributeType::VEC4_INT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE) {
+            return VertexAttributeType::VEC4_UINT8;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::SHORT) {
+            return VertexAttributeType::VEC4_INT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
+            return VertexAttributeType::VEC4_UINT16;
+        } else if (componentType == CesiumGltf::Accessor::ComponentType::FLOAT) {
+            return VertexAttributeType::VEC4_FLOAT32;
+        }
+    }
+
+    // Cases where nullopt is returned
+    // - componentType is UNSIGNED_INT. UNSIGNED_INT is not an allowed glTF vertex attribute componentType.
+    // - type is MAT2, MAT3, MAT4. Matrix types are not supported primvar types.
+    return std::nullopt;
+}
+
+omni::fabric::Type getFabricType(VertexAttributeType type) {
+    const auto baseDataType = getFabricBaseDataType();
+    const auto componentCount = getComponentCount(type);
+    return {baseDataType, static_cast<uint8_t>(componentCount), 1, omni::fabric::AttributeRole::eNone};
+}
+
+} // namespace cesium::omniverse

--- a/src/core/src/VertexAttributeType.cpp
+++ b/src/core/src/VertexAttributeType.cpp
@@ -40,9 +40,7 @@ uint64_t getComponentCount(VertexAttributeType type) {
 }
 
 omni::fabric::BaseDataType getFabricBaseDataType() {
-    // Integer primvar lookup doesn't seem to work so cast all data types to float. This is safe to do since
-    // FLOAT32 can represent all possible UINT8, INT8, UINT16, and INT16 values. Also not a significant memory
-    // overhead since Fabric doesn't support INT8, UINT16, and INT16 types anyways.
+    // See comment in header
     return omni::fabric::BaseDataType::eFloat;
 }
 

--- a/src/core/src/VertexAttributeType.cpp
+++ b/src/core/src/VertexAttributeType.cpp
@@ -32,10 +32,11 @@ uint64_t getComponentCount(VertexAttributeType type) {
         case VertexAttributeType::VEC4_INT16:
         case VertexAttributeType::VEC4_FLOAT32:
             return 4;
-        default:
-            assert(false);
-            return 0;
     }
+
+    // Unreachable code. All enum cases are handled above.
+    assert(false);
+    return 0;
 }
 
 omni::fabric::BaseDataType getFabricBaseDataType() {


### PR DESCRIPTION
Added support for custom vertex attributes. Custom attributes can be accessed by their glTF attribute name with the primvar lookup functions in MDL, e.g. `data_lookup_int` and `data_lookup_float`.

In this example, the MDL is styling the point cloud based on the `_CLASSIFICATION` and `_INTENSITY` attributes from the glTF. The data is from [here](https://github.com/CesiumGS/3d-tiles-samples/tree/main/glTF/EXT_structural_metadata/PropertyAttributesPointCloud). The blockiness is due to the default voxel size being too large for this dataset.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/9fa6b22d-3551-406b-9d32-975c6e6ec046)

[property-attributes.zip](https://github.com/CesiumGS/cesium-omniverse/files/13253251/property-attributes.zip)

Unfortunately this approach doesn't work for most pnts datasets because cesium-native transcodes pnts to `EXT_mesh_features` / property tables instead of property attributes, so per-point properties aren't accessible as vertex attributes. But I plan on adding support for property tables in a future PR.

While there's a lot of code changes the approach is pretty simple: add custom attributes to `FabricGeometryDefinition` and then add the values to `FabricGeometry`. This involved a little bit of template magic.

For consistency, vertex colors are now accessed with the name `COLOR_0` instead of `vertexColor`.