### PR TITLE
Fix startup crash due to global variable initialization order

### DIFF
--- a/src/core/include/cesium/omniverse/GltfUtil.h
+++ b/src/core/include/cesium/omniverse/GltfUtil.h
@@ -142,8 +142,8 @@ FeaturesInfo getFeaturesInfo(const CesiumGltf::Model& model, const CesiumGltf::M
 std::set<VertexAttributeInfo>
 getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive);
 
-MaterialInfo getDefaultMaterialInfo();
-TextureInfo getDefaultTextureInfo();
+const MaterialInfo& getDefaultMaterialInfo();
+const TextureInfo& getDefaultTextureInfo();
 
 bool hasNormals(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, bool smoothNormals);
 bool hasTexcoords(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, uint64_t setIndex);

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -23,8 +23,6 @@ const auto DEFAULT_DEBUG_COLOR = glm::dvec3(1.0, 1.0, 1.0);
 const auto DEFAULT_ALPHA = 1.0f;
 const auto DEFAULT_DISPLAY_COLOR = glm::dvec3(1.0, 1.0, 1.0);
 const auto DEFAULT_DISPLAY_OPACITY = 1.0;
-const auto DEFAULT_MATERIAL_INFO = GltfUtil::getDefaultMaterialInfo();
-const auto DEFAULT_TEXTURE_INFO = GltfUtil::getDefaultTextureInfo();
 const auto DEFAULT_TEXCOORD_INDEX = uint64_t(0);
 const auto DEFAULT_FEATURE_ID_PRIMVAR_NAME = std::string("_FEATURE_ID_0");
 const auto DEFAULT_NULL_FEATURE_ID = -1;
