### PR TITLE
Fix adding imagery asset to selected tileset

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
@@ -76,7 +76,7 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
         selection = context.get_selection().get_selected_prim_paths()
         tileset_path: Optional[str] = None
 
-        if len(selection) > 0 and is_tileset(selection[0]):
+        if len(selection) > 0 and is_tileset(context.get_stage().GetPrimAtPath(selection[0])):
             tileset_path = selection[0]
 
         if tileset_path is None:

--- a/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
+++ b/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
@@ -63,7 +63,7 @@ def add_imagery_ion(tileset_path: str, name: str, asset_id: int, token: str = ""
 
 
 def is_tileset(maybe_tileset: Gprim) -> bool:
-    return maybe_tileset.isA(CesiumTileset)
+    return maybe_tileset.IsA(CesiumTileset)
 
 
 def remove_tileset(tileset_path: str) -> None:


### PR DESCRIPTION
Adding an imagery layer to a selected tileset via the Assets UI would fail with the following error
```
[Error] [omni.ui.python] AttributeError: 'str' object has no attribute 'isA'
[Error] [omni.ui.python] 
[Error] [omni.ui.python] At:
[Error] [omni.ui.python]   d:/_dev/ov/cesium-omniverse-2/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py(66): is_tileset
[Error] [omni.ui.python]   d:/_dev/ov/cesium-omniverse-2/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py(79): _add_imagery_button_clicked
[Error] [omni.ui.python] 
```

This fixes the above by ensuring a `UsdPrim` is passed to `is_tileset()` instead of a `str`.  It also fixes a typo in the call to `Gprim.IsA()` inside `is_tileset()` in `usdUtils.py`.