### PR TITLE
Remove harcoded limit for feature id sets and texcoord sets

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -17,6 +17,10 @@ annotation annotation_not_connectable();
 
 export const auto DEFAULT_NULL_FEATURE_ID = -1;
 
+
+// Should match MAX_IMAGERY_LAYERS_COUNT in FabricMaterial.cpp
+export const auto MAX_IMAGERY_LAYERS_COUNT = 16;
+
 export enum up_axis_mode {
     Y,
     Z
@@ -492,7 +496,7 @@ export gltf_texture_lookup_value cesium_internal_imagery_layer_resolver(
     gltf_texture_lookup_value imagery_layer_15 = gltf_texture_lookup_value()
 ) [[ anno::hidden() ]] {
     // The array length should match MAX_IMAGERY_LAYERS_COUNT in Tokens.h
-    gltf_texture_lookup_value[16] imagery_layers(
+    gltf_texture_lookup_value[MAX_IMAGERY_LAYERS_COUNT] imagery_layers(
         imagery_layer_0,
         imagery_layer_1,
         imagery_layer_2,

--- a/src/core/include/cesium/omniverse/Tokens.h
+++ b/src/core/include/cesium/omniverse/Tokens.h
@@ -29,33 +29,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (extent) \
     (faceVertexCounts) \
     (faceVertexIndices) \
-    (feature_id_0) \
-    (feature_id_1) \
-    (feature_id_2) \
-    (feature_id_3) \
-    (feature_id_4) \
-    (feature_id_5) \
-    (feature_id_6) \
-    (feature_id_7) \
-    (feature_id_8) \
-    (feature_id_9) \
     (imagery_layer) \
-    (imagery_layer_0) \
-    (imagery_layer_1) \
-    (imagery_layer_2) \
-    (imagery_layer_3) \
-    (imagery_layer_4) \
-    (imagery_layer_5) \
-    (imagery_layer_6) \
-    (imagery_layer_7) \
-    (imagery_layer_8) \
-    (imagery_layer_9) \
-    (imagery_layer_10) \
-    (imagery_layer_11) \
-    (imagery_layer_12) \
-    (imagery_layer_13) \
-    (imagery_layer_14) \
-    (imagery_layer_15) \
     (imagery_layer_resolver) \
     (Material) \
     (Mesh) \
@@ -105,22 +79,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((inputs_texture, "inputs:texture")) \
     ((inputs_tile_color, "inputs:tile_color")) \
     ((inputs_imagery_layer, "inputs:imagery_layer")) \
-    ((inputs_imagery_layer_0, "inputs:imagery_layer_0")) \
-    ((inputs_imagery_layer_1, "inputs:imagery_layer_1")) \
-    ((inputs_imagery_layer_2, "inputs:imagery_layer_2")) \
-    ((inputs_imagery_layer_3, "inputs:imagery_layer_3")) \
-    ((inputs_imagery_layer_4, "inputs:imagery_layer_4")) \
-    ((inputs_imagery_layer_5, "inputs:imagery_layer_5")) \
-    ((inputs_imagery_layer_6, "inputs:imagery_layer_6")) \
-    ((inputs_imagery_layer_7, "inputs:imagery_layer_7")) \
-    ((inputs_imagery_layer_8, "inputs:imagery_layer_8")) \
-    ((inputs_imagery_layer_9, "inputs:imagery_layer_9")) \
-    ((inputs_imagery_layer_10, "inputs:imagery_layer_10")) \
-    ((inputs_imagery_layer_11, "inputs:imagery_layer_11")) \
-    ((inputs_imagery_layer_12, "inputs:imagery_layer_12")) \
-    ((inputs_imagery_layer_13, "inputs:imagery_layer_13")) \
-    ((inputs_imagery_layer_14, "inputs:imagery_layer_14")) \
-    ((inputs_imagery_layer_15, "inputs:imagery_layer_15")) \
     ((inputs_imagery_layers_count, "inputs:imagery_layers_count")) \
     ((inputs_imagery_layer_index, "inputs:imagery_layer_index")) \
     ((inputs_wrap_s, "inputs:wrap_s")) \
@@ -133,16 +91,6 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_displayColor, "primvars:displayColor")) \
     ((primvars_displayOpacity, "primvars:displayOpacity")) \
     ((primvars_normals, "primvars:normals")) \
-    ((primvars_st_0, "primvars:st_0")) \
-    ((primvars_st_1, "primvars:st_1")) \
-    ((primvars_st_2, "primvars:st_2")) \
-    ((primvars_st_3, "primvars:st_3")) \
-    ((primvars_st_4, "primvars:st_4")) \
-    ((primvars_st_5, "primvars:st_5")) \
-    ((primvars_st_6, "primvars:st_6")) \
-    ((primvars_st_7, "primvars:st_7")) \
-    ((primvars_st_8, "primvars:st_8")) \
-    ((primvars_st_9, "primvars:st_9")) \
     ((primvars_COLOR_0, "primvars:COLOR_0")) \
     ((primvars_vertexId, "primvars:vertexId")) \
     ((xformOp_transform_cesium, "xformOp:transform:cesium"))
@@ -176,73 +124,10 @@ __pragma(warning(pop))
 namespace cesium::omniverse::FabricTokens {
 FABRIC_DECLARE_TOKENS(USD_TOKENS);
 
-const uint64_t MAX_PRIMVAR_ST_COUNT = 10;
-const uint64_t MAX_IMAGERY_LAYERS_COUNT = 16;
-const uint64_t MAX_FEATURE_ID_COUNT = 10;
-
-const std::array<const omni::fabric::TokenC, MAX_PRIMVAR_ST_COUNT> primvars_st_n = {{
-    primvars_st_0,
-    primvars_st_1,
-    primvars_st_2,
-    primvars_st_3,
-    primvars_st_4,
-    primvars_st_5,
-    primvars_st_6,
-    primvars_st_7,
-    primvars_st_8,
-    primvars_st_9,
-}};
-
-const std::array<const omni::fabric::TokenC, MAX_FEATURE_ID_COUNT> feature_id_n = {{
-    feature_id_0,
-    feature_id_1,
-    feature_id_2,
-    feature_id_3,
-    feature_id_4,
-    feature_id_5,
-    feature_id_6,
-    feature_id_7,
-    feature_id_8,
-    feature_id_9,
-}};
-
-const std::array<const omni::fabric::TokenC, MAX_IMAGERY_LAYERS_COUNT> imagery_layer_n = {{
-    imagery_layer_0,
-    imagery_layer_1,
-    imagery_layer_2,
-    imagery_layer_3,
-    imagery_layer_4,
-    imagery_layer_5,
-    imagery_layer_6,
-    imagery_layer_7,
-    imagery_layer_8,
-    imagery_layer_9,
-    imagery_layer_10,
-    imagery_layer_11,
-    imagery_layer_12,
-    imagery_layer_13,
-    imagery_layer_14,
-    imagery_layer_15,
-}};
-
-const std::array<const omni::fabric::TokenC, MAX_IMAGERY_LAYERS_COUNT> inputs_imagery_layer_n = {{
-    inputs_imagery_layer_0,
-    inputs_imagery_layer_1,
-    inputs_imagery_layer_2,
-    inputs_imagery_layer_3,
-    inputs_imagery_layer_4,
-    inputs_imagery_layer_5,
-    inputs_imagery_layer_6,
-    inputs_imagery_layer_7,
-    inputs_imagery_layer_8,
-    inputs_imagery_layer_9,
-    inputs_imagery_layer_10,
-    inputs_imagery_layer_11,
-    inputs_imagery_layer_12,
-    inputs_imagery_layer_13,
-    inputs_imagery_layer_14,
-    inputs_imagery_layer_15,
-}};
+const omni::fabric::TokenC primvars_st_n(uint64_t index);
+const omni::fabric::TokenC imagery_layer_n(uint64_t index);
+const omni::fabric::TokenC inputs_imagery_layer_n(uint64_t index);
+const omni::fabric::TokenC feature_id_n(uint64_t index);
 
 }
 

--- a/src/core/src/Tokens.cpp
+++ b/src/core/src/Tokens.cpp
@@ -1,5 +1,7 @@
 #include "cesium/omniverse/Tokens.h"
 
+#include <spdlog/fmt/fmt.h>
+
 // clang-format off
 namespace pxr {
 
@@ -17,8 +19,51 @@ __pragma(warning(pop))
 #endif
 
 }
+// clang-format on
 
 namespace cesium::omniverse::FabricTokens {
 FABRIC_DEFINE_TOKENS(USD_TOKENS);
+
+namespace {
+std::mutex tokenMutex;
+std::vector<omni::fabric::Token> primvars_st_tokens;
+std::vector<omni::fabric::Token> imagery_layer_tokens;
+std::vector<omni::fabric::Token> inputs_imagery_layer_tokens;
+std::vector<omni::fabric::Token> feature_id_tokens;
+
+const omni::fabric::TokenC getToken(std::vector<omni::fabric::Token>& tokens, uint64_t index, std::string_view prefix) {
+    const auto lock = std::scoped_lock<std::mutex>(tokenMutex);
+
+    const auto size = index + 1;
+    if (size > tokens.size()) {
+        tokens.resize(size);
+    }
+
+    auto& token = tokens[index];
+
+    if (token.asTokenC() == omni::fabric::kUninitializedToken) {
+        const auto tokenStr = fmt::format("{}_{}", prefix, index);
+        token = omni::fabric::Token(tokenStr.c_str());
+    }
+
+    return token.asTokenC();
 }
-// clang-format on
+} // namespace
+
+const omni::fabric::TokenC primvars_st_n(uint64_t index) {
+    return getToken(primvars_st_tokens, index, "primvars:st");
+}
+
+const omni::fabric::TokenC imagery_layer_n(uint64_t index) {
+    return getToken(imagery_layer_tokens, index, "imagery_layer");
+}
+
+const omni::fabric::TokenC inputs_imagery_layer_n(uint64_t index) {
+    return getToken(inputs_imagery_layer_tokens, index, "inputs:imagery_layer");
+}
+
+const omni::fabric::TokenC feature_id_n(uint64_t index) {
+    return getToken(feature_id_tokens, index, "feature_id");
+}
+
+} // namespace cesium::omniverse::FabricTokens


### PR DESCRIPTION
Merge https://github.com/CesiumGS/cesium-omniverse/pull/545 first

Addresses https://github.com/CesiumGS/cesium-omniverse/pull/541#discussion_r1388564579

Removed harcoded limit for feature id sets and texcoord sets. Imagery layers still have a maximum of 16 but the tokens are no longer hardcoded.

Instead tokens are created on demand and cached for later use.