### PR TITLE
cesium.omniverse.dev.kit: make material_graph optional

### DIFF
--- a/apps/cesium.omniverse.dev.kit
+++ b/apps/cesium.omniverse.dev.kit
@@ -6,7 +6,7 @@ app = true
 [dependencies]
 # Include basic configuration (that brings most of basic extensions)
 "omni.app.dev" = {}
-"omni.kit.window.material_graph" = {}
+"omni.kit.window.material_graph" = {optional = true}
 "cesium.omniverse" = {}
 "cesium.powertools" = {}
 #"omni.example.ui" = {}


### PR DESCRIPTION
This allows the application to launch without installing the Nvidia launcher.