### PR TITLE
Fix crash in Cesium Debugging window

### DIFF
--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -561,25 +561,26 @@ FabricStatistics getStatistics() {
     for (size_t bucketId = 0; bucketId < geometryBuckets.bucketCount(); bucketId++) {
         auto paths = srw.getPathArray(geometryBuckets, bucketId);
 
-        // clang-format off
-        auto worldVisibilityFabric = srw.getAttributeArrayRd<bool>(geometryBuckets, bucketId, FabricTokens::_worldVisibility);
-        auto faceVertexCountsFabric = srw.getArrayAttributeArrayRd<int>(geometryBuckets, bucketId, FabricTokens::faceVertexCounts);
-        auto tilesetIdFabric = srw.getAttributeArrayRd<int64_t>(geometryBuckets, bucketId, FabricTokens::_cesium_tilesetId);
-        // clang-format on
-
         statistics.geometriesCapacity += paths.size();
 
-        for (size_t i = 0; i < paths.size(); i++) {
-            if (tilesetIdFabric[i] == NO_TILESET_ID) {
+        for (const auto& path : paths) {
+            const auto worldVisibilityFabric = srw.getAttributeRd<bool>(path, FabricTokens::_worldVisibility);
+            const auto faceVertexCountsFabric = srw.getArrayAttributeRd<int>(path, FabricTokens::faceVertexCounts);
+            const auto tilesetIdFabric = srw.getAttributeRd<int64_t>(path, FabricTokens::_cesium_tilesetId);
+
+            assert(worldVisibilityFabric);
+            assert(tilesetIdFabric);
+
+            if (*tilesetIdFabric == NO_TILESET_ID) {
                 continue;
             }
 
             statistics.geometriesLoaded++;
 
-            const auto triangleCount = faceVertexCountsFabric[i].size();
+            const auto triangleCount = faceVertexCountsFabric.size();
             statistics.trianglesLoaded += triangleCount;
 
-            if (worldVisibilityFabric[i]) {
+            if (*worldVisibilityFabric) {
                 statistics.geometriesRendered++;
                 statistics.trianglesRendered += triangleCount;
             }


### PR DESCRIPTION
Fixes a crash in the Cesium Debugging window related to printing rendering statistics.

Previously the code used `getArrayAttributeArrayRd` to get the values of `faceVertexCounts` for all cesium prims. Unfortunately this triggers an assertion for array attributes that were resized back to `0`, which happens when prims are released back into the geometry pool. It's possible the assertion is invalid and needs to be fixed in Fabric, so in the meantime I switched to the non array getters. Performance shouldn't matter here because it only happens if the Cesium Debugging window is open.

To reproduce, add a tileset, remove the tileset, and open the Cesium Debugging window. `main` will crash but this branch should not.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/915398/6aff676a-c26b-4cd4-ab70-a3c164c36e46)
