### PR TITLE
Use default GitHub Actions runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           - {
               name: "Windows - MSVC",
               artifact: "windows-msvc.tar.xz",
-              os: windows-latest-l,
+              os: windows-latest,
               cc: "cl",
               cxx: "cl",
               build-type: "Release",
@@ -33,7 +33,7 @@ jobs:
           - {
               name: "Ubuntu - GCC",
               artifact: "linux-gcc.tar.xz",
-              os: ubuntu-latest-m,
+              os: ubuntu-latest,
               cc: "gcc-11",
               cxx: "g++-11",
               build-type: "Release",
@@ -45,7 +45,7 @@ jobs:
           - {
               name: "AlmaLinux 8 - GCC",
               artifact: "linux-gcc.tar.xz",
-              os: ubuntu-latest-m,
+              os: ubuntu-latest,
               cc: "gcc-11",
               cxx: "g++-11",
               build-type: "Release",


### PR DESCRIPTION
See https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

We no longer need to use `windows-latest-l` or `ubuntu-latest-m`