### PR TITLE
Powertools context menu for cartographic polygon conversion 

### DIFF
--- a/exts/cesium.powertools/cesium/powertools/context_menu.py
+++ b/exts/cesium.powertools/cesium/powertools/context_menu.py
@@ -1,0 +1,74 @@
+import omni.kit.commands
+import omni.kit.context_menu
+from pxr import UsdGeom
+from .utils import (
+    convert_curves_to_polygons,
+)
+from cesium.usd.plugins.CesiumUsdSchemas import CartographicPolygon
+
+
+class ContextMenu:
+    @classmethod
+    def startup(cls):
+        # Adds the option to the viewport context menu
+        cls._register_viewport_context_menu()
+
+        # Adds the option to the stage window context menu
+        manager = omni.kit.app.get_app().get_extension_manager()
+        cls._hooks = manager.subscribe_to_extension_enable(
+            on_enable_fn=lambda _: cls._register_stage_context_menu(),
+            on_disable_fn=lambda _: cls._unregister_stage_context_menu(),
+            ext_name="omni.kit.window.stage",
+            hook_name="listener",
+        )
+
+    @classmethod
+    def shutdown(cls):
+        cls._unregister_viewport_context_menu()
+        cls._unregister_stage_context_menu()
+
+    @classmethod
+    def _add_convert_curve_menu_impl(cls, extension: str):
+        menu = {
+            "name": "Convert to Cesium Cartographic Polygon",
+            "glyph": "copy.svg",
+            "show_fn": cls._is_selected_all_curve,
+            "onclick_fn": cls._convert_curves,
+        }
+        return omni.kit.context_menu.add_menu(menu, "MENU", extension)
+
+    @classmethod
+    def _register_viewport_context_menu(cls):
+        cls._convert_curve_viewport_entry = cls._add_convert_curve_menu_impl("omni.kit.window.viewport")
+
+    @classmethod
+    def _unregister_viewport_context_menu(cls):
+        cls._convert_curve_viewport_entry = None
+
+    @classmethod
+    def _register_stage_context_menu(cls):
+        cls._convert_curve_stage_entry = cls._add_convert_curve_menu_impl("omni.kit.widget.stage")
+
+    @classmethod
+    def _unregister_stage_context_menu(cls):
+        cls._convert_curve_stage_entry = None
+
+    @staticmethod
+    def _is_selected_all_curve(object: dict):
+        prim_list = object.get("prim_list", [])
+        if not prim_list:
+            return False
+
+        for prim in prim_list:
+            if not prim.IsA(UsdGeom.BasisCurves):
+                return False
+            if prim.IsA(CartographicPolygon):
+                return False
+
+        return True
+
+    @classmethod
+    def _convert_curves(cls, object: dict):
+        prim_list = object.get("prim_list", [])
+        prim_list_str = [prim.GetPath().pathString for prim in prim_list if prim.IsA(UsdGeom.BasisCurves)]
+        convert_curves_to_polygons(prim_list_str)

--- a/exts/cesium.powertools/cesium/powertools/extension.py
+++ b/exts/cesium.powertools/cesium/powertools/extension.py
@@ -8,7 +8,7 @@ import omni.kit.ui
 from .powertools_window import CesiumPowertoolsWindow
 from cesium.omniverse.utils import wait_n_frames, dock_window_async
 from cesium.omniverse.install import WheelInfo, WheelInstaller
-
+from .context_menu import ContextMenu
 
 class CesiumPowertoolsExtension(omni.ext.IExt):
     def __init__(self):
@@ -25,9 +25,11 @@ class CesiumPowertoolsExtension(omni.ext.IExt):
 
         self._setup_menus()
         self._show_and_dock_startup_windows()
+        ContextMenu.startup()
 
     def on_shutdown(self):
         self._destroy_powertools_window()
+        ContextMenu.shutdown()
 
     def _setup_menus(self):
         ui.Workspace.set_show_window_fn(

--- a/exts/cesium.powertools/cesium/powertools/powertools_window.py
+++ b/exts/cesium.powertools/cesium/powertools/powertools_window.py
@@ -8,7 +8,6 @@ from .utils import (
     save_carb_settings,
     save_fabric_stage,
     set_sunstudy_from_georef,
-    convert_curves_to_polygons,
 )
 import os
 from functools import partial
@@ -52,7 +51,6 @@ class CesiumPowertoolsWindow(ui.Window):
             PowertoolsAction("Save Carb Settings", partial(save_carb_settings, powertools_extension_location)),
             PowertoolsAction("Save Fabric Stage", partial(save_fabric_stage, powertools_extension_location)),
             PowertoolsAction("Set Sun Study from Georef", set_sunstudy_from_georef),
-            PowertoolsAction("BasisCurves to Cartographic Polygons", convert_curves_to_polygons),
         ]
 
         self.frame.set_build_fn(self._build_fn)

--- a/exts/cesium.powertools/cesium/powertools/utils/utils.py
+++ b/exts/cesium.powertools/cesium/powertools/utils/utils.py
@@ -85,13 +85,13 @@ def set_sunstudy_from_georef():
     north_attr.Set(90.0)  # Always set to 90, otherwise the sun is at the wrong angle
 
 
-async def convert():
+async def convert(prim_path_list):
     ctx = omni.usd.get_context()
     stage = ctx.get_stage()
     logger = logging.getLogger(__name__)
 
-    selection = ctx.get_selection().get_selected_prim_paths()
-    for curve_path in selection:
+    # selection = ctx.get_selection().get_selected_prim_paths()
+    for curve_path in prim_path_list:
         curve_prim = stage.GetPrimAtPath(curve_path)
 
         if curve_prim.GetTypeName() != "BasisCurves":
@@ -123,5 +123,5 @@ async def convert():
                 polygon_prim.GetAttribute(attrib.GetName()).Clear()
 
 
-def convert_curves_to_polygons():
-    ensure_future(convert())
+def convert_curves_to_polygons(prim_path_list):
+    ensure_future(convert(prim_path_list))


### PR DESCRIPTION
This PR adds a context menu option to Powertools that converts Basis Curves into Cesium Cartographic Polygons.

The option is available in both the viewport 
![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/0bd8e94e-97d3-46a6-ae53-cf56f9b33d63)

And the stage window
![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/e67ac696-9482-4ce6-9cbd-b3006f5cd971)

I have based this implementation off `context_menu.py` in `omni.curve.manipulator`

The context menu item will be visible with one or more Basis Curves selected.  It will not display if any non-basis curve prims are selected.

The logic for conversion is using the pre-existing code for converting Basis Curves, and will quite possibly need changing once https://github.com/CesiumGS/cesium-omniverse/pull/626 is merged due to globe anchor changes.

I'd also propose this functionality be moved from powertools into the core plugin before the next release, given the limitations for authoring Cesium Cartographic Polygons at this stage.