### PR TITLE
Use _materialSource when copying tileset materials

### DIFF
--- a/src/core/include/cesium/omniverse/FabricUtil.h
+++ b/src/core/include/cesium/omniverse/FabricUtil.h
@@ -41,7 +41,7 @@ std::vector<omni::fabric::Path> copyMaterial(
     omni::fabric::StageReaderWriter& fabricStage,
     const omni::fabric::Path& srcMaterialPath,
     const omni::fabric::Path& dstMaterialPath);
-bool materialHasCesiumNodes(omni::fabric::StageReaderWriter& fabricStage, const omni::fabric::Path& path);
+bool materialHasCesiumNodes(omni::fabric::StageReaderWriter& fabricStage, const omni::fabric::Path& materialPath);
 bool isCesiumNode(const omni::fabric::Token& mdlIdentifier);
 bool isCesiumPropertyNode(const omni::fabric::Token& mdlIdentifier);
 bool isShaderConnectedToMaterial(

--- a/src/core/include/cesium/omniverse/UsdTokens.h
+++ b/src/core/include/cesium/omniverse/UsdTokens.h
@@ -85,6 +85,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     (_cesium_gltfLocalToEcefTransform) \
     (_cesium_tilesetId) \
     (_deletedPrims) \
+    (_materialSource) \
     (_paramColorSpace) \
     (_sdrMetadata) \
     (_worldExtent) \
@@ -274,6 +275,7 @@ const omni::fabric::Type Shader(omni::fabric::BaseDataType::eTag, 1, 0, omni::fa
 const omni::fabric::Type subdivisionScheme(omni::fabric::BaseDataType::eToken, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _cesium_gltfLocalToEcefTransform(omni::fabric::BaseDataType::eDouble, 16, 0, omni::fabric::AttributeRole::eMatrix);
 const omni::fabric::Type _cesium_tilesetId(omni::fabric::BaseDataType::eInt64, 1, 0, omni::fabric::AttributeRole::eNone);
+const omni::fabric::Type _materialSource(omni::fabric::BaseDataType::eRelationship, 1, 0, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _paramColorSpace(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _sdrMetadata(omni::fabric::BaseDataType::eToken, 1, 1, omni::fabric::AttributeRole::eNone);
 const omni::fabric::Type _worldExtent(omni::fabric::BaseDataType::eDouble, 6, 0, omni::fabric::AttributeRole::eNone);


### PR DESCRIPTION
Sometimes materials reference a `_materialSource` prim, which seems to be related to a new material pooling mechanism in Omniverse. In order to copy a tileset material to tiles it needs to copy from `_materialSource`.

For testing: [tileset-material-workaround.zip](https://github.com/CesiumGS/cesium-omniverse/files/14088414/tileset-material-workaround.zip) (the cube in there is a workaround for https://github.com/CesiumGS/cesium-omniverse/issues/607)

```
Prim: /World/Looks/Material (59393)
  Attributes:
    Attribute: _materialSource
      Type: rel
      Value: [38913]
    Attribute: Material
      Type: tag (primTypeName)
    Attribute: MergedMaterial
      Type: tag (primTypeName)
    Attribute: UsdTyped
      Type: tag (ancestorPrimTypeName)
    Attribute: NodeGraph
      Type: tag (ancestorPrimTypeName)
    Attribute: UsdSchemaBase
      Type: tag (ancestorPrimTypeName)
    Attribute: TfType::_Root
      Type: tag (ancestorPrimTypeName)

...

Prim: /__Fabric_StageInfo/MaterialPool/mat_35728244 (38913)
  Attributes:
    Attribute: _hash
      Type: uint64
      Value: 17650506036130513476
    Attribute: outputs:volume
      Type: token
      Value: 
    Attribute: outputs:displacement
      Type: token
      Value: 
    Attribute: outputs:surface
      Type: token
      Value: 
    Attribute: outputs:mdl:surface
      Type: token
      Value: 
    Attribute: outputs:mdl:volume
      Type: token
      Value: 
    Attribute: outputs:mdl:displacement
      Type: token
      Value: 
    Attribute: outputs:volume
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: outputs:displacement
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: outputs:surface
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: outputs:mdl:surface
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: outputs:mdl:volume
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: outputs:mdl:displacement
      Type: connection
      Value: Path: /__Fabric_StageInfo/MaterialPool/mat_35728244/cesium_material, Attribute Name: out
    Attribute: Material
      Type: tag (primTypeName)
    Attribute: UsdTyped
      Type: tag (ancestorPrimTypeName)
    Attribute: NodeGraph
      Type: tag (ancestorPrimTypeName)
    Attribute: UsdSchemaBase
      Type: tag (ancestorPrimTypeName)
    Attribute: TfType::_Root
      Type: tag (ancestorPrimTypeName)
```