### PR TITLE
Use "integratedTerminal" in launch.json

### DIFF
--- a/.vscode/launch.linux.json
+++ b/.vscode/launch.linux.json
@@ -13,6 +13,7 @@
         "ASAN_OPTIONS": "detect_leaks=0",
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppdbg",
       "request": "launch",
@@ -48,6 +49,7 @@
         "ASAN_OPTIONS": "detect_leaks=0",
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppdbg",
       "request": "launch",
@@ -79,6 +81,7 @@
         "ASAN_OPTIONS": "detect_leaks=0",
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppdbg",
       "request": "launch",
@@ -121,6 +124,7 @@
         "ASAN_OPTIONS": "detect_leaks=0",
         "UBSAN_OPTIONS": "print_stacktrace=1"
       },
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppdbg",
       "request": "launch",

--- a/.vscode/launch.windows.json
+++ b/.vscode/launch.windows.json
@@ -8,6 +8,7 @@
       "args": [
         "${workspaceFolder}/apps/cesium.omniverse.dev.kit"
       ],
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
       "request": "launch"
@@ -19,6 +20,7 @@
       "args": [
         "${workspaceFolder}/apps/cesium.omniverse.dev.kit"
       ],
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
       "request": "launch"
@@ -30,6 +32,7 @@
       "args": [
         "${workspaceFolder}/apps/cesium.omniverse.dev.python.debug.kit"
       ],
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
       "request": "launch"
@@ -48,6 +51,7 @@
       "args": [
         "${workspaceFolder}/apps/cesium.omniverse.cpp.tests.runner.kit"
       ],
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "type": "cppvsdbg",
       "request": "launch"


### PR DESCRIPTION
Fixes an issue where `omni.kit.pipapi` doesn't work on a clean install when using VS Code's internal console.

To reproduce, delete `C:\Users\Sean\AppData\Local\ov\data\Kit\cesium.omniverse.dev` and launch Development App from VS Code. You'll get the error:

```
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin] OSError: [WinError 6] The handle is invalid
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin] 
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin] At:
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users\sean\code\cesium-omniverse-2\extern\nvidia\_build\target-deps\kit-sdk\python\lib\subprocess.py(1334): _make_inheritable
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users\sean\code\cesium-omniverse-2\extern\nvidia\_build\target-deps\kit-sdk\python\lib\subprocess.py(1287): _get_handles
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users\sean\code\cesium-omniverse-2\extern\nvidia\_build\target-deps\kit-sdk\python\lib\subprocess.py(837): __init__
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/exts/omni.kit.pipapi/omni/kit/pipapi/pipapi.py(176): call_pip
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/exts/omni.kit.pipapi/omni/kit/pipapi/pipapi.py(294): install
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/exts/omni.kit.pipapi/omni/kit/pipapi/pipapi.py(65): wrapper
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/exts/cesium.omniverse/cesium/omniverse/install/wheel_installer.py(77): _perform_install
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/exts/cesium.omniverse/cesium/omniverse/install/wheel_installer.py(59): install
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/exts/cesium.powertools/cesium/powertools/extension.py(90): _install_py_dependencies
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:/users/sean/code/cesium-omniverse-2/exts/cesium.powertools/cesium/powertools/extension.py(21): __init__
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/kernel/py\omni\ext\_impl\_internal.py(158): _startup_ext
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/kernel/py\carb\profiler\__init__.py(85): wrapper
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/kernel/py\omni\ext\_impl\_internal.py(224): startup
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   c:\users/sean/code/cesium-omniverse-2/extern/nvidia/_build/target-deps/kit-sdk/kernel/py\omni\ext\_impl\_internal.py(328): startup_extension
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin]   PythonExtension.cpp::startup()(2): <module>
2023-12-28 20:09:20  [Error] [carb.scripting-python.plugin] 
2023-12-28 20:09:20  [Error] [omni.ext.plugin] [ext: cesium.powertools-0.1.0] Failed to startup python extension.
```

Previously this was fixed by switching to the external terminal https://github.com/CesiumGS/cesium-omniverse/pull/371 but this was reverted in https://github.com/CesiumGS/cesium-omniverse/pull/478 because it was annoying to close external terminals. The original problem still exists though, and switching to `"console": "integratedTerminal"` seems to fix it.