### PR TITLE
Pinning mypy to version 1.6.1

### DIFF
--- a/genStubs.bat
+++ b/genStubs.bat
@@ -23,7 +23,7 @@ set CESIUM_TESTS_STUB_PATH=%PROJECT_ROOT%\exts\cesium.omniverse.cpp.tests\cesium
 set PYTHONPATH=%NVIDIA_USD_PYTHON_LIBS%;%PYTHONPATH%
 
 echo "Ensuring mypy is installed"
-%NVIDIA_PYTHON_EXECUTABLE% -m pip install mypy
+%NVIDIA_PYTHON_EXECUTABLE% -m pip install mypy==1.6.1
 
 echo "Building lib files flat in temp dir"
 cmake -B build

--- a/genStubs.sh
+++ b/genStubs.sh
@@ -23,7 +23,7 @@ CESIUM_TESTS_STUB_PATH="$PROJECT_ROOT/exts/cesium.omniverse.cpp.tests/cesium/omn
 export PYTHONPATH="$NVIDIA_USD_PYTHON_LIBS:$PYTHONPATH"
 
 echo "Ensuring mypy is installed"
-$NVIDIA_PYTHON_EXECUTABLE -m pip install mypy
+$NVIDIA_PYTHON_EXECUTABLE -m pip install mypy==1.6.1
 
 echo "Building lib files flat in temp dir"
 cmake -B build


### PR DESCRIPTION
Mypy just released a new version of the stub generator which has some [major regressions since mypy 1.6.1](https://github.com/python/mypy/issues/16486). In order to fix this, and prevent this from happening again, we should pin ourselves to version 1.6.1 which we know works. I tested this out again and verified that our genStubs script works correctly with the pinned version.