### PR TITLE
Add backwards compatibility for older projects created before CesiumIonServerPrim

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -467,3 +467,10 @@ class CesiumOmniverseExtension(omni.ext.IExt):
 
             data_prim: CesiumData = CesiumData.Get(stage, CESIUM_DATA_PRIM_PATH)
             data_prim.GetSelectedIonServerRel().AddTarget(path)
+
+            # For backwards compatibility. Add access token from CesiumData prim.
+            defaultAccessToken = data_prim.GetProjectDefaultIonAccessTokenAttr().Get()
+            defaultAccessTokenId = data_prim.GetProjectDefaultIonAccessTokenIdAttr().Get()
+
+            prim.GetProjectDefaultIonAccessTokenAttr().Set(defaultAccessToken)
+            prim.GetProjectDefaultIonAccessTokenIdAttr().Set(defaultAccessTokenId)


### PR DESCRIPTION
* Transfers the default access token from the `/Cesium` prim to the `/CesiumServers/IonOfficial` prim
* Binds `/CesiumServers/IonOfficial` to any tilesets and imagery that don't already have server bindings on stage load