### PR TITLE
Fix deprecated Python VS Code settings

### DIFF
--- a/.vscode/cesium-omniverse-linux.code-workspace
+++ b/.vscode/cesium-omniverse-linux.code-workspace
@@ -362,11 +362,7 @@
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/extsPhysics/omni.usd.schema.physx"
     ],
     "python.languageServer": "Pylance",
-    "python.formatting.provider": "black",
     "python.analysis.typeCheckingMode": "basic",
-    "python.linting.enabled": true,
-    "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
     "python.defaultInterpreterPath": "${workspaceFolder}/extern/nvidia/_build/target-deps/python/python",
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"
@@ -375,6 +371,8 @@
   "extensions": {
     "recommendations": [
       "llvm-vs-code-extensions.vscode-clangd",
+      "ms-python.black-formatter",
+      "ms-python.flake8",
       "ms-python.python",
       "ms-python.vscode-pylance",
       "ms-vscode.cpptools",
@@ -384,7 +382,6 @@
       "cheshirekow.cmake-format",
       "redhat.vscode-yaml",
       "tamasfe.even-better-toml",
-      "ms-python.black-formatter"
     ],
     "unwantedRecommendations": []
   }

--- a/.vscode/cesium-omniverse-windows.code-workspace
+++ b/.vscode/cesium-omniverse-windows.code-workspace
@@ -363,11 +363,7 @@
       "${workspaceFolder}/extern/nvidia/_build/target-deps/kit-sdk/extsPhysics/omni.usdphysics.ui-105.0.7-5.1"
     ],
     "python.languageServer": "Pylance",
-    "python.formatting.provider": "black",
     "python.analysis.typeCheckingMode": "basic",
-    "python.linting.enabled": true,
-    "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
     "python.defaultInterpreterPath": "${workspaceFolder}/extern/nvidia/_build/target-deps/python/python.exe",
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"
@@ -376,6 +372,8 @@
   "extensions": {
     "recommendations": [
       "llvm-vs-code-extensions.vscode-clangd",
+      "ms-python.black-formatter",
+      "ms-python.flake8",
       "ms-python.python",
       "ms-python.vscode-pylance",
       "ms-vscode.cpptools",
@@ -383,8 +381,7 @@
       "editorconfig.editorconfig",
       "cheshirekow.cmake-format",
       "redhat.vscode-yaml",
-      "tamasfe.even-better-toml",
-      "ms-python.black-formatter"
+      "tamasfe.even-better-toml"
     ],
     "unwantedRecommendations": []
   }


### PR DESCRIPTION
According to a popup that appears when opening the workspace in VS Code now, `python.formatting` and `python.linting` options have been deprecated and separate extensions should be installed.

```
2023-12-29 10:24:28.492 [info] Experiment 'pythonRecommendTensorboardExt' is active
2023-12-29 10:24:28.492 [info] Experiment 'pythonREPLSmartSend' is active
2023-12-29 10:24:28.492 [info] Experiment 'pythonTestAdapter' is active
2023-12-29 10:24:28.492 [info] Default formatter is set to ms-python.black-formatter for workspace c:\Users\Sean\Code\cesium-omniverse
2023-12-29 10:24:28.492 [error] Following setting is deprecated: "python.linting.flake8Enabled"
2023-12-29 10:24:28.492 [error] All settings starting with "python.linting." are deprecated and can be removed from settings.
2023-12-29 10:24:28.492 [error] Linting features have been moved to separate linter extensions.
2023-12-29 10:24:28.492 [error] See here for more information: https://code.visualstudio.com/docs/python/linting
2023-12-29 10:24:28.492 [error] Please install "flake8" extension: https://marketplace.visualstudio.com/items?itemName=ms-python.flake8
2023-12-29 10:24:28.493 [info] Test server listening.
2023-12-29 10:24:28.493 [info] Python interpreter path: .\extern\nvidia\_build\target-deps\python\python.exe
2023-12-29 10:24:32.966 [info] Starting Pylance language server.
2023-12-29 10:24:32.970 [error] Active interpreter type is detected as Unknown {"id":"C:\\USERS\\SEAN\\CODE\\CESIUM-OMNIVERSE\\EXTERN\\NVIDIA\\_BUILD\\TARGET-DEPS\\PYTHON\\PYTHON.EXE","sysPrefix":"c:\\Users\\Sean\\Code\\cesium-omniverse\\extern\\nvidia\\_build\\target-deps\\python","envType":"Unknown","envName":"","envPath":"","path":"c:\\Users\\Sean\\Code\\cesium-omniverse\\extern\\nvidia\\_build\\target-deps\\python\\python.exe","architecture":3,"sysVersion":"3.10.13 (main, Sep  6 2023, 15:30:33) [MSC v.1912 64 bit (AMD64)]","version":{"raw":"3.10.13","major":3,"minor":10,"patch":13,"build":[],"prerelease":["final","0"]},"displayName":"Python 3.10.13 64-bit","detailedDisplayName":"Python 3.10.13 64-bit"}
```
