### PR TITLE
Cleanup prim creation in FabricMaterial.cpp

### DIFF
--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -118,6 +118,43 @@ template <typename T, typename U> T defaultValue(const std::optional<U>& optiona
     return optional.has_value() ? static_cast<T>(optional.value()) : defaultValue;
 }
 
+void createAttributes(
+    omni::fabric::StageReaderWriter& srw,
+    const omni::fabric::Path& path,
+    FabricAttributesBuilder& attributes,
+    const omni::fabric::Token& subidentifier) {
+
+    // clang-format off
+    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
+    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
+    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
+    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
+    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    attributes.addAttribute(FabricTypes::_paramColorSpace, FabricTokens::_paramColorSpace);
+    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
+    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
+    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
+    // clang-format on
+
+    attributes.createAttributes(path);
+
+    // clang-format off
+    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(path, FabricTokens::inputs_excludeFromWhiteMode);
+    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_implementationSource);
+    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(path, FabricTokens::info_mdl_sourceAsset);
+    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_mdl_sourceAsset_subIdentifier);
+    // clang-format on
+
+    srw.setArrayAttributeSize(path, FabricTokens::_paramColorSpace, 0);
+    srw.setArrayAttributeSize(path, FabricTokens::_sdrMetadata, 0);
+
+    *inputsExcludeFromWhiteModeFabric = false;
+    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
+    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
+    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
+    *infoMdlSourceAssetSubIdentifierFabric = subidentifier;
+}
+
 } // namespace
 
 FabricMaterial::FabricMaterial(
@@ -341,7 +378,6 @@ void FabricMaterial::createShader(const omni::fabric::Path& path) {
 
     FabricAttributesBuilder attributes;
 
-    // clang-format off
     attributes.addAttribute(FabricTypes::inputs_tile_color, FabricTokens::inputs_tile_color);
     attributes.addAttribute(FabricTypes::inputs_alpha_cutoff, FabricTokens::inputs_alpha_cutoff);
     attributes.addAttribute(FabricTypes::inputs_alpha_mode, FabricTokens::inputs_alpha_mode);
@@ -350,34 +386,8 @@ void FabricMaterial::createShader(const omni::fabric::Path& path) {
     attributes.addAttribute(FabricTypes::inputs_emissive_factor, FabricTokens::inputs_emissive_factor);
     attributes.addAttribute(FabricTypes::inputs_metallic_factor, FabricTokens::inputs_metallic_factor);
     attributes.addAttribute(FabricTypes::inputs_roughness_factor, FabricTokens::inputs_roughness_factor);
-    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
-    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
-    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    attributes.addAttribute(FabricTypes::_paramColorSpace, FabricTokens::_paramColorSpace);
-    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
-    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
-    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
-    // clang-format on
 
-    attributes.createAttributes(path);
-
-    srw.setArrayAttributeSize(path, FabricTokens::_paramColorSpace, 0);
-    srw.setArrayAttributeSize(path, FabricTokens::_sdrMetadata, 0);
-
-    // clang-format off
-    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(path, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_implementationSource);
-    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(path, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    // clang-format on
-
-    *inputsExcludeFromWhiteModeFabric = false;
-    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
-    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
-    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
-    *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_internal_material;
+    createAttributes(srw, path, attributes, FabricTokens::cesium_internal_material);
 }
 
 void FabricMaterial::createTextureCommon(
@@ -390,7 +400,6 @@ void FabricMaterial::createTextureCommon(
 
     FabricAttributesBuilder attributes;
 
-    // clang-format off
     attributes.addAttribute(FabricTypes::inputs_offset, FabricTokens::inputs_offset);
     attributes.addAttribute(FabricTypes::inputs_rotation, FabricTokens::inputs_rotation);
     attributes.addAttribute(FabricTypes::inputs_scale, FabricTokens::inputs_scale);
@@ -398,40 +407,16 @@ void FabricMaterial::createTextureCommon(
     attributes.addAttribute(FabricTypes::inputs_texture, FabricTokens::inputs_texture);
     attributes.addAttribute(FabricTypes::inputs_wrap_s, FabricTokens::inputs_wrap_s);
     attributes.addAttribute(FabricTypes::inputs_wrap_t, FabricTokens::inputs_wrap_t);
-    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
-    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
-    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    attributes.addAttribute(FabricTypes::_paramColorSpace, FabricTokens::_paramColorSpace);
-    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
-    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
-    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
-    // clang-format on
 
     for (const auto& additionalAttribute : additionalAttributes) {
         attributes.addAttribute(additionalAttribute.first, additionalAttribute.second);
     }
 
-    attributes.createAttributes(path);
+    createAttributes(srw, path, attributes, subIdentifier);
 
     // _paramColorSpace is an array of pairs: [texture_parameter_token, color_space_enum], [texture_parameter_token, color_space_enum], ...
     srw.setArrayAttributeSize(path, FabricTokens::_paramColorSpace, 2);
-    srw.setArrayAttributeSize(path, FabricTokens::_sdrMetadata, 0);
-
-    // clang-format off
-    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(path, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_implementationSource);
-    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(path, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_mdl_sourceAsset_subIdentifier);
     auto paramColorSpaceFabric = srw.getArrayAttributeWr<omni::fabric::TokenC>(path, FabricTokens::_paramColorSpace);
-    // clang-format on
-
-    *inputsExcludeFromWhiteModeFabric = false;
-    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
-    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
-    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
-    *infoMdlSourceAssetSubIdentifierFabric = subIdentifier;
     paramColorSpaceFabric[0] = FabricTokens::inputs_texture;
     paramColorSpaceFabric[1] = FabricTokens::_auto;
 }
@@ -454,34 +439,12 @@ void FabricMaterial::createImageryLayerResolver(const omni::fabric::Path& path, 
 
     FabricAttributesBuilder attributes;
 
-    // clang-format off
     attributes.addAttribute(FabricTypes::inputs_imagery_layers_count, FabricTokens::inputs_imagery_layers_count);
-    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
-    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
-    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
-    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
-    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
-    // clang-format on
 
-    attributes.createAttributes(path);
+    createAttributes(srw, path, attributes, FabricTokens::cesium_internal_imagery_layer_resolver);
 
-    // clang-format off
     auto imageryLayerCountFabric = srw.getAttributeWr<int>(path, FabricTokens::inputs_imagery_layers_count);
-    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(path, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_implementationSource);
-    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(path, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    // clang-format on
-
     *imageryLayerCountFabric = static_cast<int>(imageryLayerCount);
-    *inputsExcludeFromWhiteModeFabric = false;
-    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
-    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
-    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
-    *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_internal_imagery_layer_resolver;
 }
 
 void FabricMaterial::createFeatureIdIndex(const omni::fabric::Path& path) {
@@ -495,33 +458,10 @@ void FabricMaterial::createFeatureIdAttribute(const omni::fabric::Path& path) {
 
     FabricAttributesBuilder attributes;
 
-    // clang-format off
     attributes.addAttribute(FabricTypes::inputs_feature_id_primvar_name, FabricTokens::inputs_feature_id_primvar_name);
     attributes.addAttribute(FabricTypes::inputs_null_feature_id, FabricTokens::inputs_null_feature_id);
-    attributes.addAttribute(FabricTypes::inputs_excludeFromWhiteMode, FabricTokens::inputs_excludeFromWhiteMode);
-    attributes.addAttribute(FabricTypes::outputs_out, FabricTokens::outputs_out);
-    attributes.addAttribute(FabricTypes::info_implementationSource, FabricTokens::info_implementationSource);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset, FabricTokens::info_mdl_sourceAsset);
-    attributes.addAttribute(FabricTypes::info_mdl_sourceAsset_subIdentifier, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    attributes.addAttribute(FabricTypes::_sdrMetadata, FabricTokens::_sdrMetadata);
-    attributes.addAttribute(FabricTypes::Shader, FabricTokens::Shader);
-    attributes.addAttribute(FabricTypes::_cesium_tilesetId, FabricTokens::_cesium_tilesetId);
-    // clang-format on
 
-    attributes.createAttributes(path);
-
-    // clang-format off
-    auto inputsExcludeFromWhiteModeFabric = srw.getAttributeWr<bool>(path, FabricTokens::inputs_excludeFromWhiteMode);
-    auto infoImplementationSourceFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_implementationSource);
-    auto infoMdlSourceAssetFabric = srw.getAttributeWr<omni::fabric::AssetPath>(path, FabricTokens::info_mdl_sourceAsset);
-    auto infoMdlSourceAssetSubIdentifierFabric = srw.getAttributeWr<omni::fabric::TokenC>(path, FabricTokens::info_mdl_sourceAsset_subIdentifier);
-    // clang-format on
-
-    *inputsExcludeFromWhiteModeFabric = false;
-    *infoImplementationSourceFabric = FabricTokens::sourceAsset;
-    infoMdlSourceAssetFabric->assetPath = Context::instance().getCesiumMdlPathToken();
-    infoMdlSourceAssetFabric->resolvedPath = pxr::TfToken();
-    *infoMdlSourceAssetSubIdentifierFabric = FabricTokens::cesium_internal_feature_id_attribute_lookup;
+    createAttributes(srw, path, attributes, FabricTokens::cesium_internal_feature_id_attribute_lookup);
 }
 
 void FabricMaterial::createFeatureIdTexture(const omni::fabric::Path& path) {


### PR DESCRIPTION
Created a helper function `createAttributes` that moves a lot of the common attribute initialization code into a single place.