### PR TITLE
Fix globe anchors on prims that don't have all xform ops set 

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -2,7 +2,13 @@ from .bindings import acquire_cesium_omniverse_interface, release_cesium_omniver
 from .ui.add_menu_controller import CesiumAddMenuController
 from .install import perform_vendor_install
 from .utils import wait_n_frames, dock_window_async, perform_action_after_n_frames_async
-from .usdUtils import add_tileset_ion, add_raster_overlay_ion, add_cartographic_polygon, get_or_create_cesium_data, get_or_create_cesium_georeference
+from .usdUtils import (
+    add_tileset_ion,
+    add_raster_overlay_ion,
+    add_cartographic_polygon,
+    get_or_create_cesium_data,
+    get_or_create_cesium_georeference,
+)
 from .ui.asset_window import CesiumOmniverseAssetWindow
 from .ui.debug_window import CesiumOmniverseDebugWindow
 from .ui.main_window import CesiumOmniverseMainWindow

--- a/exts/cesium.omniverse/cesium/omniverse/extension.py
+++ b/exts/cesium.omniverse/cesium/omniverse/extension.py
@@ -2,7 +2,7 @@ from .bindings import acquire_cesium_omniverse_interface, release_cesium_omniver
 from .ui.add_menu_controller import CesiumAddMenuController
 from .install import perform_vendor_install
 from .utils import wait_n_frames, dock_window_async, perform_action_after_n_frames_async
-from .usdUtils import add_tileset_ion, add_raster_overlay_ion, add_cartographic_polygon, get_or_create_cesium_data
+from .usdUtils import add_tileset_ion, add_raster_overlay_ion, add_cartographic_polygon, get_or_create_cesium_data, get_or_create_cesium_georeference
 from .ui.asset_window import CesiumOmniverseAssetWindow
 from .ui.debug_window import CesiumOmniverseDebugWindow
 from .ui.main_window import CesiumOmniverseMainWindow
@@ -271,6 +271,7 @@ class CesiumOmniverseExtension(omni.ext.IExt):
                 asyncio.ensure_future(perform_action_after_n_frames_async(15, CesiumOmniverseExtension._open_modal))
 
             get_or_create_cesium_data()
+            get_or_create_cesium_georeference()
 
             self._setup_ion_server_prims()
         elif event.type == int(omni.usd.StageEventType.CLOSED):

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -5,6 +5,7 @@
 #include <glm/fwd.hpp>
 #include <pxr/base/gf/declare.h>
 #include <pxr/usd/usd/common.h>
+#include <pxr/usd/usdGeom/xformOp.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 class CesiumCartographicPolygon;
@@ -139,13 +140,20 @@ bool hasCesiumGlobeAnchor(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath
 bool isUsdShader(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path);
 bool isUsdMaterial(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path);
 
+glm::dvec3 getTranslate(const pxr::UsdGeomXformOp& translateOp);
+glm::dvec3 getRotate(const pxr::UsdGeomXformOp& rotateOp);
+glm::dvec3 getScale(const pxr::UsdGeomXformOp& scaleOp);
+void setTranslate(pxr::UsdGeomXformOp& translateOp, const glm::dvec3& translate);
+void setRotate(pxr::UsdGeomXformOp& rotateOp, const glm::dvec3& rotate);
+void setScale(pxr::UsdGeomXformOp& scaleOp, const glm::dvec3& scale);
+
 struct TranslateRotateScaleOps {
-    const pxr::UsdGeomXformOp* pTranslateOp;
-    const pxr::UsdGeomXformOp* pRotateOp;
-    const pxr::UsdGeomXformOp* pScaleOp;
+    pxr::UsdGeomXformOp translateOp;
+    pxr::UsdGeomXformOp rotateOp;
+    pxr::UsdGeomXformOp scaleOp;
     MathUtil::EulerAngleOrder eulerAngleOrder;
 };
 
-std::optional<TranslateRotateScaleOps> getTranslateRotateScaleOps(const pxr::UsdGeomXformable& xformable);
+std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const pxr::UsdGeomXformable& xformable);
 
 }; // namespace cesium::omniverse::UsdUtil


### PR DESCRIPTION
Globe anchors were only working on prims that had either all xform ops set or no xform ops set.

The code below where only the translation is set now works:


```python
from cesium.usd.plugins.CesiumUsdSchemas import CartographicPolygon
from asyncio import ensure_future
from pxr import UsdGeom

polygon_path = "/polygon"
ctx = omni.usd.get_context()
stage = ctx.get_stage()
polygon = CartographicPolygon.Define(stage, polygon_path)
polygon_prim = polygon.GetPrim()
xformCommonApi = UsdGeom.XformCommonAPI(polygon_prim)
xformCommonApi.SetTranslate((10, 0, 0))
```