### PR TITLE
Refactored app level settings to prep for multi-server

### DIFF
--- a/src/core/include/cesium/omniverse/CesiumIonSession.h
+++ b/src/core/include/cesium/omniverse/CesiumIonSession.h
@@ -16,7 +16,8 @@ class CesiumIonSession {
   public:
     CesiumIonSession(
         CesiumAsync::AsyncSystem& asyncSystem,
-        std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor);
+        std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor,
+        std::string ionApiUrl);
 
     [[nodiscard]] const std::shared_ptr<CesiumAsync::IAssetAccessor>& getAssetAccessor() const {
         return this->_pAssetAccessor;
@@ -97,20 +98,6 @@ class CesiumIonSession {
     [[nodiscard]] CesiumAsync::Future<CesiumIonClient::Response<CesiumIonClient::Token>>
     findToken(const std::string& token) const;
 
-    /**
-     * Gets the project default token.
-     *
-     * If the project default token exists in the signed-in user's account, full
-     * token details will be included. Otherwise, only the token value itself
-     * (i.e. the `token` property`) will be included, and it may or may not be
-     * valid. In the latter case, the `id` property will be an empty string.
-     *
-     * @return A future that resolves to the project default token.
-     */
-    CesiumAsync::SharedFuture<CesiumIonClient::Token> getProjectDefaultTokenDetails();
-
-    void invalidateProjectDefaultTokenDetails();
-
   private:
     CesiumAsync::AsyncSystem _asyncSystem;
     std::shared_ptr<CesiumAsync::IAssetAccessor> _pAssetAccessor;
@@ -133,5 +120,6 @@ class CesiumIonSession {
     bool _loadTokensQueued;
 
     std::string _authorizeUrl;
+    std::string _ionApiUrl;
 };
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/SettingsWrapper.h
+++ b/src/core/include/cesium/omniverse/SettingsWrapper.h
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace cesium::omniverse::Settings {
 
-std::string getAccessToken();
-void setAccessToken(const std::string& accessToken);
-std::string getDefaultAccessToken();
-void setDefaultAccessToken(const std::string& accessToken);
+struct UserAccessToken {
+    std::string ionUrl;
+    std::string token;
+};
+
+std::string getIonServerSettingPath(const size_t index);
+std::string getUserAccessTokenSettingPath(const size_t index);
+const std::vector<UserAccessToken> getAccessTokens();
+void setAccessTokens(const std::vector<UserAccessToken>& accessTokens);
+void clearTokens();
 
 } // namespace cesium::omniverse::Settings

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -96,7 +96,7 @@ void Context::initialize(int64_t contextId, const std::filesystem::path& cesiumE
         });
 
     CesiumAsync::AsyncSystem asyncSystem{_taskProcessor};
-    _session = std::make_shared<CesiumIonSession>(asyncSystem, _httpAssetAccessor);
+    _session = std::make_shared<CesiumIonSession>(asyncSystem, _httpAssetAccessor, "https://api.cesium.com/");
     _session->resume();
 
     Cesium3DTilesSelection::registerAllTileContentTypes();

--- a/src/core/src/SettingsWrapper.cpp
+++ b/src/core/src/SettingsWrapper.cpp
@@ -2,35 +2,77 @@
 
 #include <carb/InterfaceUtils.h>
 #include <carb/settings/ISettings.h>
+#include <spdlog/fmt/bundled/format.h>
+
+#include <optional>
 
 namespace cesium::omniverse::Settings {
 
 namespace {
+const size_t MAX_SESSIONS = 10;
 const char* PERSISTENT_SETTINGS_PREFIX = "/persistent";
-const char* USER_ACCESS_TOKEN_PATH = "/exts/cesium.omniverse/userAccessToken";
-const char* DEFAULT_ACCESS_TOKEN_PATH = "/exts/cesium.omniverse/defaultAccessToken";
+const char* SESSION_ION_SERVER_URL_BASE = "/exts/cesium.omniverse/sessions/session{}/ionServerUrl";
+const char* SESSION_USER_ACCESS_TOKEN_BASE = "/exts/cesium.omniverse/sessions/session{}/userAccessToken";
 } // namespace
 
-std::string getAccessToken() {
-    auto settings = carb::getCachedInterface<carb::settings::ISettings>();
-    auto key = std::string(PERSISTENT_SETTINGS_PREFIX).append(USER_ACCESS_TOKEN_PATH);
-    return {settings->getStringBuffer(key.c_str())};
+std::string getIonServerSettingPath(const size_t index) {
+    return std::string(PERSISTENT_SETTINGS_PREFIX).append(fmt::format(SESSION_ION_SERVER_URL_BASE, index));
 }
 
-void setAccessToken(const std::string& accessToken) {
-    auto settings = carb::getCachedInterface<carb::settings::ISettings>();
-    auto key = std::string(PERSISTENT_SETTINGS_PREFIX).append(USER_ACCESS_TOKEN_PATH);
-    settings->set(key.c_str(), accessToken.c_str());
+std::string getUserAccessTokenSettingPath(const size_t index) {
+    return std::string(PERSISTENT_SETTINGS_PREFIX).append(fmt::format(SESSION_USER_ACCESS_TOKEN_BASE, index));
 }
 
-std::string getDefaultAccessToken() {
+const std::vector<UserAccessToken> getAccessTokens() {
     auto settings = carb::getCachedInterface<carb::settings::ISettings>();
-    return {settings->getStringBuffer(DEFAULT_ACCESS_TOKEN_PATH)};
+
+    std::vector<UserAccessToken> tokens;
+    tokens.reserve(MAX_SESSIONS);
+
+    // I hate everything about this. -Adam
+    for (size_t i = 0; i < MAX_SESSIONS; ++i) {
+        const auto serverKey = getIonServerSettingPath(i);
+        const auto ionUrlSetting = settings->getStringBuffer(serverKey.c_str());
+
+        if (ionUrlSetting != nullptr) {
+            const auto tokenKey = getUserAccessTokenSettingPath(i);
+            const auto uatSetting = settings->getStringBuffer(tokenKey.c_str());
+
+            UserAccessToken token;
+            token.ionUrl = ionUrlSetting;
+            token.token = uatSetting;
+
+            tokens.emplace_back(token);
+        }
+    }
+
+    return tokens;
 }
 
-void setDefaultAccessToken(const std::string& accessToken) {
+void setAccessTokens(const std::vector<UserAccessToken>& accessTokens) {
     auto settings = carb::getCachedInterface<carb::settings::ISettings>();
-    settings->set(DEFAULT_ACCESS_TOKEN_PATH, accessToken.c_str());
+
+    clearTokens();
+
+    for (size_t i = 0; i < accessTokens.size(); ++i) {
+        const auto serverKey = getIonServerSettingPath(i);
+        const auto tokenKey = getUserAccessTokenSettingPath(i);
+
+        settings->set(serverKey.c_str(), accessTokens[i].ionUrl.c_str());
+        settings->set(tokenKey.c_str(), accessTokens[i].token.c_str());
+    }
+}
+
+void clearTokens() {
+    auto settings = carb::getCachedInterface<carb::settings::ISettings>();
+
+    for (size_t i = 0; i < MAX_SESSIONS; ++i) {
+        const auto serverKey = getIonServerSettingPath(i);
+        const auto tokenKey = getUserAccessTokenSettingPath(i);
+
+        settings->destroyItem(serverKey.c_str());
+        settings->destroyItem(tokenKey.c_str());
+    }
 }
 
 } // namespace cesium::omniverse::Settings


### PR DESCRIPTION
Refactors the application level settings to prepare for supporting multiple ion server sessions. Also cleans up some unused code.