@@ -536,12 +534,16 @@ void FabricMaterial::createFeatureIdTexture(const omni::fabric::Path& path) {
 
 void FabricMaterial::reset() {
     if (_usesDefaultMaterial) {
-        setShaderValues(_shaderPath, DEFAULT_MATERIAL_INFO, DEFAULT_DISPLAY_COLOR, DEFAULT_DISPLAY_OPACITY);
+        setShaderValues(
+            _shaderPath, GltfUtil::getDefaultMaterialInfo(), DEFAULT_DISPLAY_COLOR, DEFAULT_DISPLAY_OPACITY);
     }
 
     if (_materialDefinition.hasBaseColorTexture()) {
         setTextureValues(
-            _baseColorTexturePath, _defaultTextureAssetPathToken, DEFAULT_TEXTURE_INFO, DEFAULT_TEXCOORD_INDEX);
+            _baseColorTexturePath,
+            _defaultTextureAssetPathToken,
+            GltfUtil::getDefaultTextureInfo(),
+            DEFAULT_TEXCOORD_INDEX);
     }
 
     for (const auto& featureIdIndexPath : _featureIdIndexPaths) {
@@ -556,7 +558,7 @@ void FabricMaterial::reset() {
         setFeatureIdTextureValues(
             featureIdTexturePath,
             _defaultTransparentTextureAssetPathToken,
-            DEFAULT_TEXTURE_INFO,
+            GltfUtil::getDefaultTextureInfo(),
             DEFAULT_TEXCOORD_INDEX,
             DEFAULT_NULL_FEATURE_ID);
     }
@@ -565,7 +567,7 @@ void FabricMaterial::reset() {
         setImageryLayerValues(
             imageryLayerPath,
             _defaultTransparentTextureAssetPathToken,
-            DEFAULT_TEXTURE_INFO,
+            GltfUtil::getDefaultTextureInfo(),
             DEFAULT_TEXCOORD_INDEX,
             DEFAULT_ALPHA);
     }
@@ -739,7 +741,7 @@ void FabricMaterial::clearImageryLayer(uint64_t imageryLayerIndex) {
     setImageryLayerValues(
         imageryLayerPath,
         _defaultTransparentTextureAssetPathToken,
-        DEFAULT_TEXTURE_INFO,
+        GltfUtil::getDefaultTextureInfo(),
         DEFAULT_TEXCOORD_INDEX,
         DEFAULT_ALPHA);
 }

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -720,8 +720,8 @@ getCustomVertexAttributes(const CesiumGltf::Model& model, const CesiumGltf::Mesh
     return customVertexAttributes;
 }
 
-MaterialInfo getDefaultMaterialInfo() {
-    return {
+const MaterialInfo& getDefaultMaterialInfo() {
+    static const auto defaultInfo = MaterialInfo{
         getDefaultAlphaCutoff(),
         getDefaultAlphaMode(),
         getDefaultBaseAlpha(),
@@ -733,10 +733,12 @@ MaterialInfo getDefaultMaterialInfo() {
         false,
         std::nullopt,
     };
+
+    return defaultInfo;
 }
 
-TextureInfo getDefaultTextureInfo() {
-    return {
+const TextureInfo& getDefaultTextureInfo() {
+    static const auto defaultInfo = TextureInfo{
         getDefaultTexcoordOffset(),
         getDefaultTexcoordRotation(),
         getDefaultTexcoordScale(),
@@ -744,7 +746,10 @@ TextureInfo getDefaultTextureInfo() {
         getDefaultWrapS(),
         getDefaultWrapT(),
         true,
+        {},
     };
+
+    return defaultInfo;
 }
 
 bool hasNormals(const CesiumGltf::Model& model, const CesiumGltf::MeshPrimitive& primitive, bool smoothNormals) {

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -602,10 +602,13 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
         return getDefaultMaterialInfo();
     }
 
+// Ignore uninitialized member warning from gcc 11.2.0. This warning is not reported in gcc 11.4.0
+#ifdef CESIUM_OMNI_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     auto materialInfo = getDefaultMaterialInfo();
-
-    // This line shouldn't be needed, but gcc 11.2.0 complains about uninitialized members
-    materialInfo.baseColorTexture = std::nullopt;
+#pragma GCC diagnostic pop
+#endif
 
     const auto& material = model.materials[static_cast<size_t>(primitive.material)];
 

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -606,10 +606,10 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
 #ifdef CESIUM_OMNI_GCC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     auto materialInfo = getDefaultMaterialInfo();
+#ifdef CESIUM_OMNI_GCC
 #pragma GCC diagnostic pop
-#else
-    auto materialInfo = getDefaultMaterialInfo();
 #endif
 
     const auto& material = model.materials[static_cast<size_t>(primitive.material)];

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -608,6 +608,8 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     auto materialInfo = getDefaultMaterialInfo();
 #pragma GCC diagnostic pop
+#else
+    auto materialInfo = getDefaultMaterialInfo();
 #endif
 
     const auto& material = model.materials[static_cast<size_t>(primitive.material)];

--- a/src/core/src/GltfUtil.cpp
+++ b/src/core/src/GltfUtil.cpp
@@ -604,6 +604,9 @@ MaterialInfo getMaterialInfo(const CesiumGltf::Model& model, const CesiumGltf::M
 
     auto materialInfo = getDefaultMaterialInfo();
 
+    // This line shouldn't be needed, but gcc 11.2.0 complains about uninitialized members
+    materialInfo.baseColorTexture = std::nullopt;
+
     const auto& material = model.materials[static_cast<size_t>(primitive.material)];
 
     materialInfo.alphaCutoff = getAlphaCutoff(material);


### PR DESCRIPTION
Fixes a bug where global variables in `FabricMaterial.cpp` were being initialized before dependent global variables in `GltfUtil.cpp`. 

Since the order of global variable initialization across translation units is undefined, the quick fix was to remove those global variables from `FabricMaterial.cpp`.

This bug was recently introduced by https://github.com/CesiumGS/cesium-omniverse/pull/540, so no `CHANGES.md` update required here.