### PR TITLE
Clean up UsdNotificationHandler

### DIFF
--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -59,6 +59,7 @@ class Context {
     void destroy();
 
     std::shared_ptr<TaskProcessor> getTaskProcessor();
+    std::shared_ptr<CesiumAsync::AsyncSystem> getAsyncSystem();
     std::shared_ptr<HttpAssetAccessor> getHttpAssetAccessor();
     std::shared_ptr<CesiumUtility::CreditSystem> getCreditSystem();
     std::shared_ptr<spdlog::logger> getLogger();
@@ -123,18 +124,6 @@ class Context {
     void addGlobeAnchorToPrim(const pxr::SdfPath& path, double latitude, double longitude, double height);
 
   private:
-    void processPropertyChanged(const ChangedPrim& changedPrim);
-    void processCesiumDataChanged(const ChangedPrim& changedPrim);
-    void processCesiumTilesetChanged(const ChangedPrim& changedPrim);
-    void processCesiumImageryChanged(const ChangedPrim& changedPrim);
-    void processCesiumGeoreferenceChanged(const ChangedPrim& changedPrim);
-    void processCesiumGlobeAnchorChanged(const ChangedPrim& changedPrim);
-    void processCesiumIonServerChanged(const ChangedPrim& changedPrim);
-    void processUsdShaderChanged(const ChangedPrim& changedPrim);
-    void processPrimRemoved(const ChangedPrim& changedPrim);
-    void processPrimAdded(const ChangedPrim& changedPrim);
-    void processUsdNotifications();
-
     bool getDebugDisableMaterials() const;
     bool getDebugDisableTextures() const;
     bool getDebugDisableGeometryPool() const;

--- a/src/core/include/cesium/omniverse/LoggerSink.h
+++ b/src/core/include/cesium/omniverse/LoggerSink.h
@@ -12,7 +12,7 @@
 
 namespace cesium::omniverse {
 
-#define CESIUM_LOG_VERBOSE(...) Context::instance().getLogger()->verbose(__VA_ARGS__)
+#define CESIUM_LOG_TRACE(...) Context::instance().getLogger()->trace(__VA_ARGS__)
 #define CESIUM_LOG_INFO(...) Context::instance().getLogger()->info(__VA_ARGS__)
 #define CESIUM_LOG_WARN(...) Context::instance().getLogger()->warn(__VA_ARGS__)
 #define CESIUM_LOG_ERROR(...) Context::instance().getLogger()->error(__VA_ARGS__)

--- a/src/core/include/cesium/omniverse/UsdNotificationHandler.h
+++ b/src/core/include/cesium/omniverse/UsdNotificationHandler.h
@@ -7,9 +7,9 @@ namespace cesium::omniverse {
 class AssetRegistry;
 
 enum class ChangedPrimType {
+    CESIUM_DATA,
     CESIUM_TILESET,
     CESIUM_IMAGERY,
-    CESIUM_DATA,
     CESIUM_GEOREFERENCE,
     CESIUM_GLOBE_ANCHOR,
     CESIUM_ION_SERVER,
@@ -24,8 +24,8 @@ enum class ChangeType {
 };
 
 struct ChangedPrim {
-    pxr::SdfPath path;
-    pxr::TfToken propertyName;
+    pxr::SdfPath primPath;
+    std::vector<pxr::TfToken> properties;
     ChangedPrimType primType;
     ChangeType changeType;
 };
@@ -35,13 +35,19 @@ class UsdNotificationHandler final : public pxr::TfWeakBase {
     UsdNotificationHandler();
     ~UsdNotificationHandler();
 
-    std::vector<ChangedPrim> popChangedPrims();
+    void onStageLoaded();
+    void onUpdateFrame();
 
   private:
     void onObjectsChanged(const pxr::UsdNotice::ObjectsChanged& objectsChanged);
     void onPrimAdded(const pxr::SdfPath& path);
     void onPrimRemoved(const pxr::SdfPath& path);
     void onPropertyChanged(const pxr::SdfPath& path);
+
+    void insertAddedPrim(const pxr::SdfPath& primPath, ChangedPrimType primType);
+    void insertRemovedPrim(const pxr::SdfPath& primPath, ChangedPrimType primType);
+    void
+    insertPropertyChanged(const pxr::SdfPath& primPath, ChangedPrimType primType, const pxr::TfToken& propertyName);
 
     pxr::TfNotice::Key _noticeListenerKey;
     std::vector<ChangedPrim> _changedPrims;

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -113,6 +113,10 @@ std::shared_ptr<TaskProcessor> Context::getTaskProcessor() {
     return _taskProcessor;
 }
 
+std::shared_ptr<CesiumAsync::AsyncSystem> Context::getAsyncSystem() {
+    return _asyncSystem;
+}
+
 std::shared_ptr<HttpAssetAccessor> Context::getHttpAssetAccessor() {
     return _httpAssetAccessor;
 }
@@ -157,6 +161,8 @@ void Context::clearStage() {
 void Context::reloadStage() {
     clearStage();
 
+    _usdNotificationHandler.onStageLoaded();
+
     auto& fabricResourceManager = FabricResourceManager::getInstance();
     fabricResourceManager.setDisableMaterials(getDebugDisableMaterials());
     fabricResourceManager.setDisableTextures(getDebugDisableTextures());
@@ -168,60 +174,31 @@ void Context::reloadStage() {
     fabricResourceManager.setTexturePoolInitialCapacity(getDebugTexturePoolInitialCapacity());
     fabricResourceManager.setDebugRandomColors(getDebugRandomColors());
 
-    // Repopulate the asset registry. We need to do this manually because USD doesn't notify us about
-    // resynced paths when the stage is loaded.
-    const auto stage = UsdUtil::getUsdStage();
+    const auto defaultIonServerPath = pxr::SdfPath("/CesiumServers/IonOfficial");
 
-    // Add sessions first since they can be referenced by tilesets and imagery layers
-    for (const auto& prim : stage->Traverse()) {
-        const auto& path = prim.GetPath();
-        if (UsdUtil::isCesiumIonServer(path)) {
-            SessionRegistry::getInstance().addSession(*_asyncSystem, _httpAssetAccessor, path);
+    // For backwards compatibility. Add default ion server to tilesets without a server.
+    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
+    for (const auto& tileset : tilesets) {
+        const auto ionServerPath = tileset->getIonServerPath();
+        if (ionServerPath.IsEmpty()) {
+            const auto tilesetPrim = UsdUtil::getCesiumTileset(tileset->getPath());
+            tilesetPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
         }
     }
 
-    const auto defaultIonServerPath = pxr::SdfPath("/CesiumServers/IonOfficial");
-
-    for (const auto& prim : stage->Traverse()) {
-        const auto& path = prim.GetPath();
-        if (UsdUtil::isCesiumTileset(path)) {
-            AssetRegistry::getInstance().addTileset(path, UsdUtil::GEOREFERENCE_PATH);
-
-            // For backwards compatibility. Add default ion server to tilesets without a server.
-            const auto tileset = AssetRegistry::getInstance().getTilesetByPath(path);
-            if (tileset.has_value()) {
-                const auto ionServerPath = tileset.value()->getIonServerPath();
-                if (ionServerPath.IsEmpty()) {
-                    const auto tilesetPrim = UsdUtil::getCesiumTileset(path);
-                    tilesetPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
-                }
-            }
-        } else if (UsdUtil::isCesiumImagery(path)) {
-            AssetRegistry::getInstance().addImagery(path);
-
-            // For backwards compatibility. Add default ion server to imagery without a server.
-            const auto imagery = AssetRegistry::getInstance().getImageryByPath(path);
-            if (imagery.has_value()) {
-                const auto ionServerPath = imagery.value()->getIonServerPath();
-                if (ionServerPath.IsEmpty()) {
-                    const auto imageryPrim = UsdUtil::getCesiumImagery(path);
-                    imageryPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
-                }
-            }
-        } else if (UsdUtil::hasCesiumGlobeAnchor(path)) {
-            auto origin = UsdUtil::getCartographicOriginForAnchor(path);
-
-            // We probably need to do something else other than crash, but there really isn't more we can do in this case.
-            assert(origin.has_value());
-
-            auto anchorToFixed = UsdUtil::computeUsdLocalToEcefTransformForPrim(origin.value(), path);
-            GlobeAnchorRegistry::getInstance().createAnchor(path, anchorToFixed);
+    // For backwards compatibility. Add default ion server to imagery without a server.
+    const auto& imageries = AssetRegistry::getInstance().getAllImageries();
+    for (const auto& imagery : imageries) {
+        const auto ionServerPath = imagery->getIonServerPath();
+        if (ionServerPath.IsEmpty()) {
+            const auto imageryPrim = UsdUtil::getCesiumImagery(imagery->getPath());
+            imageryPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
         }
     }
 }
 
 void Context::onUpdateFrame(const std::vector<Viewport>& viewports) {
-    processUsdNotifications();
+    _usdNotificationHandler.onUpdateFrame();
 
     const auto georeferenceOrigin = Context::instance().getGeoreferenceOrigin();
     const auto ecefToUsdTransform = UsdUtil::computeEcefToUsdLocalTransform(georeferenceOrigin);
@@ -239,345 +216,6 @@ void Context::onUpdateFrame(const std::vector<Viewport>& viewports) {
     const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
     for (const auto& tileset : tilesets) {
         tileset->onUpdateFrame(viewports);
-    }
-}
-
-void Context::processPropertyChanged(const ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    switch (primType) {
-        case ChangedPrimType::CESIUM_DATA:
-            return processCesiumDataChanged(changedPrim);
-        case ChangedPrimType::CESIUM_TILESET:
-            return processCesiumTilesetChanged(changedPrim);
-        case ChangedPrimType::CESIUM_IMAGERY:
-            return processCesiumImageryChanged(changedPrim);
-        case ChangedPrimType::CESIUM_GEOREFERENCE:
-            return processCesiumGeoreferenceChanged(changedPrim);
-        case ChangedPrimType::CESIUM_GLOBE_ANCHOR:
-            return processCesiumGlobeAnchorChanged(changedPrim);
-        case ChangedPrimType::CESIUM_ION_SERVER:
-            return processCesiumIonServerChanged(changedPrim);
-        case ChangedPrimType::USD_SHADER:
-            return processUsdShaderChanged(changedPrim);
-        default:
-            return;
-    }
-}
-
-void Context::processCesiumDataChanged(const ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    if (name == pxr::CesiumTokens->cesiumDebugDisableMaterials ||
-        name == pxr::CesiumTokens->cesiumDebugDisableTextures ||
-        name == pxr::CesiumTokens->cesiumDebugDisableGeometryPool ||
-        name == pxr::CesiumTokens->cesiumDebugDisableMaterialPool ||
-        name == pxr::CesiumTokens->cesiumDebugDisableTexturePool ||
-        name == pxr::CesiumTokens->cesiumDebugGeometryPoolInitialCapacity ||
-        name == pxr::CesiumTokens->cesiumDebugMaterialPoolInitialCapacity ||
-        name == pxr::CesiumTokens->cesiumDebugTexturePoolInitialCapacity ||
-        name == pxr::CesiumTokens->cesiumDebugRandomColors) {
-        reloadStage();
-    }
-}
-
-void Context::processCesiumTilesetChanged(const ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(path);
-    if (!tileset.has_value()) {
-        return;
-    }
-
-    // clang-format off
-    if (name == pxr::CesiumTokens->cesiumMaximumScreenSpaceError ||
-        name == pxr::CesiumTokens->cesiumPreloadAncestors ||
-        name == pxr::CesiumTokens->cesiumPreloadSiblings ||
-        name == pxr::CesiumTokens->cesiumForbidHoles ||
-        name == pxr::CesiumTokens->cesiumMaximumSimultaneousTileLoads ||
-        name == pxr::CesiumTokens->cesiumMaximumCachedBytes ||
-        name == pxr::CesiumTokens->cesiumLoadingDescendantLimit ||
-        name == pxr::CesiumTokens->cesiumEnableFrustumCulling ||
-        name == pxr::CesiumTokens->cesiumEnableFogCulling ||
-        name == pxr::CesiumTokens->cesiumEnforceCulledScreenSpaceError ||
-        name == pxr::CesiumTokens->cesiumCulledScreenSpaceError ||
-        name == pxr::CesiumTokens->cesiumMainThreadLoadingTimeLimit) {
-        tileset.value()->updateTilesetOptionsFromProperties();
-    } else if (name == pxr::UsdTokens->primvars_displayColor ||
-        name == pxr::UsdTokens->primvars_displayOpacity) {
-        tileset.value()->updateDisplayColorAndOpacity();
-    } else if (name == pxr::CesiumTokens->cesiumSourceType ||
-        name == pxr::CesiumTokens->cesiumUrl ||
-        name == pxr::CesiumTokens->cesiumIonAssetId ||
-        name == pxr::CesiumTokens->cesiumIonAccessToken ||
-        name == pxr::CesiumTokens->cesiumIonServerBinding ||
-        name == pxr::CesiumTokens->cesiumSmoothNormals ||
-        name == pxr::CesiumTokens->cesiumShowCreditsOnScreen ||
-        name == pxr::UsdTokens->material_binding) {
-        tileset.value()->reload();
-    }
-    // clang-format on
-}
-
-void Context::processCesiumImageryChanged(const ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    const auto tilesetPath = path.GetParentPath();
-    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
-    if (!tileset.has_value()) {
-        return;
-    }
-
-    // clang-format off
-    if (name == pxr::CesiumTokens->cesiumIonAssetId ||
-        name == pxr::CesiumTokens->cesiumIonAccessToken ||
-        name == pxr::CesiumTokens->cesiumIonServerBinding ||
-        name == pxr::CesiumTokens->cesiumShowCreditsOnScreen) {
-        // Reload the tileset that the imagery is attached to
-        tileset.value()->reload();
-    }
-    // clang-format on
-
-    if (name == pxr::CesiumTokens->cesiumAlpha) {
-        const auto imageryLayerIndex = tileset.value()->findImageryLayerIndex(path);
-        if (imageryLayerIndex.has_value()) {
-            tileset.value()->updateImageryLayerAlpha(imageryLayerIndex.value());
-        }
-    }
-}
-
-void Context::processCesiumGeoreferenceChanged(const cesium::omniverse::ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    auto anchors = GlobeAnchorRegistry::getInstance().getAllAnchors();
-    for (const auto& globeAnchor : anchors) {
-        auto anchorApi = UsdUtil::getCesiumGlobeAnchor(globeAnchor->getPrimPath());
-
-        // We only want to update an anchor if we are updating it's related Georeference Prim.
-        if (path !=
-            UsdUtil::getAnchorGeoreferencePath(globeAnchor->getPrimPath()).value_or(pxr::SdfPath::EmptyPath())) {
-            continue;
-        }
-
-        auto origin = UsdUtil::getCartographicOriginForAnchor(globeAnchor->getPrimPath());
-        if (!origin.has_value()) {
-            continue;
-        }
-
-        GeospatialUtil::updateAnchorOrigin(origin.value(), anchorApi, globeAnchor);
-    }
-}
-
-void Context::processCesiumGlobeAnchorChanged(const cesium::omniverse::ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    auto globeAnchor = UsdUtil::getCesiumGlobeAnchor(path);
-    auto origin = UsdUtil::getCartographicOriginForAnchor(path);
-
-    if (!origin.has_value()) {
-        return;
-    }
-
-    bool detectTransformChanges;
-    globeAnchor.GetDetectTransformChangesAttr().Get(&detectTransformChanges);
-
-    if (detectTransformChanges && (name == pxr::CesiumTokens->cesiumAnchorDetectTransformChanges ||
-                                   name == pxr::UsdTokens->xformOp_transform_cesium)) {
-        GeospatialUtil::updateAnchorByUsdTransform(origin.value(), globeAnchor);
-
-        return;
-    }
-
-    if (name == pxr::CesiumTokens->cesiumAnchorGeographicCoordinates) {
-        GeospatialUtil::updateAnchorByLatLongHeight(origin.value(), globeAnchor);
-
-        return;
-    }
-
-    if (name == pxr::CesiumTokens->cesiumAnchorPosition || name == pxr::CesiumTokens->cesiumAnchorRotation ||
-        name == pxr::CesiumTokens->cesiumAnchorScale) {
-        GeospatialUtil::updateAnchorByFixedTransform(origin.value(), globeAnchor);
-
-        return;
-    }
-}
-
-namespace {
-void reloadIonServerAssets(const pxr::SdfPath& ionServerPath) {
-    // Reload tilesets that reference this ion server
-    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
-    for (const auto& tileset : tilesets) {
-        if (tileset->getIonServerPath() == ionServerPath) {
-            tileset->reload();
-        }
-    }
-
-    // Reload tilesets whose imagery layers reference this ion server
-    const auto& imageries = AssetRegistry::getInstance().getAllImageries();
-    for (const auto& imagery : imageries) {
-        if (imagery->getIonServerPath() == ionServerPath) {
-            const auto tilesetPath = imagery->getPath();
-            const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
-            if (tileset.has_value()) {
-                tileset.value()->reload();
-            }
-        }
-    }
-}
-} // namespace
-
-void Context::processCesiumIonServerChanged([[maybe_unused]] const cesium::omniverse::ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    if (name == pxr::CesiumTokens->cesiumIonServerUrl || name == pxr::CesiumTokens->cesiumIonServerApiUrl ||
-        name == pxr::CesiumTokens->cesiumIonServerApplicationId) {
-        // Reload the session
-        SessionRegistry::getInstance().removeSession(path);
-        SessionRegistry::getInstance().addSession(*_asyncSystem, _httpAssetAccessor, path);
-        // Reload assets that references this server
-        reloadIonServerAssets(path);
-    } else if (
-        name == pxr::CesiumTokens->cesiumProjectDefaultIonAccessToken ||
-        name == pxr::CesiumTokens->cesiumProjectDefaultIonAccessTokenId) {
-        // Reload assets that references this server, in particular those that don't specify an access token
-        reloadIonServerAssets(path);
-    }
-}
-
-void Context::processUsdShaderChanged(const cesium::omniverse::ChangedPrim& changedPrim) {
-    const auto& [path, name, primType, changeType] = changedPrim;
-
-    const auto shader = UsdUtil::getUsdShader(path);
-    const auto shaderPathFabric = FabricUtil::toFabricPath(path);
-    const auto materialPath = path.GetParentPath();
-    const auto materialPathFabric = FabricUtil::toFabricPath(materialPath);
-
-    if (!UsdUtil::isUsdMaterial(materialPath)) {
-        // Skip if parent path is not a material
-        return;
-    }
-
-    const auto inputNamespace = std::string("inputs:");
-
-    const auto& attributeName = name.GetString();
-
-    if (attributeName.rfind(inputNamespace) != 0) {
-        // Skip if changed attribute is not a shader input
-        return;
-    }
-
-    const auto inputName = pxr::TfToken(attributeName.substr(inputNamespace.size()));
-
-    auto shaderInput = shader.GetInput(inputName);
-    if (!shaderInput.IsDefined()) {
-        // Skip if changed attribute is not a shader input
-        return;
-    }
-
-    if (shaderInput.HasConnectedSource()) {
-        // Skip if shader input is connected to something else
-        return;
-    }
-
-    if (!FabricUtil::materialHasCesiumNodes(materialPathFabric)) {
-        // Simple materials can be skipped. We only need to handle materials that have been copied to each tile.
-        return;
-    }
-
-    if (!FabricUtil::isShaderConnectedToMaterial(materialPathFabric, shaderPathFabric)) {
-        // Skip if shader is not connected to the material
-        return;
-    }
-
-    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
-    for (const auto& tileset : tilesets) {
-        if (tileset->getMaterialPath() == materialPath) {
-            tileset->updateShaderInput(path, name);
-        }
-    }
-
-    FabricResourceManager::getInstance().updateShaderInput(materialPath, path, name);
-}
-
-void Context::processPrimRemoved(const ChangedPrim& changedPrim) {
-    switch (changedPrim.primType) {
-        case ChangedPrimType::CESIUM_TILESET: {
-            // Remove the tileset from the asset registry
-            const auto tilesetPath = changedPrim.path;
-            AssetRegistry::getInstance().removeTileset(changedPrim.path);
-        } break;
-        case ChangedPrimType::CESIUM_IMAGERY: {
-            // Remove the imagery from the asset registry and reload the tileset that the imagery was attached to
-            const auto imageryPath = changedPrim.path;
-            const auto tilesetPath = changedPrim.path.GetParentPath();
-            AssetRegistry::getInstance().removeImagery(imageryPath);
-            reloadTileset(tilesetPath);
-        } break;
-        case ChangedPrimType::CESIUM_GLOBE_ANCHOR: {
-            if (!GlobeAnchorRegistry::getInstance().removeAnchor(changedPrim.path)) {
-                CESIUM_LOG_ERROR("Failed to remove anchor from registry: {}", changedPrim.path.GetString());
-            }
-        } break;
-        case ChangedPrimType::CESIUM_ION_SERVER: {
-            SessionRegistry::getInstance().removeSession(changedPrim.path);
-            reloadIonServerAssets(changedPrim.path);
-        } break;
-        case ChangedPrimType::CESIUM_GEOREFERENCE:
-        case ChangedPrimType::CESIUM_DATA:
-        case ChangedPrimType::USD_SHADER:
-        case ChangedPrimType::OTHER:
-            break;
-    }
-}
-
-void Context::processPrimAdded(const ChangedPrim& changedPrim) {
-    if (changedPrim.primType == ChangedPrimType::CESIUM_TILESET) {
-        // Add the tileset to the asset registry
-        const auto tilesetPath = changedPrim.path;
-        AssetRegistry::getInstance().addTileset(tilesetPath, UsdUtil::GEOREFERENCE_PATH);
-    } else if (changedPrim.primType == ChangedPrimType::CESIUM_IMAGERY) {
-        // Add the imagery to the asset registry and reload the tileset that the imagery is attached to
-        const auto imageryPath = changedPrim.path;
-        const auto tilesetPath = changedPrim.path.GetParentPath();
-        AssetRegistry::getInstance().addImagery(imageryPath);
-        reloadTileset(tilesetPath);
-    } else if (changedPrim.primType == ChangedPrimType::CESIUM_GLOBE_ANCHOR) {
-        auto anchorApi = UsdUtil::getCesiumGlobeAnchor(changedPrim.path);
-        auto origin = UsdUtil::getCartographicOriginForAnchor(changedPrim.path);
-        assert(origin.has_value());
-        pxr::GfVec3d coordinates;
-        anchorApi.GetGeographicCoordinateAttr().Get(&coordinates);
-
-        if (coordinates == pxr::GfVec3d{0.0, 0.0, 10.0}) {
-            // Default geo coordinates. Place based on current USD position.
-            GeospatialUtil::updateAnchorByUsdTransform(origin.value(), anchorApi);
-        } else {
-            // Provided geo coordinates. Place at correct location.
-            GeospatialUtil::updateAnchorByLatLongHeight(origin.value(), anchorApi);
-        }
-    } else if (changedPrim.primType == ChangedPrimType::CESIUM_ION_SERVER) {
-        SessionRegistry::getInstance().addSession(*_asyncSystem, _httpAssetAccessor, changedPrim.path);
-        reloadIonServerAssets(changedPrim.path);
-    }
-}
-
-void Context::processUsdNotifications() {
-    const auto changedPrims = _usdNotificationHandler.popChangedPrims();
-
-    for (const auto& change : changedPrims) {
-        switch (change.changeType) {
-            case ChangeType::PROPERTY_CHANGED:
-                processPropertyChanged(change);
-                break;
-            case ChangeType::PRIM_REMOVED:
-                processPrimRemoved(change);
-                break;
-            case ChangeType::PRIM_ADDED:
-                processPrimAdded(change);
-                break;
-            default:
-                break;
-        }
     }
 }
 

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -183,6 +183,7 @@ void Context::reloadStage() {
         if (ionServerPath.IsEmpty()) {
             const auto tilesetPrim = UsdUtil::getCesiumTileset(tileset->getPath());
             tilesetPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
+            CESIUM_LOG_WARN("Tileset does not specify an ion server. Assigning to the default Cesium ion server.");
         }
     }
 
@@ -193,6 +194,7 @@ void Context::reloadStage() {
         if (ionServerPath.IsEmpty()) {
             const auto imageryPrim = UsdUtil::getCesiumImagery(imagery->getPath());
             imageryPrim.GetIonServerBindingRel().SetTargets({defaultIonServerPath});
+            CESIUM_LOG_WARN("Imagery does not specify an ion server. Assigning to the default Cesium ion server.");
         }
     }
 }

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -1,11 +1,16 @@
 #include "cesium/omniverse/UsdNotificationHandler.h"
 
 #include "cesium/omniverse/AssetRegistry.h"
+#include "cesium/omniverse/FabricResourceManager.h"
+#include "cesium/omniverse/FabricUtil.h"
+#include "cesium/omniverse/GeospatialUtil.h"
 #include "cesium/omniverse/GlobeAnchorRegistry.h"
 #include "cesium/omniverse/LoggerSink.h"
+#include "cesium/omniverse/OmniGlobeAnchor.h"
 #include "cesium/omniverse/OmniImagery.h"
 #include "cesium/omniverse/OmniTileset.h"
 #include "cesium/omniverse/SessionRegistry.h"
+#include "cesium/omniverse/Tokens.h"
 #include "cesium/omniverse/UsdUtil.h"
 
 #include <pxr/usd/usd/primRange.h>
@@ -13,6 +18,7 @@
 namespace cesium::omniverse {
 
 namespace {
+
 ChangedPrimType getType(const pxr::SdfPath& path) {
     if (UsdUtil::primExists(path)) {
         if (UsdUtil::isCesiumData(path)) {
@@ -31,7 +37,7 @@ ChangedPrimType getType(const pxr::SdfPath& path) {
             return ChangedPrimType::USD_SHADER;
         }
     } else {
-        // If the prim doesn't exist (because it was removed from the stage already) we can get the type from the asset registry
+        // If the prim doesn't exist, because it was removed from the stage already, we can get the type from the asset registry
         const auto assetType = AssetRegistry::getInstance().getAssetType(path);
 
         switch (assetType) {
@@ -43,7 +49,7 @@ ChangedPrimType getType(const pxr::SdfPath& path) {
                 break;
         }
 
-        // If we still haven't found the prim type, it could be a globe anchor, and we should check if it exists in the anchor registry
+        // If we still haven't found the prim type, it could be a globe anchor, and we should check if it exists in the globe anchor registry
         if (GlobeAnchorRegistry::getInstance().anchorExists(path)) {
             return ChangedPrimType::CESIUM_GLOBE_ANCHOR;
         }
@@ -71,6 +77,411 @@ bool inSubtree(const pxr::SdfPath& path, const pxr::SdfPath& descendantPath) {
     return false;
 }
 
+void reloadIonServerAssets(const pxr::SdfPath& ionServerPath) {
+    // Reload tilesets that reference this ion server
+    const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
+    for (const auto& tileset : tilesets) {
+        if (tileset->getIonServerPath() == ionServerPath) {
+            tileset->reload();
+        }
+    }
+
+    // Reload tilesets whose imagery layers reference this ion server
+    const auto& imageries = AssetRegistry::getInstance().getAllImageries();
+    for (const auto& imagery : imageries) {
+        if (imagery->getIonServerPath() == ionServerPath) {
+            const auto tilesetPath = imagery->getPath().GetParentPath();
+            const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
+            if (tileset.has_value()) {
+                tileset.value()->reload();
+            }
+        }
+    }
+}
+
+void processCesiumDataChanged(const std::vector<pxr::TfToken>& properties) {
+    auto reloadStage = false;
+
+    // No change tracking needed for
+    // * selectedIonServer
+    // * projectDefaultIonAccessToken (deprecated)
+    // * projectDefaultIonAccessTokenId (deprecated)
+
+    for (const auto& property : properties) {
+        if (property == pxr::CesiumTokens->cesiumDebugDisableMaterials ||
+            property == pxr::CesiumTokens->cesiumDebugDisableTextures ||
+            property == pxr::CesiumTokens->cesiumDebugDisableGeometryPool ||
+            property == pxr::CesiumTokens->cesiumDebugDisableMaterialPool ||
+            property == pxr::CesiumTokens->cesiumDebugDisableTexturePool ||
+            property == pxr::CesiumTokens->cesiumDebugGeometryPoolInitialCapacity ||
+            property == pxr::CesiumTokens->cesiumDebugMaterialPoolInitialCapacity ||
+            property == pxr::CesiumTokens->cesiumDebugTexturePoolInitialCapacity ||
+            property == pxr::CesiumTokens->cesiumDebugRandomColors ||
+            property == pxr::CesiumTokens->cesiumDebugDisableGeoreferencing) {
+            reloadStage = true;
+        }
+    }
+
+    if (reloadStage) {
+        Context::instance().reloadStage();
+    }
+}
+
+void processCesiumTilesetChanged(const pxr::SdfPath& tilesetPath, const std::vector<pxr::TfToken>& properties) {
+    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
+    if (!tileset.has_value()) {
+        return;
+    }
+
+    auto reloadTileset = false;
+    auto updateTilesetOptions = false;
+    auto updateDisplayColorAndOpacity = false;
+
+    // No change tracking needed for
+    // * cesiumSuspendUpdate
+    // * georeferenceBinding
+
+    // clang-format off
+    for (const auto& property : properties) {
+        if (property == pxr::CesiumTokens->cesiumSourceType ||
+            property == pxr::CesiumTokens->cesiumUrl ||
+            property == pxr::CesiumTokens->cesiumIonAssetId ||
+            property == pxr::CesiumTokens->cesiumIonAccessToken ||
+            property == pxr::CesiumTokens->cesiumIonServerBinding ||
+            property == pxr::CesiumTokens->cesiumSmoothNormals ||
+            property == pxr::CesiumTokens->cesiumShowCreditsOnScreen ||
+            property == pxr::UsdTokens->material_binding) {
+            reloadTileset = true;
+        } else if (
+            property == pxr::CesiumTokens->cesiumMaximumScreenSpaceError ||
+            property == pxr::CesiumTokens->cesiumPreloadAncestors ||
+            property == pxr::CesiumTokens->cesiumPreloadSiblings ||
+            property == pxr::CesiumTokens->cesiumForbidHoles ||
+            property == pxr::CesiumTokens->cesiumMaximumSimultaneousTileLoads ||
+            property == pxr::CesiumTokens->cesiumMaximumCachedBytes ||
+            property == pxr::CesiumTokens->cesiumLoadingDescendantLimit ||
+            property == pxr::CesiumTokens->cesiumEnableFrustumCulling ||
+            property == pxr::CesiumTokens->cesiumEnableFogCulling ||
+            property == pxr::CesiumTokens->cesiumEnforceCulledScreenSpaceError ||
+            property == pxr::CesiumTokens->cesiumCulledScreenSpaceError ||
+            property == pxr::CesiumTokens->cesiumMainThreadLoadingTimeLimit) {
+            updateTilesetOptions = true;
+        } else if (
+            property == pxr::UsdTokens->primvars_displayColor ||
+            property == pxr::UsdTokens->primvars_displayOpacity) {
+            updateDisplayColorAndOpacity = true;
+        }
+    }
+    // clang-format on
+
+    if (reloadTileset) {
+        tileset.value()->reload();
+        return; // Skip other updates
+    }
+
+    if (updateTilesetOptions) {
+        tileset.value()->updateTilesetOptionsFromProperties();
+    }
+
+    if (updateDisplayColorAndOpacity) {
+        tileset.value()->updateDisplayColorAndOpacity();
+    }
+}
+
+void processCesiumImageryChanged(const pxr::SdfPath& imageryPath, const std::vector<pxr::TfToken>& properties) {
+    const auto tilesetPath = imageryPath.GetParentPath();
+    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
+    if (!tileset.has_value()) {
+        return;
+    }
+
+    auto reloadTileset = false;
+    auto updateImageryLayerAlpha = false;
+
+    // clang-format off
+    for (const auto& property : properties) {
+        if (property == pxr::CesiumTokens->cesiumIonAssetId ||
+            property == pxr::CesiumTokens->cesiumIonAccessToken ||
+            property == pxr::CesiumTokens->cesiumIonServerBinding ||
+            property == pxr::CesiumTokens->cesiumShowCreditsOnScreen) {
+            reloadTileset = true;
+        } else if (property == pxr::CesiumTokens->cesiumAlpha) {
+            updateImageryLayerAlpha = true;
+        }
+    }
+    // clang-format on
+
+    if (reloadTileset) {
+        tileset.value()->reload();
+        return; // Skip other updates
+    }
+
+    if (updateImageryLayerAlpha) {
+        const auto imageryLayerIndex = tileset.value()->findImageryLayerIndex(imageryPath);
+        if (imageryLayerIndex.has_value()) {
+            tileset.value()->updateImageryLayerAlpha(imageryLayerIndex.value());
+        }
+    }
+}
+
+void processCesiumGeoreferenceChanged(
+    const pxr::SdfPath& georeferencePath,
+    const std::vector<pxr::TfToken>& properties) {
+    auto updateGlobeAnchors = false;
+
+    // clang-format off
+    for (const auto& property : properties) {
+        if (property == pxr::CesiumTokens->cesiumGeoreferenceOriginLongitude ||
+            property == pxr::CesiumTokens->cesiumGeoreferenceOriginLatitude ||
+            property == pxr::CesiumTokens->cesiumGeoreferenceOriginHeight) {
+            updateGlobeAnchors = true;
+        }
+    }
+    // clang-format on
+
+    if (updateGlobeAnchors) {
+        const auto anchors = GlobeAnchorRegistry::getInstance().getAllAnchors();
+        for (const auto& globeAnchor : anchors) {
+            const auto anchorApi = UsdUtil::getCesiumGlobeAnchor(globeAnchor->getPrimPath());
+
+            // We only want to update an anchor if we are updating its related Georeference Prim.
+            if (georeferencePath !=
+                UsdUtil::getAnchorGeoreferencePath(globeAnchor->getPrimPath()).value_or(pxr::SdfPath::EmptyPath())) {
+                continue;
+            }
+
+            const auto origin = UsdUtil::getCartographicOriginForAnchor(globeAnchor->getPrimPath());
+            if (!origin.has_value()) {
+                continue;
+            }
+
+            GeospatialUtil::updateAnchorOrigin(origin.value(), anchorApi, globeAnchor);
+        }
+    }
+}
+
+void processCesiumGlobeAnchorChanged(const pxr::SdfPath& globeAnchorPath, const std::vector<pxr::TfToken>& properties) {
+    const auto globeAnchor = UsdUtil::getCesiumGlobeAnchor(globeAnchorPath);
+    const auto origin = UsdUtil::getCartographicOriginForAnchor(globeAnchorPath);
+
+    if (!origin.has_value()) {
+        return;
+    }
+
+    auto updateByUsdTransform = false;
+    auto updateByLatLongHeight = false;
+    auto updateByFixedTransform = false;
+
+    bool detectTransformChanges;
+    globeAnchor.GetDetectTransformChangesAttr().Get(&detectTransformChanges);
+
+    // clang-format off
+    for (const auto& property : properties) {
+        if (detectTransformChanges && (property == pxr::CesiumTokens->cesiumAnchorDetectTransformChanges ||
+                                       property == pxr::UsdTokens->xformOp_transform_cesium)) {
+            updateByUsdTransform = true;
+        } else if (property == pxr::CesiumTokens->cesiumAnchorGeographicCoordinates) {
+            updateByLatLongHeight = true;
+        } else if (
+            property == pxr::CesiumTokens->cesiumAnchorPosition ||
+            property == pxr::CesiumTokens->cesiumAnchorRotation ||
+            property == pxr::CesiumTokens->cesiumAnchorScale) {
+            updateByFixedTransform = true;
+        }
+    }
+    // clang-format on
+
+    if (updateByUsdTransform) {
+        GeospatialUtil::updateAnchorByUsdTransform(origin.value(), globeAnchor);
+    } else if (updateByLatLongHeight) {
+        GeospatialUtil::updateAnchorByLatLongHeight(origin.value(), globeAnchor);
+    } else if (updateByFixedTransform) {
+        GeospatialUtil::updateAnchorByFixedTransform(origin.value(), globeAnchor);
+    }
+}
+
+void processCesiumIonServerChanged(const pxr::SdfPath& ionServerPath, const std::vector<pxr::TfToken>& properties) {
+    auto reloadSession = false;
+    auto reloadAssets = false;
+
+    // clang-format off
+    for (const auto& property : properties) {
+        if (property == pxr::CesiumTokens->cesiumIonServerUrl ||
+            property == pxr::CesiumTokens->cesiumIonServerApiUrl ||
+            property == pxr::CesiumTokens->cesiumIonServerApplicationId) {
+            reloadSession = true;
+            reloadAssets = true;
+        } else if (
+            property == pxr::CesiumTokens->cesiumProjectDefaultIonAccessToken ||
+            property == pxr::CesiumTokens->cesiumProjectDefaultIonAccessTokenId) {
+            reloadAssets = true;
+        }
+    }
+    // clang-format on
+
+    if (reloadSession) {
+        SessionRegistry::getInstance().removeSession(ionServerPath);
+        SessionRegistry::getInstance().addSession(
+            *Context::instance().getAsyncSystem().get(), Context::instance().getHttpAssetAccessor(), ionServerPath);
+    }
+
+    if (reloadAssets) {
+        reloadIonServerAssets(ionServerPath);
+    }
+}
+
+void processUsdShaderChanged(const pxr::SdfPath& shaderPath, const std::vector<pxr::TfToken>& properties) {
+    const auto shader = UsdUtil::getUsdShader(shaderPath);
+    const auto shaderPathFabric = FabricUtil::toFabricPath(shaderPath);
+    const auto materialPath = shaderPath.GetParentPath();
+    const auto materialPathFabric = FabricUtil::toFabricPath(materialPath);
+
+    if (!UsdUtil::isUsdMaterial(materialPath)) {
+        // Skip if parent path is not a material
+        return;
+    }
+
+    for (const auto& property : properties) {
+        const auto inputNamespace = std::string_view("inputs:");
+
+        const auto& attributeName = property.GetString();
+
+        if (attributeName.rfind(inputNamespace) != 0) {
+            // Skip if changed attribute is not a shader input
+            return;
+        }
+
+        const auto inputName = pxr::TfToken(attributeName.substr(inputNamespace.size()));
+
+        auto shaderInput = shader.GetInput(inputName);
+        if (!shaderInput.IsDefined()) {
+            // Skip if changed attribute is not a shader input
+            return;
+        }
+
+        if (shaderInput.HasConnectedSource()) {
+            // Skip if shader input is connected to something else
+            return;
+        }
+
+        if (!FabricUtil::materialHasCesiumNodes(materialPathFabric)) {
+            // Simple materials can be skipped. We only need to handle materials that have been copied to each tile.
+            return;
+        }
+
+        if (!FabricUtil::isShaderConnectedToMaterial(materialPathFabric, shaderPathFabric)) {
+            // Skip if shader is not connected to the material
+            return;
+        }
+
+        const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
+        for (const auto& tileset : tilesets) {
+            if (tileset->getMaterialPath() == materialPath) {
+                tileset->updateShaderInput(shaderPath, property);
+            }
+        }
+
+        FabricResourceManager::getInstance().updateShaderInput(materialPath, shaderPath, property);
+    }
+}
+
+void processCesiumTilesetRemoved(const pxr::SdfPath& tilesetPath) {
+    AssetRegistry::getInstance().removeTileset(tilesetPath);
+}
+
+void processCesiumImageryRemoved(const pxr::SdfPath& imageryPath) {
+    AssetRegistry::getInstance().removeImagery(imageryPath);
+
+    const auto tilesetPath = imageryPath.GetParentPath();
+    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
+
+    if (tileset.has_value()) {
+        tileset.value()->reload();
+    }
+}
+
+void processCesiumGlobeAnchorRemoved(const pxr::SdfPath& globeAnchorPath) {
+    const auto removed = GlobeAnchorRegistry::getInstance().removeAnchor(globeAnchorPath);
+
+    if (!removed) {
+        CESIUM_LOG_ERROR("Failed to remove anchor from registry: {}", globeAnchorPath.GetString());
+    }
+}
+
+void processCesiumIonServerRemoved(const pxr::SdfPath& ionServerPath) {
+    SessionRegistry::getInstance().removeSession(ionServerPath);
+    reloadIonServerAssets(ionServerPath);
+}
+
+void processCesiumTilesetAdded(const pxr::SdfPath& tilesetPath) {
+    const auto georeferencePath = UsdUtil::getOrCreateCesiumGeoreference().GetPath();
+    AssetRegistry::getInstance().addTileset(tilesetPath, georeferencePath);
+}
+
+void processCesiumImageryAdded(const pxr::SdfPath& imageryPath) {
+    AssetRegistry::getInstance().addImagery(imageryPath);
+
+    const auto tilesetPath = imageryPath.GetParentPath();
+    const auto tileset = AssetRegistry::getInstance().getTilesetByPath(tilesetPath);
+
+    if (tileset.has_value()) {
+        tileset.value()->reload();
+    }
+}
+
+void processCesiumGlobeAnchorAdded(const pxr::SdfPath& globeAnchorPath) {
+    const auto anchorApi = UsdUtil::getCesiumGlobeAnchor(globeAnchorPath);
+    const auto origin = UsdUtil::getCartographicOriginForAnchor(globeAnchorPath);
+    assert(origin.has_value());
+    pxr::GfVec3d coordinates;
+    anchorApi.GetGeographicCoordinateAttr().Get(&coordinates);
+
+    if (coordinates == pxr::GfVec3d{0.0, 0.0, 10.0}) {
+        // Default geo coordinates. Place based on current USD position.
+        GeospatialUtil::updateAnchorByUsdTransform(origin.value(), anchorApi);
+    } else {
+        // Provided geo coordinates. Place at correct location.
+        GeospatialUtil::updateAnchorByLatLongHeight(origin.value(), anchorApi);
+    }
+}
+
+void processCesiumIonServerAdded(const pxr::SdfPath& ionServerPath) {
+    SessionRegistry::getInstance().addSession(
+        *Context::instance().getAsyncSystem().get(), Context::instance().getHttpAssetAccessor(), ionServerPath);
+    reloadIonServerAssets(ionServerPath);
+}
+
+std::vector<ChangedPrim> consolidateChangedPrims(const std::vector<ChangedPrim>& changedPrims) {
+    // Consolidate changes while preserving original insertion order
+    std::vector<ChangedPrim> consolidated;
+
+    ChangedPrim* previous = nullptr;
+
+    for (const auto& changedPrim : changedPrims) {
+        if (previous != nullptr && changedPrim.primPath == previous->primPath) {
+            if (previous->changeType == ChangeType::PRIM_ADDED &&
+                changedPrim.changeType == ChangeType::PROPERTY_CHANGED) {
+                // Ignore property changes that occur immediately after the prim is added. This avoids unecessary churn.
+                continue;
+            }
+
+            if (previous->changeType == ChangeType::PROPERTY_CHANGED &&
+                changedPrim.changeType == ChangeType::PROPERTY_CHANGED) {
+                // Consolidate property changes so that they can be processed together
+                previous->properties.insert(
+                    previous->properties.end(), changedPrim.properties.begin(), changedPrim.properties.end());
+                continue;
+            }
+        }
+
+        consolidated.push_back(changedPrim);
+
+        previous = &consolidated.back();
+    }
+
+    return consolidated;
+}
+
 } // namespace
 
 UsdNotificationHandler::UsdNotificationHandler() {
@@ -81,23 +492,100 @@ UsdNotificationHandler::~UsdNotificationHandler() {
     pxr::TfNotice::Revoke(_noticeListenerKey);
 }
 
-std::vector<ChangedPrim> UsdNotificationHandler::popChangedPrims() {
-    static const std::vector<ChangedPrim> empty;
+void UsdNotificationHandler::onStageLoaded() {
+    const auto stage = UsdUtil::getUsdStage();
 
-    if (_changedPrims.size() == 0) {
-        return empty;
+    // We need to add prims manually because USD doesn't notify us about resynced paths when the stage is loaded
+    for (const auto& prim : stage->Traverse()) {
+        const auto type = getType(prim.GetPath());
+        if (type != ChangedPrimType::OTHER) {
+            insertAddedPrim(prim.GetPath(), type);
+        }
     }
 
-    std::vector<ChangedPrim> changedPrims;
+    // Process changes immediately
+    onUpdateFrame();
+}
 
-    changedPrims.insert(
-        changedPrims.end(),
-        std::make_move_iterator(_changedPrims.begin()),
-        std::make_move_iterator(_changedPrims.end()));
+void UsdNotificationHandler::onUpdateFrame() {
+    const auto changedPrims = consolidateChangedPrims(_changedPrims);
 
-    _changedPrims.erase(_changedPrims.begin(), _changedPrims.end());
+    // Reset for next frame
+    _changedPrims.clear();
 
-    return changedPrims;
+    for (const auto& changedPrim : changedPrims) {
+        switch (changedPrim.changeType) {
+            case ChangeType::PROPERTY_CHANGED:
+                switch (changedPrim.primType) {
+                    case ChangedPrimType::CESIUM_DATA:
+                        processCesiumDataChanged(changedPrim.properties);
+                        break;
+                    case ChangedPrimType::CESIUM_TILESET:
+                        processCesiumTilesetChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::CESIUM_IMAGERY:
+                        processCesiumImageryChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::CESIUM_GEOREFERENCE:
+                        processCesiumGeoreferenceChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::CESIUM_GLOBE_ANCHOR:
+                        processCesiumGlobeAnchorChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::CESIUM_ION_SERVER:
+                        processCesiumIonServerChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::USD_SHADER:
+                        processUsdShaderChanged(changedPrim.primPath, changedPrim.properties);
+                        break;
+                    case ChangedPrimType::OTHER:
+                        break;
+                }
+                break;
+            case ChangeType::PRIM_ADDED:
+                switch (changedPrim.primType) {
+                    case ChangedPrimType::CESIUM_TILESET:
+                        processCesiumTilesetAdded(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_IMAGERY:
+                        processCesiumImageryAdded(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_GLOBE_ANCHOR:
+                        processCesiumGlobeAnchorAdded(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_ION_SERVER:
+                        processCesiumIonServerAdded(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_DATA:
+                    case ChangedPrimType::CESIUM_GEOREFERENCE:
+                    case ChangedPrimType::USD_SHADER:
+                    case ChangedPrimType::OTHER:
+                        break;
+                }
+                break;
+            case ChangeType::PRIM_REMOVED:
+                switch (changedPrim.primType) {
+                    case ChangedPrimType::CESIUM_TILESET:
+                        processCesiumTilesetRemoved(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_IMAGERY:
+                        processCesiumImageryRemoved(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_GLOBE_ANCHOR:
+                        processCesiumGlobeAnchorRemoved(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_ION_SERVER:
+                        processCesiumIonServerRemoved(changedPrim.primPath);
+                        break;
+                    case ChangedPrimType::CESIUM_DATA:
+                    case ChangedPrimType::CESIUM_GEOREFERENCE:
+                    case ChangedPrimType::USD_SHADER:
+                    case ChangedPrimType::OTHER:
+                        break;
+                }
+                break;
+        }
+    }
 }
 
 void UsdNotificationHandler::onObjectsChanged(const pxr::UsdNotice::ObjectsChanged& objectsChanged) {
@@ -110,12 +598,12 @@ void UsdNotificationHandler::onObjectsChanged(const pxr::UsdNotice::ObjectsChang
         if (path.IsPrimPath()) {
             if (UsdUtil::primExists(path)) {
                 const auto isTileset = getType(path) == ChangedPrimType::CESIUM_TILESET;
-                const auto alreadyRegistered = AssetRegistry::getInstance().getTilesetByPath(path).has_value();
+                const auto isTilesetAlreadyRegistered = AssetRegistry::getInstance().getTilesetByPath(path).has_value();
 
-                if (isTileset && alreadyRegistered) {
-                    // A prim may be resynced even if its path doesn't change, like when an API Schema is applied to it
-                    // This happens when a material is assigned to a tileset for the first time
-                    // We don't want to add the prim again if it's already registered
+                if (isTileset && isTilesetAlreadyRegistered) {
+                    // A prim may be resynced even if its path doesn't change, like when an API Schema is applied to it.
+                    // This happens when a material is assigned to a tileset for the first time.
+                    // We don't want to add the prim again if it's already registered.
                     continue;
                 }
 
@@ -137,8 +625,7 @@ void UsdNotificationHandler::onObjectsChanged(const pxr::UsdNotice::ObjectsChang
 void UsdNotificationHandler::onPrimAdded(const pxr::SdfPath& primPath) {
     const auto type = getType(primPath);
     if (type != ChangedPrimType::OTHER) {
-        _changedPrims.emplace_back(ChangedPrim{primPath, pxr::TfToken(), type, ChangeType::PRIM_ADDED});
-        CESIUM_LOG_INFO("Added prim: {}", primPath.GetText());
+        insertAddedPrim(primPath, type);
     }
 
     // USD only notifies us about the top-most prim. Traverse over descendant prims and add those as well.
@@ -153,15 +640,14 @@ void UsdNotificationHandler::onPrimAdded(const pxr::SdfPath& primPath) {
 void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
     // USD only notifies us about the top-most prim. This prim may have tileset / imagery descendants that need to
     // be removed as well. Unlike onPrimAdded we can't traverse the stage because these prims no longer exist. Instead
-    // loop through tilesets and imagery in the asset registry.
+    // loop through items in the asset registry.
     const auto& tilesets = AssetRegistry::getInstance().getAllTilesets();
     for (const auto& tileset : tilesets) {
         const auto tilesetPath = tileset->getPath();
         const auto type = getType(tilesetPath);
         if (type == ChangedPrimType::CESIUM_TILESET) {
             if (inSubtree(primPath, tilesetPath)) {
-                _changedPrims.emplace_back(ChangedPrim{tilesetPath, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
-                CESIUM_LOG_INFO("Removed prim: {}", tilesetPath.GetText());
+                insertRemovedPrim(primPath, type);
             }
         }
     }
@@ -172,8 +658,7 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
         const auto type = getType(imageryPath);
         if (type == ChangedPrimType::CESIUM_IMAGERY) {
             if (inSubtree(primPath, imageryPath)) {
-                _changedPrims.emplace_back(ChangedPrim{imageryPath, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
-                CESIUM_LOG_INFO("Removed prim: {}", imageryPath.GetText());
+                insertRemovedPrim(primPath, type);
             }
         }
     }
@@ -184,8 +669,7 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
         const auto& type = getType(path);
         if (type == ChangedPrimType::CESIUM_GLOBE_ANCHOR) {
             if (inSubtree(primPath, path)) {
-                _changedPrims.emplace_back(ChangedPrim{path, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
-                CESIUM_LOG_INFO("Removed prim: {}", path.GetText());
+                insertRemovedPrim(primPath, type);
             }
         }
     }
@@ -195,8 +679,7 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
         const auto& type = getType(path);
         if (type == ChangedPrimType::CESIUM_ION_SERVER) {
             if (inSubtree(primPath, path)) {
-                _changedPrims.emplace_back(ChangedPrim{path, pxr::TfToken(), type, ChangeType::PRIM_REMOVED});
-                CESIUM_LOG_INFO("Removed prim: {}", path.GetText());
+                insertRemovedPrim(primPath, type);
             }
         }
     }
@@ -204,12 +687,32 @@ void UsdNotificationHandler::onPrimRemoved(const pxr::SdfPath& primPath) {
 
 void UsdNotificationHandler::onPropertyChanged(const pxr::SdfPath& propertyPath) {
     const auto& propertyName = propertyPath.GetNameToken();
-    const auto& primPath = propertyPath.GetPrimPath();
-    const auto& type = getType(primPath);
+    const auto primPath = propertyPath.GetPrimPath();
+    const auto type = getType(primPath);
     if (type != ChangedPrimType::OTHER) {
-        _changedPrims.emplace_back(ChangedPrim{primPath, propertyName, type, ChangeType::PROPERTY_CHANGED});
-        CESIUM_LOG_INFO("Changed property: {}", propertyPath.GetText());
+        insertPropertyChanged(primPath, type, propertyName);
     }
+}
+
+void UsdNotificationHandler::insertAddedPrim(const pxr::SdfPath& primPath, ChangedPrimType primType) {
+    // In C++ 20 the ChangePrim{} wrapper can be removed
+    _changedPrims.emplace_back(ChangedPrim{primPath, {}, primType, ChangeType::PRIM_ADDED});
+    CESIUM_LOG_TRACE("Added prim: {}", primPath.GetText());
+}
+
+void UsdNotificationHandler::insertRemovedPrim(const pxr::SdfPath& primPath, ChangedPrimType primType) {
+    // In C++ 20 the ChangePrim{} wrapper can be removed
+    _changedPrims.emplace_back(ChangedPrim{primPath, {}, primType, ChangeType::PRIM_REMOVED});
+    CESIUM_LOG_TRACE("Removed prim: {}", primPath.GetText());
+}
+
+void UsdNotificationHandler::insertPropertyChanged(
+    const pxr::SdfPath& primPath,
+    ChangedPrimType primType,
+    const pxr::TfToken& propertyName) {
+    // In C++ 20 the ChangePrim{} wrapper can be removed
+    _changedPrims.emplace_back(ChangedPrim{primPath, {propertyName}, primType, ChangeType::PROPERTY_CHANGED});
+    CESIUM_LOG_TRACE("Property changed: {} {}", primPath.GetText(), propertyName.GetText());
 }
 
 } // namespace cesium::omniverse


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/483

Previously `UsdNotificationHandler` would poll notifications and `Context` would process them each frame. This PR moves the processing into `UsdNotificationHandler` to help simplify `Context`.

There are some other performance / stability improvements:

* Ignore property change notifications that occur immediately after prim added notifications
* Consolidate property changes so that they can be processed together

This should help prevent assets from going into an invalid state. It should also help improve performance.

In terms of https://github.com/CesiumGS/cesium-omniverse/issues/483:

* I didn't add a container class for `ChangedPrim` but I simplified how prims are added to the vector. Personally I'm ok with the current setup. A vector is a simple way to ensure that notifications are processed in the order they're added.
* I added some inline comments about improvements once we can switch to C++ 20.