### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Everyone's a code owner!
-*   @lilleyse @r-veenstra @corybarr


### PR DESCRIPTION
Removing `CODEOWNERS` since it can get out of date easily. Anyone who's developing cesium-omniverse will just need to subscribe to repo notifications themselves.

In the future we could use GitHub teams to replace `CODEOWNERS`.