### PR TITLE
Enabling caching for packman

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -10,7 +10,7 @@ runs:
   # Tell Conan to look for or create its build folder (.conan) in the repository's root directory
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE
-    PACKMAN_ROOT: $GITHUB_WORKSPACE/packman-repo
+    PM_PACKAGES_ROOT: $GITHUB_WORKSPACE/packman-repo
   args:
     # Tell bash to run a command
     - "-c"

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -10,6 +10,7 @@ runs:
   # Tell Conan to look for or create its build folder (.conan) in the repository's root directory
   env:
     CONAN_USER_HOME: $GITHUB_WORKSPACE
+    PACKMAN_ROOT: $GITHUB_WORKSPACE/packman-repo
   args:
     # Tell bash to run a command
     - "-c"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         id: packman-cache
         uses: actions/cache@v3
         with:
-          path: ${{ github.workspace }}/extern/nvidia/_build
+          path: extern/nvidia/_build
           key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}-v1
 
       - name: AlmaLinux Build with Docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,8 +86,8 @@ jobs:
         id: packman-cache
         uses: actions/cache@v3
         with:
-          path: extern/nvidia/_build
-          key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}-v1
+          path: ${{ env.PACKMAN_ROOT }}
+          key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}
 
       - name: AlmaLinux Build with Docker
         uses: ./.github/actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PACKMAN_ROOT: $GITHUB_WORKSPACE/packman-repo
+  PACKMAN_ROOT: ${{ github.workspace }}/packman-repo
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,13 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}/.conan
           key: conan-${{ matrix.config.name }}-${{ hashFiles('cmake/AddConanDependencies.cmake') }}-v3
 
+      - name: Packman Check cache
+        id: packman-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/extern/nvidia/target-deps
+          key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}-v1
+
       - name: AlmaLinux Build with Docker
         uses: ./.github/actions
         if: matrix.config.name == 'AlmaLinux 8 - GCC'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PACKMAN_ROOT: $GITHUB_WORKSPACE/packman-repo
+
 jobs:
   build:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
               cxx: "cl",
               build-type: "Release",
               build-code: "Windows",
+              cache-type: "Windows",
               generator: "Ninja Multi-Config",
               coverage: "false",
             }
@@ -37,6 +38,7 @@ jobs:
               cxx: "g++-11",
               build-type: "Release",
               build-code: "Ubuntu",
+              cache-type: "Linux",
               generator: "Unix Makefiles",
               coverage: "false",
             }
@@ -48,6 +50,7 @@ jobs:
               cxx: "g++-11",
               build-type: "Release",
               build-code: "AlmaLinux8",
+              cache-type: "Linux",
               generator: "Unix Makefiles",
               coverage: "false",
             }
@@ -91,7 +94,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.PM_PACKAGES_ROOT }}
-          key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}
+          key: packman-${{ matrix.config.cache-type }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}
 
       - name: AlmaLinux Build with Docker
         uses: ./.github/actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         id: packman-cache
         uses: actions/cache@v3
         with:
-          path: ${{ github.workspace }}/extern/nvidia/target-deps
+          path: ${{ github.workspace }}/extern/nvidia/_build
           key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}-v1
 
       - name: AlmaLinux Build with Docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,9 +105,11 @@ jobs:
       # Change the ownership from root to user for all files created by Docker in
       # the Conan build directory so that the files can be cached without permission
       # denied errors
-      - name: AlmaLinux Change Conan directory permissions
+      - name: AlmaLinux Change Conan & Packman directory permissions
         if: matrix.config.name == 'AlmaLinux 8 - GCC'
-        run: sudo chown -R $USER:$USER $CONAN_USER_HOME/.conan
+        run: |
+          sudo chown -R $USER:$USER $CONAN_USER_HOME/.conan
+          sudo chown -R $USER:$USER $PM_PACKAGES_ROOT
 
       - name: Install Linux dependencies
         if: ${{ runner.os == 'Linux' && matrix.config.name != 'AlmaLinux 8 - GCC' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PACKMAN_ROOT: ${{ github.workspace }}/packman-repo
+  # Packman
+  PM_PACKAGES_ROOT: ${{ github.workspace }}/packman-repo
 
 jobs:
   build:
@@ -89,7 +90,7 @@ jobs:
         id: packman-cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.PACKMAN_ROOT }}
+          path: ${{ env.PM_PACKAGES_ROOT }}
           key: packman-${{ matrix.config.name }}-${{ hashFiles('extern/nvidia/deps/kit-sdk.packman.xml', 'extern/nvidia/deps/target-deps.packman.xml') }}
 
       - name: AlmaLinux Build with Docker

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,10 @@ _testoutput
 tests/include/testUtils.h
 
 # Packman user files
-*.user
+*.packman.xml.user
+*.packman.user.xml
+!extern/nvidia/debug-deps/kit-sdk.packman.user.xml
+!extern/nvidia/debug-deps/target-deps.packman.user.xml
 
 # Tracing files
 cesium-trace-*.json

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -37,6 +37,10 @@ add_external_project(
 )
 # cmake-format: on
 
