### PR TITLE
Reduce number of metadata warnings

### DIFF
--- a/src/core/src/FabricMaterialDefinition.cpp
+++ b/src/core/src/FabricMaterialDefinition.cpp
@@ -23,6 +23,19 @@ std::vector<FeatureIdType> filterFeatureIdTypes(const FeaturesInfo& featuresInfo
 
     return featureIdTypes;
 }
+
+std::vector<MetadataUtil::PropertyDefinition> getStyleableProperties(
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const pxr::SdfPath& tilesetMaterialPath) {
+
+    if (tilesetMaterialPath.IsEmpty()) {
+        // Ignore properties if there's no tileset material
+        return {};
+    }
+
+    return MetadataUtil::getStyleableProperties(model, primitive);
+}
 } // namespace
 
 FabricMaterialDefinition::FabricMaterialDefinition(
@@ -38,7 +51,7 @@ FabricMaterialDefinition::FabricMaterialDefinition(
     , _featureIdTypes(filterFeatureIdTypes(featuresInfo, disableTextures))
     , _imageryLayerCount(disableTextures ? 0 : imageryLayerCount)
     , _tilesetMaterialPath(tilesetMaterialPath)
-    , _properties(MetadataUtil::getStyleableProperties(model, primitive)) {}
+    , _properties(getStyleableProperties(model, primitive, tilesetMaterialPath)) {}
 
 bool FabricMaterialDefinition::hasVertexColors() const {
     return _hasVertexColors;

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -77,7 +77,26 @@ std::vector<const CesiumGltf::ImageCesium*> getPropertyTextureImages(
         return {};
     }
 
+    if (fabricMesh.material->getMaterialDefinition().getProperties().empty()) {
+        return {};
+    }
+
     return MetadataUtil::getPropertyTextureImages(model, primitive);
+}
+
+std::unordered_map<uint64_t, uint64_t> getPropertyTextureIndexMapping(
+    const FabricMesh& fabricMesh,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::MeshPrimitive& primitive) {
+    if (fabricMesh.material == nullptr) {
+        return {};
+    }
+
+    if (fabricMesh.material->getMaterialDefinition().getProperties().empty()) {
+        return {};
+    }
+
+    return MetadataUtil::getPropertyTextureIndexMapping(model, primitive);
 }
 
 uint64_t getPropertyTableTextureCount(
@@ -85,6 +104,10 @@ uint64_t getPropertyTableTextureCount(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive) {
     if (fabricMesh.material == nullptr) {
+        return 0;
+    }
+
+    if (fabricMesh.material->getMaterialDefinition().getProperties().empty()) {
         return 0;
     }
 
@@ -96,6 +119,10 @@ std::vector<TextureData> encodePropertyTables(
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive) {
     if (fabricMesh.material == nullptr) {
+        return {};
+    }
+
+    if (fabricMesh.material->getMaterialDefinition().getProperties().empty()) {
         return {};
     }
 
@@ -227,7 +254,7 @@ std::vector<FabricMesh> acquireFabricMeshes(
         fabricMesh.featureIdTextureSetIndexMapping = getSetIndexMapping(featuresInfo, FeatureIdType::TEXTURE);
 
         // Map glTF texture index to property texture index
-        fabricMesh.propertyTextureIndexMapping = MetadataUtil::getPropertyTextureIndexMapping(model, primitive);
+        fabricMesh.propertyTextureIndexMapping = getPropertyTextureIndexMapping(fabricMesh, model, primitive);
     }
 
     return fabricMeshes;


### PR DESCRIPTION
Currently a warning is printed every time an unsupported metadata property is encountered. This happens for every tile in the tileset, so the number of warnings can add up.

This PR skips property processing unless you're using a tileset material. This should help when loading OSM buildings.

I have a more robust fix in mind, something like CesiumJS's `oneTimeWarning`, but I don't want to hold up the release any longer.