### PR TITLE
Add support for EXT_mesh_features

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -4,6 +4,7 @@ import ::anno::*;
 import ::state::*;
 import ::tex::*;
 import ::scene::*;
+import ::math::*;
 
 using ::gltf::pbr import *;
 
@@ -13,6 +14,8 @@ module [[
 ]];
 
 annotation annotation_not_connectable();
+
+export const auto DEFAULT_NULL_FEATURE_ID = -1;
 
 export enum up_axis_mode {
     Y,
@@ -124,6 +127,27 @@ export float4 cesium_imagery_layer_float4(
     return imagery_layer.valid ? imagery_layer.value : float4(0.0);
 }
 
+export int cesium_feature_id_int(
+    int feature_id = DEFAULT_NULL_FEATURE_ID
+    [[
+        anno::hidden(),
+        annotation_not_connectable()
+    ]],
+    uniform int feature_id_set_index = 0
+    [[
+        anno::unused()
+    ]]
+)
+[[
+    anno::display_name("Cesium feature ID lookup int"),
+    anno::description("Returns the feature ID for the given feature ID set. Returns -1 if the feature ID set does not exist or the feature ID is equal to nullFeatureId in the EXT_mesh_features extension."),
+    anno::author("Cesium GS Inc."),
+    anno::in_group("Cesium")
+]]
+{
+    return feature_id;
+}
+
 export material cesium_material(
     color base_color_factor = color(1.0)
     [[
@@ -218,6 +242,173 @@ float4 compute_base_color(
     base_color *= tile_color;
 
     return base_color;
+}
+
+// Copied from gltf/pbr.mdl since it's not exported
+float2 khr_texture_transform_apply(
+    float2 coord,
+    float2 offset,
+    float rotation,
+    float2 scale
+)
+{
+    // MDL expects the texture coordinate origin at the bottom left (gltf at top left)
+    // Assuming the renderer follows the MDL specification in which case the coordinates
+    // have been flipped either while loading the glTF geometry or while setting up the state.
+
+    // Undo the flipping for the transformation to get into the original glTF texture space.
+    coord = float2(coord.x, 1.0f - coord.y);
+
+    // first scale
+    coord = coord * scale;
+    // then rotate
+    float cos_rotation = ::math::cos(rotation);
+    float sin_rotation = ::math::sin(rotation);
+    coord = float2(cos_rotation * coord.x + sin_rotation * coord.y, cos_rotation * coord.y - sin_rotation * coord.x);
+    // then translate
+    coord = coord + offset;
+
+    // flip back
+    coord = float2(coord.x, 1.0f - coord.y);
+    return coord;
+}
+
+struct texel_fetch_value
+{
+    bool valid = false;
+    int4 value = int4(0, 0, 0, 0);
+};
+
+int mod(int a, int n) {
+    return (a % n + n) % n;
+}
+
+int mirror(int a) {
+    return a >= 0 ? a : -(1 + a);
+}
+
+int apply_mirrored_repeat(int x, int size) {
+    return (size - 1) - mirror(mod(x, 2 * size) - size);
+}
+
+int apply_clamp_to_edge(int x, int size) {
+    return math::clamp(x, 0, size - 1);
+}
+
+int apply_repeat(int x, int size) {
+    return mod(x, size);
+}
+
+// Modified version of gltf_texture_lookup that uses texel_float4 instead of lookup_float4 to avoid
+// linearly interpolating the texture values which would be incorrect for feature ID tetures. There
+// doesn't seem to be an easier way to do nearest sampling. Unfortunately texel_float4 doesn't do
+// texcoord wrapping so we need to do it ourselves.
+texel_fetch_value texel_fetch(
+    uniform texture_2d texture = texture_2d(),
+    uniform int tex_coord_index = 0,
+    uniform float2 offset = float2(0.0f, 0.0),
+    uniform float rotation = 0.0,
+    uniform float2 scale = float2(1.0f, 1.0f),
+    uniform gltf_wrapping_mode wrap_s = repeat,
+    uniform gltf_wrapping_mode wrap_t = repeat
+)
+{
+    texel_fetch_value tex_ret;
+    if (!tex::texture_isvalid(texture)) {
+        return tex_ret;
+    }
+
+    auto tex_coord3 = state::texture_coordinate(tex_coord_index);
+    auto tex_coord = khr_texture_transform_apply(
+        coord: float2(tex_coord3.x, tex_coord3.y),
+        offset: offset,
+        rotation: rotation,
+        scale: scale);
+
+    auto width = tex::width(texture);
+    auto height = tex::height(texture);
+
+    auto pixel_x = int(tex_coord.x * width);
+    auto pixel_y = int(tex_coord.y * height);
+
+    switch (wrap_s) {
+        case clamp_to_edge:
+            pixel_x = apply_clamp_to_edge(pixel_x, width);
+            break;
+        case mirrored_repeat:
+            pixel_x = apply_mirrored_repeat(pixel_x, width);
+            break;
+        case repeat:
+            pixel_x = apply_repeat(pixel_x, width);
+            break;
+    }
+
+    switch (wrap_t) {
+        case clamp_to_edge:
+            pixel_y = apply_clamp_to_edge(pixel_y, height);
+            break;
+        case mirrored_repeat:
+            pixel_y = apply_mirrored_repeat(pixel_y, height);
+            break;
+        case repeat:
+            pixel_y = apply_repeat(pixel_y, height);
+            break;
+    }
+
+    auto value = tex::texel_float4(
+        tex: texture,
+        coord: int2(pixel_x, pixel_y));
+
+    tex_ret.value = int4(math::round(value * 255.0));
+    tex_ret.valid = true;
+    return tex_ret;
+}
+
+export int cesium_internal_feature_id_texture_lookup(
+    uniform int4 channels = int4(0),
+    uniform int channel_count = 1,
+    uniform int null_feature_id = DEFAULT_NULL_FEATURE_ID,
+    // gltf_texture_lookup inputs below
+    uniform texture_2d texture = texture_2d(),
+    uniform int tex_coord_index = 0,
+    uniform float2 offset = float2(0.0, 0.0),
+    uniform float rotation = 0.0,
+    uniform float2 scale = float2(1.0, 1.0),
+    uniform gltf_wrapping_mode wrap_s = repeat,
+    uniform gltf_wrapping_mode wrap_t = repeat
+) [[ anno::hidden() ]] {
+    auto texel_value = texel_fetch(
+        texture: texture,
+        tex_coord_index: tex_coord_index,
+        offset: offset,
+        rotation: rotation,
+        scale: scale,
+        wrap_s: wrap_s,
+        wrap_t: wrap_t
+    );
+
+    if (!texel_value.valid) {
+        return DEFAULT_NULL_FEATURE_ID;
+    }
+
+    // Feature IDs can be in multiple channels of the texture to form a single uint32
+    auto feature_id = 0;
+    for (int i = 0; i < channel_count; i++) {
+        feature_id |= (texel_value.value[channels[i]] << (i * 8));
+    }
+
+    return feature_id == null_feature_id ? DEFAULT_NULL_FEATURE_ID : feature_id;
+}
+
+export int cesium_internal_feature_id_attribute_lookup(
+    uniform string feature_id_primvar_name,
+    uniform int null_feature_id = DEFAULT_NULL_FEATURE_ID
+) [[ anno::hidden() ]] {
+    // Even if all feature ids in a triangle are the same value, the primvar interpolation math can yield non integer
+    // results (e.g. 0.99999999 or 1.00000001), which when accessed as ints (i.e. floored) can cause variance across
+    // the triangle surface. The fix is to read the primvar as a float, round the value, and cast to int.
+    auto feature_id = int(::math::round(::scene::data_lookup_float(feature_id_primvar_name)));
+    return feature_id == null_feature_id ? DEFAULT_NULL_FEATURE_ID : feature_id;
 }
 
 export gltf_texture_lookup_value cesium_internal_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();

--- a/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricGeometryDefinition.h
@@ -17,10 +17,12 @@ class FabricGeometryDefinition {
     FabricGeometryDefinition(
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
+        const FeaturesInfo& featuresInfo,
         bool smoothNormals);
 
     [[nodiscard]] bool hasNormals() const;
     [[nodiscard]] bool hasVertexColors() const;
+    [[nodiscard]] bool hasVertexIds() const;
     [[nodiscard]] uint64_t getTexcoordSetCount() const;
     [[nodiscard]] const std::set<VertexAttributeInfo>& getCustomVertexAttributes() const;
 
@@ -29,9 +31,11 @@ class FabricGeometryDefinition {
   private:
     bool _hasNormals{false};
     bool _hasVertexColors{false};
+    bool _hasVertexIds{false};
     uint64_t _texcoordSetCount{0};
 
     // std::set is sorted which is important for checking FabricGeometryDefinition equality
+    // Note that features ids are treated as custom vertex attributes since they don't have specific parsing behavior
     std::set<VertexAttributeInfo> _customVertexAttributes;
 };
 

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -30,10 +30,15 @@ class FabricMaterial {
     void setMaterial(
         int64_t tilesetId,
         const MaterialInfo& materialInfo,
+        const FeaturesInfo& featuresInfo,
         const std::shared_ptr<FabricTexture>& baseColorTexture,
+        const std::vector<std::shared_ptr<FabricTexture>>& featureIdTextures,
         const glm::dvec3& displayColor,
         double displayOpacity,
-        const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping);
+        const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping,
+        const std::vector<uint64_t>& featureIdIndexIndexMapping,
+        const std::vector<uint64_t>& featureIdAttributeIndexMapping,
+        const std::vector<uint64_t>& featureIdTextureIndexMapping);
 
     void setImageryLayer(
         const std::shared_ptr<FabricTexture>& texture,
@@ -65,6 +70,9 @@ class FabricMaterial {
     void createTexture(const omni::fabric::Path& path);
     void createImageryLayer(const omni::fabric::Path& path);
     void createImageryLayerResolver(const omni::fabric::Path& path, uint64_t textureCount);
+    void createFeatureIdIndex(const omni::fabric::Path& path);
+    void createFeatureIdAttribute(const omni::fabric::Path& path);
+    void createFeatureIdTexture(const omni::fabric::Path& path);
 
     void reset();
 
@@ -90,6 +98,15 @@ class FabricMaterial {
         uint64_t texcoordIndex,
         double alpha);
     void setImageryLayerAlphaValue(const omni::fabric::Path& path, double alpha);
+    void setFeatureIdIndexValues(const omni::fabric::Path& path, int nullFeatureId);
+    void
+    setFeatureIdAttributeValues(const omni::fabric::Path& path, const std::string& attributeName, int nullFeatureId);
+    void setFeatureIdTextureValues(
+        const omni::fabric::Path& path,
+        const pxr::TfToken& textureAssetPathToken,
+        const TextureInfo& textureInfo,
+        uint64_t texcoordIndex,
+        int nullFeatureId);
 
     bool stageDestroyed();
 
@@ -109,6 +126,10 @@ class FabricMaterial {
     omni::fabric::Path _baseColorTexturePath;
     std::vector<omni::fabric::Path> _imageryLayerPaths;
     omni::fabric::Path _imageryLayerResolverPath;
+    std::vector<omni::fabric::Path> _featureIdPaths;
+    std::vector<omni::fabric::Path> _featureIdIndexPaths;
+    std::vector<omni::fabric::Path> _featureIdAttributePaths;
+    std::vector<omni::fabric::Path> _featureIdTexturePaths;
 
     std::vector<omni::fabric::Path> _allPaths;
 };

--- a/src/core/include/cesium/omniverse/FabricMaterial.h
+++ b/src/core/include/cesium/omniverse/FabricMaterial.h
@@ -41,9 +41,9 @@ class FabricMaterial {
         const glm::dvec3& displayColor,
         double displayOpacity,
         const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping,
-        const std::vector<uint64_t>& featureIdIndexIndexMapping,
-        const std::vector<uint64_t>& featureIdAttributeIndexMapping,
-        const std::vector<uint64_t>& featureIdTextureIndexMapping);
+        const std::vector<uint64_t>& featureIdIndexSetIndexMapping,
+        const std::vector<uint64_t>& featureIdAttributeSetIndexMapping,
+        const std::vector<uint64_t>& featureIdTextureSetIndexMapping);
 
     void setImageryLayer(
         const std::shared_ptr<FabricTexture>& texture,

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -21,9 +21,6 @@ class FabricMaterialDefinition {
     [[nodiscard]] bool hasVertexColors() const;
     [[nodiscard]] bool hasBaseColorTexture() const;
     [[nodiscard]] const std::vector<FeatureIdType>& getFeatureIdTypes() const;
-    [[nodiscard]] uint64_t getFeatureIdIndexCount() const;
-    [[nodiscard]] uint64_t getFeatureIdAttributeCount() const;
-    [[nodiscard]] uint64_t getFeatureIdTextureCount() const;
     [[nodiscard]] uint64_t getImageryLayerCount() const;
     [[nodiscard]] bool hasTilesetMaterial() const;
     [[nodiscard]] const pxr::SdfPath& getTilesetMaterialPath() const;

--- a/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDefinition.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cesium/omniverse/GltfUtil.h"
+
 #include <glm/glm.hpp>
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec3f.h>
@@ -7,18 +9,21 @@
 
 namespace cesium::omniverse {
 
-struct MaterialInfo;
-
 class FabricMaterialDefinition {
   public:
     FabricMaterialDefinition(
         const MaterialInfo& materialInfo,
+        const FeaturesInfo& featuresInfo,
         uint64_t imageryLayerCount,
         bool disableTextures,
         const pxr::SdfPath& tilesetMaterialPath);
 
     [[nodiscard]] bool hasVertexColors() const;
     [[nodiscard]] bool hasBaseColorTexture() const;
+    [[nodiscard]] const std::vector<FeatureIdType>& getFeatureIdTypes() const;
+    [[nodiscard]] uint64_t getFeatureIdIndexCount() const;
+    [[nodiscard]] uint64_t getFeatureIdAttributeCount() const;
+    [[nodiscard]] uint64_t getFeatureIdTextureCount() const;
     [[nodiscard]] uint64_t getImageryLayerCount() const;
     [[nodiscard]] bool hasTilesetMaterial() const;
     [[nodiscard]] const pxr::SdfPath& getTilesetMaterialPath() const;
@@ -29,6 +34,7 @@ class FabricMaterialDefinition {
   private:
     bool _hasVertexColors;
     bool _hasBaseColorTexture;
+    std::vector<FeatureIdType> _featureIdTypes;
     uint64_t _imageryLayerCount;
     pxr::SdfPath _tilesetMaterialPath;
 };

--- a/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
+++ b/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
@@ -26,9 +26,9 @@ struct FabricMesh {
     FeaturesInfo featuresInfo;
     std::unordered_map<uint64_t, uint64_t> texcoordIndexMapping;
     std::unordered_map<uint64_t, uint64_t> imageryTexcoordIndexMapping;
-    std::vector<uint64_t> featureIdIndexIndexMapping;
-    std::vector<uint64_t> featureIdAttributeIndexMapping;
-    std::vector<uint64_t> featureIdTextureIndexMapping;
+    std::vector<uint64_t> featureIdIndexSetIndexMapping;
+    std::vector<uint64_t> featureIdAttributeSetIndexMapping;
+    std::vector<uint64_t> featureIdTextureSetIndexMapping;
 };
 
 struct TileRenderResources {

--- a/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
+++ b/src/core/include/cesium/omniverse/FabricPrepareRenderResources.h
@@ -21,9 +21,14 @@ struct FabricMesh {
     std::shared_ptr<FabricGeometry> geometry;
     std::shared_ptr<FabricMaterial> material;
     std::shared_ptr<FabricTexture> baseColorTexture;
+    std::vector<std::shared_ptr<FabricTexture>> featureIdTextures;
     MaterialInfo materialInfo;
+    FeaturesInfo featuresInfo;
     std::unordered_map<uint64_t, uint64_t> texcoordIndexMapping;
     std::unordered_map<uint64_t, uint64_t> imageryTexcoordIndexMapping;
+    std::vector<uint64_t> featureIdIndexIndexMapping;
+    std::vector<uint64_t> featureIdAttributeIndexMapping;
+    std::vector<uint64_t> featureIdTextureIndexMapping;
 };
 
 struct TileRenderResources {

--- a/src/core/include/cesium/omniverse/FabricResourceManager.h
+++ b/src/core/include/cesium/omniverse/FabricResourceManager.h
@@ -58,11 +58,13 @@ class FabricResourceManager {
     std::shared_ptr<FabricGeometry> acquireGeometry(
         const CesiumGltf::Model& model,
         const CesiumGltf::MeshPrimitive& primitive,
+        const FeaturesInfo& featuresInfo,
         bool smoothNormals,
         long stageId);
 
     std::shared_ptr<FabricMaterial> acquireMaterial(
         const MaterialInfo& materialInfo,
+        const FeaturesInfo& featuresInfo,
         uint64_t imageryLayerCount,
         long stageId,
         int64_t tilesetId,

--- a/src/core/include/cesium/omniverse/FabricTexture.h
+++ b/src/core/include/cesium/omniverse/FabricTexture.h
@@ -16,12 +16,17 @@ struct ImageCesium;
 
 namespace cesium::omniverse {
 
+enum class TransferFunction {
+    LINEAR,
+    SRGB,
+};
+
 class FabricTexture {
   public:
     FabricTexture(const std::string& name);
     ~FabricTexture();
 
-    void setImage(const CesiumGltf::ImageCesium& image);
+    void setImage(const CesiumGltf::ImageCesium& image, TransferFunction transferFunction);
 
     void setActive(bool active);
 

--- a/src/core/include/cesium/omniverse/GltfAccessors.h
+++ b/src/core/include/cesium/omniverse/GltfAccessors.h
@@ -112,6 +112,18 @@ class VertexColorsAccessor {
     uint64_t _size;
 };
 
+class VertexIdsAccessor {
+  public:
+    VertexIdsAccessor();
+    VertexIdsAccessor(uint64_t size);
+
+    void fill(const gsl::span<float>& values, uint64_t repeat = 1) const;
+    [[nodiscard]] uint64_t size() const;
+
+  private:
+    uint64_t _size;
+};
+
 class FaceVertexCountsAccessor {
   public:
     FaceVertexCountsAccessor();

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -72,6 +72,11 @@ struct FeaturesInfo {
     std::vector<FeatureId> featureIds;
 };
 
+FeatureIdType getFeatureIdType(const FeatureId& featureId);
+std::vector<FeatureIdType> getFeatureIdTypes(const FeaturesInfo& featuresInfo);
+std::vector<uint64_t> getSetIndexMapping(const FeaturesInfo& featuresInfo, FeatureIdType type);
+bool hasFeatureIdType(const FeaturesInfo& featuresInfo, FeatureIdType type);
+
 struct VertexAttributeInfo {
     VertexAttributeType type;
     omni::fabric::Token fabricAttributeName;

--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -8,6 +8,7 @@
 #include <omni/fabric/core/FabricTypes.h>
 
 #include <set>
+#include <variant>
 
 namespace CesiumGltf {
 struct ImageCesium;
@@ -33,6 +34,7 @@ struct TextureInfo {
     int32_t wrapS;
     int32_t wrapT;
     bool flipVertical;
+    std::vector<uint8_t> channels;
 
     // Make sure to update this function when adding new fields to the struct
     bool operator==(const TextureInfo& other) const;
@@ -52,6 +54,22 @@ struct MaterialInfo {
 
     // Make sure to update this function when adding new fields to the struct
     bool operator==(const MaterialInfo& other) const;
+};
+
+enum class FeatureIdType {
+    INDEX,
+    ATTRIBUTE,
+    TEXTURE,
+};
+
+struct FeatureId {
+    std::optional<uint64_t> nullFeatureId;
+    uint64_t featureCount;
+    std::variant<std::monostate, uint64_t, TextureInfo> featureIdStorage;
+};
+
+struct FeaturesInfo {
+    std::vector<FeatureId> featureIds;
 };
 
 struct VertexAttributeInfo {
@@ -96,6 +114,8 @@ getImageryTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimit
 VertexColorsAccessor
 getVertexColors(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);
 
+VertexIdsAccessor getVertexIds(const PositionsAccessor& positionsAccessor);
+
 template <VertexAttributeType T>
 VertexAttributeAccessor<T> getVertexAttributeValues(
     const CesiumGltf::Model& model,
@@ -105,7 +125,14 @@ VertexAttributeAccessor<T> getVertexAttributeValues(
 const CesiumGltf::ImageCesium*
 getBaseColorTextureImage(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
+const CesiumGltf::ImageCesium* getFeatureIdTextureImage(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    uint64_t featureIdSetIndex);
+
 MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
+
+FeaturesInfo getFeaturesInfo(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
 std::set<VertexAttributeInfo>
 getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -16,7 +16,10 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (base_color_texture) \
     (cesium) \
     (cesium_base_color_texture_float4) \
+    (cesium_feature_id_int) \
     (cesium_imagery_layer_float4) \
+    (cesium_internal_feature_id_attribute_lookup) \
+    (cesium_internal_feature_id_texture_lookup) \
     (cesium_internal_imagery_layer_lookup) \
     (cesium_internal_imagery_layer_resolver) \
     (cesium_internal_material) \
@@ -26,6 +29,16 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (extent) \
     (faceVertexCounts) \
     (faceVertexIndices) \
+    (feature_id_0) \
+    (feature_id_1) \
+    (feature_id_2) \
+    (feature_id_3) \
+    (feature_id_4) \
+    (feature_id_5) \
+    (feature_id_6) \
+    (feature_id_7) \
+    (feature_id_8) \
+    (feature_id_9) \
     (imagery_layer) \
     (imagery_layer_0) \
     (imagery_layer_1) \
@@ -54,6 +67,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (sourceAsset) \
     (subdivisionScheme) \
     (vertex) \
+    (vertexId) \
     (_cesium_localToEcefTransform) \
     (_cesium_tilesetId) \
     (_deletedPrims) \
@@ -74,9 +88,15 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_base_alpha, "inputs:base_alpha")) \
     ((inputs_base_color_factor, "inputs:base_color_factor")) \
     ((inputs_base_color_texture, "inputs:base_color_texture")) \
+    ((inputs_channel_count, "inputs:channel_count")) \
+    ((inputs_channels, "inputs:channels")) \
     ((inputs_emissive_factor, "inputs:emissive_factor")) \
     ((inputs_excludeFromWhiteMode, "inputs:excludeFromWhiteMode")) \
+    ((inputs_feature_id, "inputs:feature_id")) \
+    ((inputs_feature_id_primvar_name, "inputs:feature_id_primvar_name")) \
+    ((inputs_feature_id_set_index, "inputs:feature_id_set_index")) \
     ((inputs_metallic_factor, "inputs:metallic_factor")) \
+    ((inputs_null_feature_id, "inputs:null_feature_id")) \
     ((inputs_offset, "inputs:offset")) \
     ((inputs_rotation, "inputs:rotation")) \
     ((inputs_roughness_factor, "inputs:roughness_factor")) \
@@ -124,6 +144,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_st_8, "primvars:st_8")) \
     ((primvars_st_9, "primvars:st_9")) \
     ((primvars_COLOR_0, "primvars:COLOR_0")) \
+    ((primvars_vertexId, "primvars:vertexId")) \
     ((xformOp_transform_cesium, "xformOp:transform:cesium"))
 
 TF_DECLARE_PUBLIC_TOKENS(UsdTokens, USD_TOKENS);
@@ -157,6 +178,7 @@ FABRIC_DECLARE_TOKENS(USD_TOKENS);
 
 const uint64_t MAX_PRIMVAR_ST_COUNT = 10;
 const uint64_t MAX_IMAGERY_LAYERS_COUNT = 16;
+const uint64_t MAX_FEATURE_ID_COUNT = 10;
 
 const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n = {{
     primvars_st_0,
@@ -169,6 +191,19 @@ const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n
     primvars_st_7,
     primvars_st_8,
     primvars_st_9,
+}};
+
+const std::array<const omni::fabric::TokenC, MAX_FEATURE_ID_COUNT> feature_id_n = {{
+    feature_id_0,
+    feature_id_1,
+    feature_id_2,
+    feature_id_3,
+    feature_id_4,
+    feature_id_5,
+    feature_id_6,
+    feature_id_7,
+    feature_id_8,
+    feature_id_9,
 }};
 
 const std::array<const omni::fabric::TokenC, MAX_IMAGERY_LAYERS_COUNT> imagery_layer_n = {{
@@ -225,10 +260,14 @@ const omni::fabric::Type inputs_alpha_cutoff(omni::fabric::BaseDataType::eFloat,
 const omni::fabric::Type inputs_alpha_mode(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_alpha(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_base_color_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
+const omni::fabric::Type inputs_channel_count(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_channels(omni::fabric::BaseDataType::eInt, 4, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_tile_color(omni::fabric::BaseDataType::eFloat, 4, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_emissive_factor(omni::fabric::BaseDataType::eFloat, 3, 0, omni::fabric::AttributeRole::eColor);
 const omni::fabric::Type inputs_excludeFromWhiteMode(omni::fabric::BaseDataType::eBool, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_feature_id_primvar_name(omni::fabric::BaseDataType::eUChar, 1, 1, omni::fabric::AttributeRole::eText);
 const omni::fabric::Type inputs_metallic_factor(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type inputs_null_feature_id(omni::fabric::BaseDataType::eInt, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_offset(omni::fabric::BaseDataType::eFloat, 2, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_rotation(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type inputs_roughness_factor(omni::fabric::BaseDataType::eFloat, 1, 0, omni::fabric::AttributeRole::eNone);
@@ -248,6 +287,7 @@ const omni::fabric::Type primvars(omni::fabric::BaseDataType::eToken, 1, 1, omni
 const omni::fabric::Type primvars_normals(omni::fabric::BaseDataType::eFloat, 3, 1, omni::fabric::AttributeRole::eNormal);
 const omni::fabric::Type primvars_st(omni::fabric::BaseDataType::eFloat, 2, 1, omni::fabric::AttributeRole::eTexCoord);
 const omni::fabric::Type primvars_COLOR_0(omni::fabric::BaseDataType::eFloat, 4, 1, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type primvars_vertexId(omni::fabric::BaseDataType::eFloat, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type Shader(omni::fabric::BaseDataType::eTag, 1, 0, omni::fabric::AttributeRole::ePrimTypeName);
 const omni::fabric::Type subdivisionScheme(omni::fabric::BaseDataType::eToken, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _cesium_localToEcefTransform(omni::fabric::BaseDataType::eDouble, 16, 0, omni::fabric::AttributeRole::eMatrix);

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -11,18 +11,6 @@
 
 namespace cesium::omniverse {
 
-bool hasVertexIds(const FeaturesInfo& featuresInfo) {
-    const auto& featureIds = featuresInfo.featureIds;
-
-    for (const auto& featureId : featureIds) {
-        if (std::holds_alternative<std::monostate>(featureId.featureIdStorage)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
@@ -30,7 +18,7 @@ FabricGeometryDefinition::FabricGeometryDefinition(
     bool smoothNormals)
     : _hasNormals(GltfUtil::hasNormals(model, primitive, smoothNormals))
     , _hasVertexColors(GltfUtil::hasVertexColors(model, primitive, 0))
-    , _hasVertexIds(::cesium::omniverse::hasVertexIds(featuresInfo))
+    , _hasVertexIds(hasFeatureIdType(featuresInfo, FeatureIdType::INDEX))
     , _texcoordSetCount(
           GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
           GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size())

--- a/src/core/src/FabricGeometryDefinition.cpp
+++ b/src/core/src/FabricGeometryDefinition.cpp
@@ -11,12 +11,26 @@
 
 namespace cesium::omniverse {
 
+bool hasVertexIds(const FeaturesInfo& featuresInfo) {
+    const auto& featureIds = featuresInfo.featureIds;
+
+    for (const auto& featureId : featureIds) {
+        if (std::holds_alternative<std::monostate>(featureId.featureIdStorage)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 FabricGeometryDefinition::FabricGeometryDefinition(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
+    const FeaturesInfo& featuresInfo,
     bool smoothNormals)
     : _hasNormals(GltfUtil::hasNormals(model, primitive, smoothNormals))
     , _hasVertexColors(GltfUtil::hasVertexColors(model, primitive, 0))
+    , _hasVertexIds(::cesium::omniverse::hasVertexIds(featuresInfo))
     , _texcoordSetCount(
           GltfUtil::getTexcoordSetIndexes(model, primitive).size() +
           GltfUtil::getImageryTexcoordSetIndexes(model, primitive).size())
@@ -30,6 +44,10 @@ bool FabricGeometryDefinition::hasVertexColors() const {
     return _hasVertexColors;
 }
 
+bool FabricGeometryDefinition::hasVertexIds() const {
+    return _hasVertexIds;
+}
+
 uint64_t FabricGeometryDefinition::getTexcoordSetCount() const {
     return _texcoordSetCount;
 }
@@ -40,7 +58,8 @@ const std::set<VertexAttributeInfo>& FabricGeometryDefinition::getCustomVertexAt
 
 bool FabricGeometryDefinition::operator==(const FabricGeometryDefinition& other) const {
     return _hasNormals == other._hasNormals && _hasVertexColors == other._hasVertexColors &&
-           _texcoordSetCount == other._texcoordSetCount && _customVertexAttributes == other._customVertexAttributes;
+           _hasVertexIds == other._hasVertexIds && _texcoordSetCount == other._texcoordSetCount &&
+           _customVertexAttributes == other._customVertexAttributes;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -584,9 +584,9 @@ void FabricMaterial::setMaterial(
     const glm::dvec3& displayColor,
     double displayOpacity,
     const std::unordered_map<uint64_t, uint64_t>& texcoordIndexMapping,
-    const std::vector<uint64_t>& featureIdIndexIndexMapping,
-    const std::vector<uint64_t>& featureIdAttributeIndexMapping,
-    const std::vector<uint64_t>& featureIdTextureIndexMapping) {
+    const std::vector<uint64_t>& featureIdIndexSetIndexMapping,
+    const std::vector<uint64_t>& featureIdAttributeSetIndexMapping,
+    const std::vector<uint64_t>& featureIdTextureSetIndexMapping) {
 
     if (stageDestroyed()) {
         return;
@@ -618,7 +618,7 @@ void FabricMaterial::setMaterial(
     const auto featureIdCounts = getFeatureIdCounts(_materialDefinition);
 
     for (uint64_t i = 0; i < featureIdCounts.indexCount; i++) {
-        const auto featureIdSetIndex = featureIdIndexIndexMapping[i];
+        const auto featureIdSetIndex = featureIdIndexSetIndexMapping[i];
         const auto featureId = featuresInfo.featureIds[featureIdSetIndex];
         assert(std::holds_alternative<std::monostate>(featureId.featureIdStorage));
         const auto& featureIdPath = _featureIdPaths[featureIdSetIndex];
@@ -628,7 +628,7 @@ void FabricMaterial::setMaterial(
     }
 
     for (uint64_t i = 0; i < featureIdCounts.attributeCount; i++) {
-        const auto featureIdSetIndex = featureIdAttributeIndexMapping[i];
+        const auto featureIdSetIndex = featureIdAttributeSetIndexMapping[i];
         const auto featureId = featuresInfo.featureIds[featureIdSetIndex];
         assert(std::holds_alternative<uint64_t>(featureId.featureIdStorage));
         const auto attributeSetIndex = std::get<uint64_t>(featureId.featureIdStorage);
@@ -640,7 +640,7 @@ void FabricMaterial::setMaterial(
     }
 
     for (uint64_t i = 0; i < featureIdCounts.textureCount; i++) {
-        const auto featureIdSetIndex = featureIdTextureIndexMapping[i];
+        const auto featureIdSetIndex = featureIdTextureSetIndexMapping[i];
         const auto& featureId = featuresInfo.featureIds[featureIdSetIndex];
         assert(std::holds_alternative<TextureInfo>(featureId.featureIdStorage));
         const auto& textureInfo = std::get<TextureInfo>(featureId.featureIdStorage);

--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -11,13 +11,40 @@
 
 namespace cesium::omniverse {
 
+namespace {
+
+std::vector<FeatureIdType> getFeatureIdTypes(const FeaturesInfo& featuresInfo, bool disableTextures) {
+    const auto& featureIds = featuresInfo.featureIds;
+
+    std::vector<FeatureIdType> featureIdTypes;
+    featureIdTypes.reserve(featureIds.size());
+
+    for (const auto& featureId : featureIds) {
+        if (std::holds_alternative<std::monostate>(featureId.featureIdStorage)) {
+            featureIdTypes.push_back(FeatureIdType::INDEX);
+        } else if (std::holds_alternative<uint64_t>(featureId.featureIdStorage)) {
+            featureIdTypes.push_back(FeatureIdType::ATTRIBUTE);
+        } else if (std::holds_alternative<TextureInfo>(featureId.featureIdStorage)) {
+            if (!disableTextures) {
+                featureIdTypes.push_back(FeatureIdType::TEXTURE);
+            }
+        }
+    }
+
+    return featureIdTypes;
+}
+
+} // namespace
+
 FabricMaterialDefinition::FabricMaterialDefinition(
     const MaterialInfo& materialInfo,
+    const FeaturesInfo& featuresInfo,
     uint64_t imageryLayerCount,
     bool disableTextures,
     const pxr::SdfPath& tilesetMaterialPath)
     : _hasVertexColors(materialInfo.hasVertexColors)
     , _hasBaseColorTexture(disableTextures ? false : materialInfo.baseColorTexture.has_value())
+    , _featureIdTypes(::cesium::omniverse::getFeatureIdTypes(featuresInfo, disableTextures))
     , _imageryLayerCount(disableTextures ? 0 : imageryLayerCount)
     , _tilesetMaterialPath(tilesetMaterialPath) {}
 
@@ -27,6 +54,22 @@ bool FabricMaterialDefinition::hasVertexColors() const {
 
 bool FabricMaterialDefinition::hasBaseColorTexture() const {
     return _hasBaseColorTexture;
+}
+
+const std::vector<FeatureIdType>& FabricMaterialDefinition::getFeatureIdTypes() const {
+    return _featureIdTypes;
+}
+
+uint64_t FabricMaterialDefinition::getFeatureIdIndexCount() const {
+    return static_cast<uint64_t>(std::count(_featureIdTypes.begin(), _featureIdTypes.end(), FeatureIdType::INDEX));
+}
+
+uint64_t FabricMaterialDefinition::getFeatureIdAttributeCount() const {
+    return static_cast<uint64_t>(std::count(_featureIdTypes.begin(), _featureIdTypes.end(), FeatureIdType::ATTRIBUTE));
+}
+
+uint64_t FabricMaterialDefinition::getFeatureIdTextureCount() const {
+    return static_cast<uint64_t>(std::count(_featureIdTypes.begin(), _featureIdTypes.end(), FeatureIdType::TEXTURE));
 }
 
 uint64_t FabricMaterialDefinition::getImageryLayerCount() const {
@@ -44,7 +87,8 @@ const pxr::SdfPath& FabricMaterialDefinition::getTilesetMaterialPath() const {
 // In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDefinition::operator==(const FabricMaterialDefinition& other) const {
     return _hasVertexColors == other._hasVertexColors && _hasBaseColorTexture == other._hasBaseColorTexture &&
-           _imageryLayerCount == other._imageryLayerCount && _tilesetMaterialPath == other._tilesetMaterialPath;
+           _featureIdTypes == other._featureIdTypes && _imageryLayerCount == other._imageryLayerCount &&
+           _tilesetMaterialPath == other._tilesetMaterialPath;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -65,10 +65,11 @@ bool FabricResourceManager::shouldAcquireMaterial(
 std::shared_ptr<FabricGeometry> FabricResourceManager::acquireGeometry(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
+    const FeaturesInfo& featuresInfo,
     bool smoothNormals,
     long stageId) {
 
-    FabricGeometryDefinition geometryDefinition(model, primitive, smoothNormals);
+    FabricGeometryDefinition geometryDefinition(model, primitive, featuresInfo, smoothNormals);
 
     if (_disableGeometryPool) {
         const auto pathStr = fmt::format("/fabric_geometry_{}", getNextGeometryId());
@@ -179,11 +180,13 @@ void FabricResourceManager::releaseSharedMaterial(const std::shared_ptr<FabricMa
 
 std::shared_ptr<FabricMaterial> FabricResourceManager::acquireMaterial(
     const MaterialInfo& materialInfo,
+    const FeaturesInfo& featuresInfo,
     uint64_t imageryLayerCount,
     long stageId,
     int64_t tilesetId,
     const pxr::SdfPath& tilesetMaterialPath) {
-    FabricMaterialDefinition materialDefinition(materialInfo, imageryLayerCount, _disableTextures, tilesetMaterialPath);
+    FabricMaterialDefinition materialDefinition(
+        materialInfo, featuresInfo, imageryLayerCount, _disableTextures, tilesetMaterialPath);
 
     if (useSharedMaterial(materialDefinition)) {
         return acquireSharedMaterial(materialInfo, materialDefinition, stageId, tilesetId);

--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -883,7 +883,8 @@ bool materialHasCesiumNodes(const omni::fabric::Path& path) {
 
 bool isCesiumNode(const omni::fabric::Token& mdlIdentifier) {
     return mdlIdentifier == FabricTokens::cesium_base_color_texture_float4 ||
-           mdlIdentifier == FabricTokens::cesium_imagery_layer_float4;
+           mdlIdentifier == FabricTokens::cesium_imagery_layer_float4 ||
+           mdlIdentifier == FabricTokens::cesium_feature_id_int;
 }
 
 bool isShaderConnectedToMaterial(const omni::fabric::Path& materialPath, const omni::fabric::Path& shaderPath) {

--- a/src/core/src/GltfAccessors.cpp
+++ b/src/core/src/GltfAccessors.cpp
@@ -300,6 +300,25 @@ uint64_t VertexColorsAccessor::size() const {
     return _size;
 }
 
+VertexIdsAccessor::VertexIdsAccessor()
+    : _size(0) {}
+
+VertexIdsAccessor::VertexIdsAccessor(uint64_t size)
+    : _size(size) {}
+
+void VertexIdsAccessor::fill(const gsl::span<float>& values, uint64_t repeat) const {
+    const auto size = values.size();
+    assert(size == _size * repeat);
+
+    for (uint64_t i = 0; i < size; i++) {
+        values[i] = static_cast<float>(i / repeat);
+    }
+}
+
+uint64_t VertexIdsAccessor::size() const {
+    return _size;
+}
+
 FaceVertexCountsAccessor::FaceVertexCountsAccessor()
     : _size(0) {}
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -807,6 +807,59 @@ bool hasMaterial(const CesiumGltf::MeshPrimitive& primitive) {
 
 namespace cesium::omniverse {
 
+FeatureIdType getFeatureIdType(const FeatureId& featureId) {
+    if (std::holds_alternative<std::monostate>(featureId.featureIdStorage)) {
+        return FeatureIdType::INDEX;
+    } else if (std::holds_alternative<uint64_t>(featureId.featureIdStorage)) {
+        return FeatureIdType::ATTRIBUTE;
+    } else if (std::holds_alternative<TextureInfo>(featureId.featureIdStorage)) {
+        return FeatureIdType::TEXTURE;
+    }
+
+    assert(false);
+    return FeatureIdType::INDEX;
+}
+
+std::vector<FeatureIdType> getFeatureIdTypes(const FeaturesInfo& featuresInfo) {
+    const auto& featureIds = featuresInfo.featureIds;
+
+    std::vector<FeatureIdType> featureIdTypes;
+    featureIdTypes.reserve(featureIds.size());
+
+    for (const auto& featureId : featureIds) {
+        featureIdTypes.push_back(getFeatureIdType(featureId));
+    }
+
+    return featureIdTypes;
+}
+
+std::vector<uint64_t> getSetIndexMapping(const FeaturesInfo& featuresInfo, FeatureIdType type) {
+    const auto& featureIds = featuresInfo.featureIds;
+
+    std::vector<uint64_t> setIndexMapping;
+    setIndexMapping.reserve(featureIds.size());
+
+    for (uint64_t i = 0; i < featureIds.size(); i++) {
+        if (getFeatureIdType(featureIds[i]) == type) {
+            setIndexMapping.push_back(i);
+        }
+    }
+
+    return setIndexMapping;
+}
+
+bool hasFeatureIdType(const FeaturesInfo& featuresInfo, FeatureIdType type) {
+    const auto& featureIds = featuresInfo.featureIds;
+
+    for (const auto& featureId : featureIds) {
+        if (getFeatureIdType(featureId) == type) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // In C++ 20 we can use the default equality comparison (= default)
 bool TextureInfo::operator==(const TextureInfo& other) const {
     return offset == other.offset && rotation == other.rotation && scale == other.scale && setIndex == other.setIndex &&


### PR DESCRIPTION
Adds support for [EXT_mesh_features](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) and adds an MDL function `cesium_feature_id_int` that hides all the complex implementation details.

Three types of feature ID modes are supported:

* **Per-index feature IDs**: this is implemented with a `vertexId` primvar that mimicks OpenGL's `gl_VertexId`. This will  eventually be important for doing point cloud styling.
* **Per-vertex feature IDs**: similar to above, but reads the `_FEATURE_ID_n` primvar (made possible by [#538](https://github.com/CesiumGS/cesium-omniverse/pull/538)).
* **Per-texel feature IDs**: load feature ID textures. Made a few changes to `FabricTexture` to support linear vs. sRGB transfer functions and added a `texel_fetch` helper function in `cesium.mdl` to do nearest sampling (which unfortunately also forces us to implement our own texture wrapping code).

The finer points of the extension are also supported, like handling arbitrary channels and `nullFeatureId`.

![feature-id-texture-ferry-building](https://github.com/CesiumGS/cesium-omniverse/assets/915398/68d71673-1e7f-4588-b5c2-c8e4e2d73217)

[ferry-building.usda.zip](https://github.com/CesiumGS/cesium-omniverse/files/13302930/ferry-building.usda.zip)

What's cool about this test scene is that it uses almost all the cesium.mdl functions that we export. It takes a really long time to compile though.