+if(NOT ${USE_NVIDIA_RELEASE_LIBRARIES})
+    execute_process(COMMAND "${Python3_EXECUTABLE}" "${SCRIPTS_DIRECTORY}/copy_from_dir.py" "*.user.xml" "${PROJECT_SOURCE_DIR}/extern/nvidia/debug-deps" "${PROJECT_SOURCE_DIR}/extern/nvidia/deps")
+endif()
+
 if(UNIX)
     execute_process(COMMAND bash -c "${PROJECT_SOURCE_DIR}/extern/nvidia/prebuild.sh" RESULT_VARIABLE exit_code)
 elseif(WIN32)

--- a/extern/nvidia/debug-deps/kit-sdk.packman.user.xml
+++ b/extern/nvidia/debug-deps/kit-sdk.packman.user.xml
@@ -1,0 +1,5 @@
+<project toolsVersion="5.6">
+  <dependency name="kit_sdk_debug" linkPath="../_build/target-deps/kit-sdk-debug/">
+    <package name="kit-sdk" version="105.1+release.127680.dd92291b.tc.${platform}.debug"/>
+  </dependency>
+</project>

--- a/extern/nvidia/debug-deps/target-deps.packman.user.xml
+++ b/extern/nvidia/debug-deps/target-deps.packman.user.xml
@@ -1,0 +1,6 @@
+<project toolsVersion="5.6">
+  <import path="../_build/target-deps/kit-sdk-debug/dev/all-deps.packman.xml">
+    <filter include="nv_usd_py310_debug"/>
+  </import>
+  <dependency name="nv_usd_py310_debug" linkPath="../_build/target-deps/usd/debug"/>
+</project>

--- a/extern/nvidia/deps/kit-sdk.packman.xml
+++ b/extern/nvidia/deps/kit-sdk.packman.xml
@@ -2,7 +2,4 @@
   <dependency name="kit_sdk" linkPath="../_build/target-deps/kit-sdk/">
     <package name="kit-sdk" version="105.1+release.127680.dd92291b.tc.${platform}.release"/>
   </dependency>
-  <dependency name="kit_sdk_debug" linkPath="../_build/target-deps/kit-sdk-debug/">
-    <package name="kit-sdk" version="105.1+release.127680.dd92291b.tc.${platform}.debug"/>
-  </dependency>
 </project>

--- a/extern/nvidia/deps/target-deps.packman.xml
+++ b/extern/nvidia/deps/target-deps.packman.xml
@@ -8,13 +8,9 @@
     <filter include="pybind11"/>
     <filter include="cuda"/>
   </import>
-  <import path="../_build/target-deps/kit-sdk-debug/dev/all-deps.packman.xml">
-    <filter include="nv_usd_py310_debug"/>
-  </import>
   <!-- Override the link paths to point to the correct locations. -->
   <dependency name="python" linkPath="../_build/target-deps/python"/>
   <dependency name="nv_usd_py310_release" linkPath="../_build/target-deps/usd/release"/>
-  <dependency name="nv_usd_py310_debug" linkPath="../_build/target-deps/usd/debug"/>
   <dependency name="usdrt" linkPath="../_build/target-deps/usdrt"/>
   <dependency name="carb_sdk_plugins" linkPath="../_build/target-deps/carb_sdk_plugins"/>
   <dependency name="pybind11" linkPath="../_build/target-deps/pybind11/pybind11"/>

--- a/scripts/copy_from_dir.py
+++ b/scripts/copy_from_dir.py
@@ -1,0 +1,40 @@
+import glob
+import sys
+from pathlib import Path
+from shutil import copy2
+
+# Broken out for formatting reasons, since tabs within HEREDOCs will be output.
+usage_message = """Invalid arguments.
+    Usage: copy_from_dir.py <glob-pattern> <source-dir-path> <destination-dir-path>
+
+Please fix your command and try again.
+"""
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(usage_message)
+        return 1
+
+    glob_pattern: str = sys.argv[1]
+    source_dir = Path(sys.argv[2]).resolve()
+    dest_dir = Path(sys.argv[3]).resolve()
+
+    print(f'Performing file copy with glob pattern "{glob_pattern}"')
+    print(f"\tSource: {source_dir}")
+    print(f"\tDestination: {dest_dir}\n")
+
+    source_files = glob.glob(glob_pattern, root_dir=source_dir)
+
+    for f in source_files:
+        source_path = source_dir / f
+
+        copy2(source_path, dest_dir, follow_symlinks=True)
+
+        print(f"Copied {source_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/copy_from_dir.py
+++ b/scripts/copy_from_dir.py
@@ -1,4 +1,3 @@
-import glob
 import sys
 from pathlib import Path
 from shutil import copy2
@@ -24,7 +23,7 @@ def main():
     print(f"\tSource: {source_dir}")
     print(f"\tDestination: {dest_dir}\n")
 
-    source_files = glob.glob(glob_pattern, root_dir=source_dir)
+    source_files = source_dir.glob(glob_pattern)
 
     for f in source_files:
         source_path = source_dir / f


### PR DESCRIPTION
Resolves #522.

Enables caching for Nvidia packman. Caching is performed by platform, not job, so Ubuntu and AlmaLinux share caches. This keeps us under GitHub's 10 GB limit on cumulative cache size.

The hash is generated on both `*.packman.xml` files since all of the artifacts go into the same folder.

Kit Debug builds are no longer downloaded on the build servers. I am abusing Packman user files to do this, but Packman has no other mechanisms for handling this sort of build flag optional requirements.