### PR TITLE
Clean up FabricMaterial

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -203,7 +203,7 @@ float4 alpha_blend(float4 src, float4 dst) {
 }
 
 float4 compute_base_color(
-    gltf_texture_lookup_value imagery_layers_texture,
+    gltf_texture_lookup_value imagery_layer,
     float4 tile_color,
     gltf_texture_lookup_value base_color_texture,
     color base_color_factor,
@@ -214,7 +214,7 @@ float4 compute_base_color(
     auto base_color = base_color_texture.valid ? base_color_texture.value : float4(1.0);
     base_color *= float4(base_color_factor_float3.x, base_color_factor_float3.y, base_color_factor_float3.z, base_alpha);
     base_color *= ::scene::data_lookup_float4("COLOR_0", float4(1.0));
-    base_color = alpha_blend(imagery_layers_texture.value, base_color);
+    base_color = alpha_blend(imagery_layer.value, base_color);
     base_color *= tile_color;
 
     return base_color;
@@ -251,7 +251,7 @@ export gltf_texture_lookup_value cesium_internal_imagery_layer_lookup(
 }
 
 export material cesium_internal_material(
-    gltf_texture_lookup_value imagery_layers_texture = gltf_texture_lookup_value(true, float4(0.0)),
+    gltf_texture_lookup_value imagery_layer = gltf_texture_lookup_value(true, float4(0.0)),
     uniform float4 tile_color = float4(1.0),
     // gltf_material inputs below
     gltf_texture_lookup_value base_color_texture = gltf_texture_lookup_value(),
@@ -263,7 +263,7 @@ export material cesium_internal_material(
     uniform float base_alpha = 1.0,
     uniform float alpha_cutoff  = 0.5
 ) [[ anno::hidden() ]] = let {
-    auto base_color = compute_base_color(imagery_layers_texture, tile_color, base_color_texture, base_color_factor, base_alpha);
+    auto base_color = compute_base_color(imagery_layer, tile_color, base_color_texture, base_color_factor, base_alpha);
     material base = gltf_material(
         base_color_texture: gltf_texture_lookup_value(true, base_color),
         metallic_factor: metallic_factor,

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -14,6 +14,8 @@ class DynamicTextureProvider;
 
 namespace cesium::omniverse {
 
+class FabricTexture;
+
 class FabricMaterial {
   public:
     FabricMaterial(
@@ -28,80 +30,66 @@ class FabricMaterial {
     void setMaterial(
         int64_t tilesetId,
         const MaterialInfo& materialInfo,
+        const std::shared_ptr<FabricTexture>& baseColorTexture,
         const glm::dvec3& displayColor,
-        double displayOpacity);
-    void setBaseColorTexture(
-        const pxr::TfToken& textureAssetPathToken,
-        const TextureInfo& textureInfo,
-        uint64_t texcoordIndex);
+        double displayOpacity,
+        const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping);
+
     void setImageryLayer(
-        const pxr::TfToken& textureAssetPathToken,
+        const std::shared_ptr<FabricTexture>& texture,
         const TextureInfo& textureInfo,
-        uint64_t texcoordIndex,
         uint64_t imageryLayerIndex,
-        double alpha);
+        double alpha,
+        const std::unordered_map<uint64_t, uint64_t>& imageryTexcoordIndexMapping);
+
     void setImageryLayerAlpha(uint64_t imageryLayerIndex, double alpha);
     void setDisplayColorAndOpacity(const glm::dvec3& displayColor, double displayOpacity);
     void updateShaderInput(const omni::fabric::Path& shaderPath, const omni::fabric::Token& attributeName);
-
-    void clearMaterial();
-    void clearBaseColorTexture();
     void clearImageryLayer(uint64_t imageryLayerIndex);
-    void clearImageryLayers();
-
     void setActive(bool active);
 
     [[nodiscard]] const omni::fabric::Path& getPath() const;
     [[nodiscard]] const FabricMaterialDefinition& getMaterialDefinition() const;
 
   private:
-    void initialize();
-    void initializeFromExistingMaterial(const omni::fabric::Path& path);
+    void initializeNodes();
+    void initializeDefaultMaterial();
+    void initializeExistingMaterial(const omni::fabric::Path& path);
 
-    void createMaterial(const omni::fabric::Path& materialPath);
-    void createShader(const omni::fabric::Path& shaderPath, const omni::fabric::Path& materialPath);
+    void createMaterial(const omni::fabric::Path& path);
+    void createShader(const omni::fabric::Path& path);
     void createTextureCommon(
-        const omni::fabric::Path& texturePath,
-        const omni::fabric::Path& shaderPath,
-        const omni::fabric::Token& shaderInput,
+        const omni::fabric::Path& path,
         const omni::fabric::Token& subIdentifier,
         const std::vector<std::pair<omni::fabric::Type, omni::fabric::Token>>& additionalAttributes = {});
-    void createTexture(
-        const omni::fabric::Path& texturePath,
-        const omni::fabric::Path& shaderPath,
-        const omni::fabric::Token& shaderInput);
-    void createImageryLayer(
-        const omni::fabric::Path& imageryLayerPath,
-        const omni::fabric::Path& shaderPath,
-        const omni::fabric::Token& shaderInput);
-    void createImageryLayerResolver(
-        const omni::fabric::Path& imageryLayerResolverPath,
-        const omni::fabric::Path& shaderPath,
-        const omni::fabric::Token& shaderInput,
-        uint64_t textureCount);
+    void createTexture(const omni::fabric::Path& path);
+    void createImageryLayer(const omni::fabric::Path& path);
+    void createImageryLayerResolver(const omni::fabric::Path& path, uint64_t textureCount);
+
     void reset();
+
     void setShaderValues(
-        const omni::fabric::Path& shaderPath,
+        const omni::fabric::Path& path,
         const MaterialInfo& materialInfo,
         const glm::dvec3& displayColor,
         double displayOpacity);
     void setTextureValuesCommon(
-        const omni::fabric::Path& texturePath,
+        const omni::fabric::Path& path,
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex);
     void setTextureValues(
-        const omni::fabric::Path& texturePath,
+        const omni::fabric::Path& path,
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex);
     void setImageryLayerValues(
-        const omni::fabric::Path& imageryLayerPath,
+        const omni::fabric::Path& path,
         const pxr::TfToken& textureAssetPathToken,
         const TextureInfo& textureInfo,
         uint64_t texcoordIndex,
         double alpha);
-    void setImageryLayerAlphaValue(const omni::fabric::Path& imageryLayerPath, double alpha);
+    void setImageryLayerAlphaValue(const omni::fabric::Path& path, double alpha);
 
     bool stageDestroyed();
 
@@ -112,12 +100,15 @@ class FabricMaterial {
     const bool _debugRandomColors;
     const long _stageId;
 
-    AlphaMode _alphaMode;
-    glm::dvec3 _debugColor;
+    bool _usesDefaultMaterial;
 
-    std::vector<omni::fabric::Path> _shaderPaths;
-    std::vector<omni::fabric::Path> _baseColorTexturePaths;
-    std::vector<std::vector<omni::fabric::Path>> _imageryLayerPaths;
+    AlphaMode _alphaMode{AlphaMode::OPAQUE};
+    glm::dvec3 _debugColor{1.0, 1.0, 1.0};
+
+    omni::fabric::Path _shaderPath;
+    omni::fabric::Path _baseColorTexturePath;
+    std::vector<omni::fabric::Path> _imageryLayerPaths;
+    omni::fabric::Path _imageryLayerResolverPath;
 
     std::vector<omni::fabric::Path> _allPaths;
 };

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -3,6 +3,11 @@
 #include "cesium/omniverse/FabricMaterialDefinition.h"
 #include "cesium/omniverse/GltfUtil.h"
 
+#ifdef CESIUM_OMNI_MSVC
+#pragma push_macro("OPAQUE")
+#undef OPAQUE
+#endif
+
 #include <omni/fabric/IPath.h>
 #include <omni/fabric/Type.h>
 #include <pxr/usd/sdf/assetPath.h>

--- a/src/core/include/cesium/omniverse/FabricTexture.h
+++ b/src/core/include/cesium/omniverse/FabricTexture.h
@@ -15,6 +15,7 @@ struct ImageCesium;
 } // namespace CesiumGltf
 
 namespace cesium::omniverse {
+
 class FabricTexture {
   public:
     FabricTexture(const std::string& name);

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -103,8 +103,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_imagery_layer_15, "inputs:imagery_layer_15")) \
     ((inputs_imagery_layers_count, "inputs:imagery_layers_count")) \
     ((inputs_imagery_layer_index, "inputs:imagery_layer_index")) \
-    ((inputs_imagery_layers_texture, "inputs:imagery_layers_texture")) \
-    ((inputs_vertex_color_name, "inputs:vertex_color_name")) \
     ((inputs_wrap_s, "inputs:wrap_s")) \
     ((inputs_wrap_t, "inputs:wrap_t")) \
     ((material_binding, "material:binding")) \
@@ -238,7 +236,6 @@ const omni::fabric::Type inputs_scale(omni::fabric::BaseDataType::eFloat, 2, 0, 
 const omni::fabric::Type inputs_tex_coord_index(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_texture(omni::fabric::BaseDataType::eAsset, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_imagery_layers_count(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
-const omni::fabric::Type inputs_vertex_color_name(omni::fabric::BaseDataType::eUChar, 1, 1, omni::fabric::AttributeRole::eText);
 const omni::fabric::Type inputs_wrap_s(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_wrap_t(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type Material(omni::fabric::BaseDataType::eTag, 1, 0, omni::fabric::AttributeRole::ePrimTypeName);

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -287,7 +287,7 @@ int32_t getDefaultWrapT() {
 TextureInfo getTextureInfo(const CesiumGltf::Model& model, const CesiumGltf::TextureInfo& textureInfoGltf) {
     TextureInfo textureInfo = getDefaultTextureInfo();
 
-    textureInfo.setIndex = textureInfoGltf.texCoord;
+    textureInfo.setIndex = static_cast<uint64_t>(textureInfoGltf.texCoord);
 
     if (textureInfoGltf.hasExtension<CesiumGltf::ExtensionKhrTextureTransform>()) {
         const auto& textureTransform = *textureInfoGltf.getExtension<CesiumGltf::ExtensionKhrTextureTransform>();
@@ -301,7 +301,7 @@ TextureInfo getTextureInfo(const CesiumGltf::Model& model, const CesiumGltf::Tex
         const auto& texture = model.textures[static_cast<size_t>(index)];
         const auto samplerIndex = texture.sampler;
         if (samplerIndex != -1) {
-            const auto& sampler = model.samplers[samplerIndex];
+            const auto& sampler = model.samplers[static_cast<uint64_t>(samplerIndex)];
             textureInfo.wrapS = getWrapS(sampler);
             textureInfo.wrapT = getWrapT(sampler);
         }
@@ -320,8 +320,8 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
     int searchPosition = static_cast<int>(attributeName.size()) - 1;
     int lastUnderscorePosition{-1};
     while (searchPosition > 0) {
-        if (!isdigit(attributeName[searchPosition])) {
-            if (attributeName[searchPosition] == '_') {
+        if (!isdigit(attributeName[static_cast<size_t>(searchPosition)])) {
+            if (attributeName[static_cast<size_t>(searchPosition)] == '_') {
                 lastUnderscorePosition = searchPosition;
             }
 
@@ -335,7 +335,7 @@ std::pair<std::string, uint64_t> parseAttributeName(const std::string& attribute
     if (lastUnderscorePosition == -1) {
         semantic = attributeName;
     } else {
-        semantic = attributeName.substr(0, lastUnderscorePosition);
+        semantic = attributeName.substr(0, static_cast<size_t>(lastUnderscorePosition));
         std::from_chars(
             attributeName.data() + lastUnderscorePosition + 1,
             attributeName.data() + attributeName.size(),


### PR DESCRIPTION
I did some cleanup in `FabricMaterial` while adding support for feature ids.

* The base color texture is now set in `setMaterial` rather than a separate function. This keeps the material setting code more cohesive. Imagery layers are still set separately because their loading happens in a different phase of the pipeline.
* Reverted some of the changes in https://github.com/CesiumGS/cesium-omniverse/pull/406. E.g. if the user has multiple `cesium_base_color_texture_float4` nodes, we no longer create multiple base color texture prims to feed into each one. Instead we create a single prim and add multiple connections. This is cleaner and should be more performant. This applies to imagery layers too.
* General cleanup that made it easier to implement feature ids, and might make it easier to  fix https://github.com/CesiumGS/cesium-omniverse/issues/504

I tested this PR with a variety of scenes from previous PRs: [test-data-sets.zip](https://github.com/CesiumGS/cesium-omniverse/files/13302959/test-data-sets.zip)
