### PR TITLE
Fix texture parameter warnings

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -1469,7 +1469,25 @@ export float4 cesium_internal_property_table_float4_lookup(
     return finalize_float4(raw_value, has_no_data, no_data, default_value, offset, scale);
 }
 
-export gltf_texture_lookup_value cesium_internal_texture_lookup(*) [[ anno::hidden() ]] = gltf_texture_lookup();
+export gltf_texture_lookup_value cesium_internal_texture_lookup(
+    uniform texture_2d texture,
+    uniform int tex_coord_index,
+    uniform float2 tex_coord_offset,
+    uniform float tex_coord_rotation,
+    uniform float2 tex_coord_scale,
+    uniform gltf_wrapping_mode wrap_s,
+    uniform gltf_wrapping_mode wrap_t
+) [[ anno::hidden() ]] {
+    return gltf_texture_lookup(
+        texture: texture,
+        tex_coord_index: tex_coord_index,
+        offset: tex_coord_offset,
+        rotation: tex_coord_rotation,
+        scale: tex_coord_scale,
+        wrap_s: wrap_s,
+        wrap_t: wrap_t
+    );
+}
 
 export gltf_texture_lookup_value cesium_internal_imagery_layer_lookup(
     uniform texture_2d texture,


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/CesiumGS/cesium-omniverse/pull/553 where thousands of warnings would get printed to the console when loading textured tilesets due to parameter names prefixed with `tex_coord_` not being recognized by `gltf_texture_lookup`.

```
2023-11-30 21:01:10 [103,962ms] [Warning] [omni.hydra] Parameter 'tex_coord_offset' of shade node 'usd::rtx_scope0::/fabric_material_pool_1_object_545/base_color_texture::::Z73file_3A::home::slilley::Code::Z33cesium_2Domniverse::exts::Z34cesium_2Eomniverse::mdl::cesium::cesium_internal_texture_lookup(texture_2d,int,float2,float,float2,::gltf::pbr::gltf_wrapping_mode,::gltf::pbr::gltf_wrapping_mode)((2153))' not available in the MDL representation.
2023-11-30 21:01:10 [103,962ms] [Warning] [omni.hydra] Parameter 'tex_coord_rotation' of shade node 'usd::rtx_scope0::/fabric_material_pool_1_object_545/base_color_texture::::Z73file_3A::home::slilley::Code::Z33cesium_2Domniverse::exts::Z34cesium_2Eomniverse::mdl::cesium::cesium_internal_texture_lookup(texture_2d,int,float2,float,float2,::gltf::pbr::gltf_wrapping_mode,::gltf::pbr::gltf_wrapping_mode)((2153))' not available in the MDL representation.
```

The fix is pretty simple, just rewire the parameter names in `cesium_internal_texture_lookup`. `cesium_internal_imagery_layer_lookup` was already doing something like this.