### PR TITLE
Remove retain paths workaround

### DIFF
--- a/src/core/include/cesium/omniverse/FabricResourceManager.h
+++ b/src/core/include/cesium/omniverse/FabricResourceManager.h
@@ -93,8 +93,6 @@ class FabricResourceManager {
         const pxr::SdfPath& shaderPath,
         const pxr::TfToken& attributeName);
 
-    void retainPath(const omni::fabric::Path& path);
-
     void clear();
 
   protected:
@@ -156,8 +154,6 @@ class FabricResourceManager {
     std::unique_ptr<omni::ui::DynamicTextureProvider> _defaultTransparentTexture;
     pxr::TfToken _defaultTextureAssetPathToken;
     pxr::TfToken _defaultTransparentTextureAssetPathToken;
-
-    std::vector<omni::fabric::Path> _retainedPaths;
 
     std::vector<SharedMaterial> _sharedMaterials;
 };

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -62,8 +62,6 @@ FabricGeometry::FabricGeometry(
         return;
     }
 
-    FabricResourceManager::getInstance().retainPath(path);
-
     initialize();
     reset();
 }

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -463,10 +463,6 @@ FabricMaterial::FabricMaterial(
         initializeExistingMaterial(existingMaterialPath);
     }
 
-    for (const auto& nodePath : _allPaths) {
-        FabricResourceManager::getInstance().retainPath(nodePath);
-    }
-
     reset();
 }
 

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -390,15 +390,6 @@ std::shared_ptr<FabricTexturePool> FabricResourceManager::createTexturePool() {
         std::make_shared<FabricTexturePool>(getNextPoolId(), _texturePoolInitialCapacity));
 }
 
-void FabricResourceManager::retainPath(const omni::fabric::Path& path) {
-    // This is a workaround for https://github.com/CesiumGS/cesium-omniverse/issues/425.
-    // By retaining a reference to the path we avoid a crash deep in the Sdf library
-    // that's triggered by loading a tileset, removing the tileset, and reloading the tileset.
-    // It's possible this will be fixed in a future Kit release at which point we can remove
-    // this workaround.
-    _retainedPaths.push_back(path);
-}
-
 int64_t FabricResourceManager::getNextGeometryId() {
     return _geometryId++;
 }


### PR DESCRIPTION
The workaround in https://github.com/CesiumGS/cesium-omniverse/pull/442 is no longer needed. The underlying issue was fixed in `105.1+release.127680.dd92291b.tc` which we've been using for a few months now.

I confirmed that adding CWT + Bing, removing CWT + Bing, adding CWT + Bing doesn't trigger a crash.