### PR TITLE
Only print warnings for properties that are in use

### DIFF
--- a/src/core/include/cesium/omniverse/CppUtil.h
+++ b/src/core/include/cesium/omniverse/CppUtil.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <optional>
 #include <set>
 #include <unordered_set>
@@ -60,6 +61,10 @@ template <typename T, size_t C, typename U> bool contains(const std::array<T, C>
 
 template <typename T, typename U> bool contains(const std::unordered_set<T>& set, const U& value) {
     return set.find(value) != set.end();
+}
+
+template <typename T, typename U> bool contains(const std::map<T, U>& map, const U& value) {
+    return map.find(value) != map.end();
 }
 
 template <typename T, typename U> bool containsByMember(const std::vector<T>& vector, U T::*member, const U& value) {

--- a/src/core/include/cesium/omniverse/FabricMaterialDescriptor.h
+++ b/src/core/include/cesium/omniverse/FabricMaterialDescriptor.h
@@ -46,6 +46,7 @@ class FabricMaterialDescriptor {
     [[nodiscard]] bool hasTilesetMaterial() const;
     [[nodiscard]] const pxr::SdfPath& getTilesetMaterialPath() const;
     [[nodiscard]] const std::vector<FabricPropertyDescriptor>& getStyleableProperties() const;
+    [[nodiscard]] const std::map<std::string, std::string>& getUnsupportedPropertyWarnings() const;
 
     bool operator==(const FabricMaterialDescriptor& other) const;
 
@@ -56,6 +57,7 @@ class FabricMaterialDescriptor {
     std::vector<FabricOverlayRenderMethod> _rasterOverlayRenderMethods;
     pxr::SdfPath _tilesetMaterialPath;
     std::vector<FabricPropertyDescriptor> _styleableProperties;
+    std::map<std::string, std::string> _unsupportedPropertyWarnings;
 };
 
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/Logger.h
+++ b/src/core/include/cesium/omniverse/Logger.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cesium/omniverse/CppUtil.h"
+
 #include <spdlog/logger.h>
 
 #include <unordered_set>
@@ -9,7 +11,26 @@ namespace cesium::omniverse {
 class Logger final : public spdlog::logger {
   public:
     Logger();
-    void oneTimeWarning(const std::string& warning);
+
+    template <typename T> void oneTimWarning(const T& warning) {
+        if (CppUtil::contains(_oneTimeWarnings, warning)) {
+            return;
+        }
+
+        _oneTimeWarnings.insert(warning);
+        warn(warning);
+    }
+
+    template <typename... Args> void oneTimeWarning(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+        const auto warning = fmt::format(fmt, std::forward<Args>(args)...);
+
+        if (CppUtil::contains(_oneTimeWarnings, warning)) {
+            return;
+        }
+
+        _oneTimeWarnings.insert(warning);
+        warn(warning);
+    }
 
   private:
     std::unordered_set<std::string> _oneTimeWarnings;

--- a/src/core/include/cesium/omniverse/MetadataUtil.h
+++ b/src/core/include/cesium/omniverse/MetadataUtil.h
@@ -47,7 +47,7 @@ void forEachPropertyAttributeProperty(
         if (!pPropertyAttribute) {
             if (logWarnings) {
                 context.getLogger()->oneTimeWarning(
-                    fmt::format("Property attribute index {} is out of range.", propertyAttributeIndex));
+                    "Property attribute index {} is out of range.", propertyAttributeIndex);
             }
             continue;
         }
@@ -55,9 +55,9 @@ void forEachPropertyAttributeProperty(
         const auto propertyAttributeView = CesiumGltf::PropertyAttributeView(model, *pPropertyAttribute);
         if (propertyAttributeView.status() != CesiumGltf::PropertyAttributeViewStatus::Valid) {
             if (logWarnings) {
-                context.getLogger()->oneTimeWarning(fmt::format(
+                context.getLogger()->oneTimeWarning(
                     "Property attribute is invalid and will be ignored. Status code: {}",
-                    static_cast<int>(propertyAttributeView.status())));
+                    static_cast<int>(propertyAttributeView.status()));
             }
             continue;
         }
@@ -72,10 +72,10 @@ void forEachPropertyAttributeProperty(
              &pPropertyAttribute](const std::string& propertyId, const auto& propertyAttributePropertyView) {
                 if (propertyAttributePropertyView.status() != CesiumGltf::PropertyAttributePropertyViewStatus::Valid) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "Property \"{}\" is invalid and will be ignored. Status code: {}",
                             propertyId,
-                            static_cast<int>(propertyAttributePropertyView.status())));
+                            static_cast<int>(propertyAttributePropertyView.status()));
                     }
                     return;
                 }
@@ -155,9 +155,9 @@ void forEachPropertyTextureProperty(
         const auto propertyTextureView = CesiumGltf::PropertyTextureView(model, *pPropertyTexture);
         if (propertyTextureView.status() != CesiumGltf::PropertyTextureViewStatus::Valid) {
             if (logWarnings) {
-                context.getLogger()->oneTimeWarning(fmt::format(
+                context.getLogger()->oneTimeWarning(
                     "Property texture is invalid and will be ignored. Status code: {}",
-                    static_cast<int>(propertyTextureView.status())));
+                    static_cast<int>(propertyTextureView.status()));
             }
             continue;
         }
@@ -171,10 +171,10 @@ void forEachPropertyTextureProperty(
              &pPropertyTexture](const std::string& propertyId, const auto& propertyTexturePropertyView) {
                 if (propertyTexturePropertyView.status() != CesiumGltf::PropertyTexturePropertyViewStatus::Valid) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "Property \"{}\" is invalid and will be ignored. Status code: {}",
                             propertyId,
-                            static_cast<int>(propertyTexturePropertyView.status())));
+                            static_cast<int>(propertyTexturePropertyView.status()));
                     }
                     return;
                 }
@@ -264,9 +264,9 @@ void forEachPropertyTableProperty(
             const auto propertyTableView = CesiumGltf::PropertyTableView(model, *pPropertyTable);
             if (propertyTableView.status() != CesiumGltf::PropertyTableViewStatus::Valid) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
+                    context.getLogger()->oneTimeWarning(
                         "Property table is invalid and will be ignored. Status code: {}",
-                        static_cast<int>(propertyTableView.status())));
+                        static_cast<int>(propertyTableView.status()));
                 }
                 continue;
             }
@@ -281,10 +281,10 @@ void forEachPropertyTableProperty(
                  featureIdSetIndex](const std::string& propertyId, const auto& propertyTablePropertyView) {
                     if (propertyTablePropertyView.status() != CesiumGltf::PropertyTablePropertyViewStatus::Valid) {
                         if (logWarnings) {
-                            context.getLogger()->oneTimeWarning(fmt::format(
+                            context.getLogger()->oneTimeWarning(
                                 "Property \"{}\" is invalid and will be ignored. Status code: {}",
                                 propertyId,
-                                static_cast<int>(propertyTablePropertyView.status())));
+                                static_cast<int>(propertyTablePropertyView.status()));
                         }
                         return;
                     }
@@ -361,9 +361,9 @@ void forEachStyleablePropertyAttributeProperty(
 
             if constexpr (DataTypeUtil::isMatrix<type>()) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
+                    context.getLogger()->oneTimeWarning(
                         "Matrix properties are not supported for styling. Property \"{}\" will be ignored.",
-                        propertyId));
+                        propertyId);
                 }
                 return;
             } else {
@@ -420,9 +420,8 @@ void forEachStyleablePropertyTextureProperty(
 
             if constexpr (IsArray) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
-                        "Array properties are not supported for styling. Property \"{}\" will be ignored.",
-                        propertyId));
+                    context.getLogger()->oneTimeWarning(
+                        "Array properties are not supported for styling. Property \"{}\" will be ignored.", propertyId);
                 }
                 return;
             } else {
@@ -430,10 +429,10 @@ void forEachStyleablePropertyTextureProperty(
 
                 if constexpr (DataTypeUtil::getComponentByteLength<type>() > 1) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "Only 8-bit per-component property texture properties are supported for styling. Property "
                             "\"{}\" will be ignored.",
-                            propertyId));
+                            propertyId);
                     }
                     return;
                 } else {
@@ -441,21 +440,21 @@ void forEachStyleablePropertyTextureProperty(
 
                     if (textureInfo.channels.size() != DataTypeUtil::getComponentCount<type>()) {
                         if (logWarnings) {
-                            context.getLogger()->oneTimeWarning(fmt::format(
+                            context.getLogger()->oneTimeWarning(
                                 "Properties with components that are packed across multiple texture channels are not "
                                 "supported for styling. Property \"{}\" will be ignored.",
-                                propertyId));
+                                propertyId);
                         }
                         return;
                     }
 
                     if (textureInfo.channels.size() > 4) {
                         if (logWarnings) {
-                            context.getLogger()->oneTimeWarning(fmt::format(
+                            context.getLogger()->oneTimeWarning(
                                 "Properties with more than four channels are not supported for styling. Property "
                                 "\"{}\" "
                                 "will be ignored.",
-                                propertyId));
+                                propertyId);
                         }
                         return;
                     }
@@ -514,23 +513,22 @@ void forEachStyleablePropertyTableProperty(
 
             if constexpr (IsArray) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
-                        "Array properties are not supported for styling. Property \"{}\" will be ignored.",
-                        propertyId));
+                    context.getLogger()->oneTimeWarning(
+                        "Array properties are not supported for styling. Property \"{}\" will be ignored.", propertyId);
                 }
                 return;
             } else if constexpr (IsBoolean) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
+                    context.getLogger()->oneTimeWarning(
                         "Boolean properties are not supported for styling. Property \"{}\" will be ignored.",
-                        propertyId));
+                        propertyId);
                 }
                 return;
             } else if constexpr (IsString) {
                 if (logWarnings) {
-                    context.getLogger()->oneTimeWarning(fmt::format(
+                    context.getLogger()->oneTimeWarning(
                         "String properties are not supported for styling. Property \"{}\" will be ignored.",
-                        propertyId));
+                        propertyId);
                 }
                 return;
             } else {
@@ -539,43 +537,43 @@ void forEachStyleablePropertyTableProperty(
 
                 if constexpr (DataTypeUtil::isMatrix<type>()) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "Matrix properties are not supported for styling. Property \"{}\" will be ignored.",
-                            propertyId));
+                            propertyId);
                     }
                     return;
                 } else if constexpr (unnormalizedComponentType == DataType::UINT32) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "UINT32 properties are not supported for styling due to potential precision loss. Property "
                             "\"{}\" will be ignored.",
-                            propertyId));
+                            propertyId);
                     }
                     return;
                 } else if constexpr (unnormalizedComponentType == DataType::UINT64) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "UINT64 properties are not supported for styling due to potential precision loss. Property "
                             "\"{}\" will be ignored.",
-                            propertyId));
+                            propertyId);
                     }
                     return;
                 } else if constexpr (unnormalizedComponentType == DataType::INT64) {
                     if (logWarnings) {
-                        context.getLogger()->oneTimeWarning(fmt::format(
+                        context.getLogger()->oneTimeWarning(
                             "INT64 properties are not supported for styling due to potential precision loss. Property "
                             "\"{}\" will be ignored.",
-                            propertyId));
+                            propertyId);
                     }
                     return;
                 } else {
                     if constexpr (unnormalizedComponentType == DataType::FLOAT64) {
                         if (logWarnings) {
-                            context.getLogger()->oneTimeWarning(fmt::format(
+                            context.getLogger()->oneTimeWarning(
                                 "64-bit float properties are converted to 32-bit floats for styling. Some precision "
                                 "loss "
                                 "may occur for property \"{}\".",
-                                propertyId));
+                                propertyId);
                         }
                     }
 

--- a/src/core/include/cesium/omniverse/MetadataUtil.h
+++ b/src/core/include/cesium/omniverse/MetadataUtil.h
@@ -22,12 +22,12 @@ struct FabricTextureData;
 
 namespace cesium::omniverse::MetadataUtil {
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachPropertyAttributeProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     const auto pStructuralMetadataModel = model.getExtension<CesiumGltf::ExtensionModelExtStructuralMetadata>();
@@ -60,7 +60,7 @@ void forEachPropertyAttributeProperty(
         propertyAttributeView.forEachProperty(
             primitive,
             [&context,
-             &supportedCallback,
+             callback = std::forward<Callback>(callback),
              &unsupportedCallback,
              &propertyAttributeView,
              &pStructuralMetadataModel,
@@ -99,7 +99,7 @@ void forEachPropertyAttributeProperty(
 
                 const auto& propertyAttributeProperty = pPropertyAttribute->properties.at(propertyId);
 
-                supportedCallback(
+                callback(
                     propertyId,
                     schema.value(),
                     *pClassDefinition,
@@ -112,12 +112,12 @@ void forEachPropertyAttributeProperty(
     }
 }
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachPropertyTextureProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     const auto pStructuralMetadataModel = model.getExtension<CesiumGltf::ExtensionModelExtStructuralMetadata>();
@@ -149,7 +149,7 @@ void forEachPropertyTextureProperty(
 
         propertyTextureView.forEachProperty(
             [&context,
-             &supportedCallback,
+             callback = std::forward<Callback>(callback),
              &unsupportedCallback,
              &propertyTextureView,
              &pStructuralMetadataModel,
@@ -194,7 +194,7 @@ void forEachPropertyTextureProperty(
 
                 const auto& propertyTextureProperty = pPropertyTexture->properties.at(propertyId);
 
-                supportedCallback(
+                callback(
                     propertyId,
                     schema.value(),
                     *pClassDefinition,
@@ -207,12 +207,12 @@ void forEachPropertyTextureProperty(
     }
 }
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachPropertyTableProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     const auto pStructuralMetadataModel = model.getExtension<CesiumGltf::ExtensionModelExtStructuralMetadata>();
@@ -247,7 +247,7 @@ void forEachPropertyTableProperty(
 
             propertyTableView.forEachProperty(
                 [&context,
-                 &supportedCallback,
+                 callback = std::forward<Callback>(callback),
                  &unsupportedCallback,
                  &propertyTableView,
                  &pStructuralMetadataModel,
@@ -287,7 +287,7 @@ void forEachPropertyTableProperty(
 
                     const auto& propertyTableProperty = pPropertyTable->properties.at(propertyId);
 
-                    supportedCallback(
+                    callback(
                         propertyId,
                         schema.value(),
                         *pClassDefinition,
@@ -302,19 +302,19 @@ void forEachPropertyTableProperty(
     }
 }
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachStyleablePropertyAttributeProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     forEachPropertyAttributeProperty(
         context,
         model,
         primitive,
-        [&context, &supportedCallback, &unsupportedCallback](
+        [&context, callback = std::forward<Callback>(callback), &unsupportedCallback](
             const std::string& propertyId,
             [[maybe_unused]] const CesiumGltf::Schema& schema,
             [[maybe_unused]] const CesiumGltf::Class& classDefinition,
@@ -354,25 +354,25 @@ void forEachStyleablePropertyAttributeProperty(
                         propertyInfo,
                     };
 
-                supportedCallback(propertyId, propertyAttributePropertyView, property);
+                callback(propertyId, propertyAttributePropertyView, property);
             }
         },
         unsupportedCallback);
 }
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachStyleablePropertyTextureProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     forEachPropertyTextureProperty(
         context,
         model,
         primitive,
-        [&context, &supportedCallback, &unsupportedCallback, &model](
+        [&context, callback = std::forward<Callback>(callback), &unsupportedCallback, &model](
             const std::string& propertyId,
             [[maybe_unused]] const CesiumGltf::Schema& schema,
             [[maybe_unused]] const CesiumGltf::Class& classDefinition,
@@ -444,26 +444,26 @@ void forEachStyleablePropertyTextureProperty(
                             propertyInfo,
                         };
 
-                    supportedCallback(propertyId, propertyTexturePropertyView, property);
+                    callback(propertyId, propertyTexturePropertyView, property);
                 }
             }
         },
         unsupportedCallback);
 }
 
-template <typename SupportedCallback, typename UnsupportedCallback>
+template <typename Callback, typename UnsupportedCallback>
 void forEachStyleablePropertyTableProperty(
     const Context& context,
     const CesiumGltf::Model& model,
     const CesiumGltf::MeshPrimitive& primitive,
-    const SupportedCallback& supportedCallback,
+    Callback&& callback,
     const UnsupportedCallback& unsupportedCallback) {
 
     forEachPropertyTableProperty(
         context,
         model,
         primitive,
-        [&context, &supportedCallback, &unsupportedCallback](
+        [&context, callback = std::forward<Callback>(callback), &unsupportedCallback](
             const std::string& propertyId,
             [[maybe_unused]] const CesiumGltf::Schema& schema,
             [[maybe_unused]] const CesiumGltf::Class& classDefinition,
@@ -562,7 +562,7 @@ void forEachStyleablePropertyTableProperty(
                             propertyInfo,
                         };
 
-                    supportedCallback(propertyId, propertyTablePropertyView, property);
+                    callback(propertyId, propertyTablePropertyView, property);
                 }
             }
         },

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -1699,7 +1699,7 @@ void FabricMaterial::createConnectionsToProperties() {
         const auto index = CppUtil::indexOfByMember(properties, &FabricPropertyDescriptor::propertyId, propertyId);
 
         if (index == properties.size()) {
-            _pContext->getLogger()->warn(
+            _pContext->getLogger()->oneTimeWarning(
                 "Could not find property \"{}\" referenced by {}. A default value will be returned instead.",
                 propertyId,
                 mdlIdentifier.getText());
@@ -1709,7 +1709,7 @@ void FabricMaterial::createConnectionsToProperties() {
         const auto propertyTypeInternal = properties[index].type;
 
         if (!FabricUtil::typesCompatible(propertyTypeExternal, propertyTypeInternal)) {
-            _pContext->getLogger()->warn(
+            _pContext->getLogger()->oneTimeWarning(
                 "Property \"{}\" referenced by {} has incompatible type. A default value will be returned instead.",
                 propertyId,
                 mdlIdentifier.getText());

--- a/src/core/src/FabricMaterial.cpp
+++ b/src/core/src/FabricMaterial.cpp
@@ -1524,6 +1524,9 @@ void FabricMaterial::setMaterial(
         return _propertyPaths[index];
     };
 
+    const auto unsupportedCallback = []([[maybe_unused]] const std::string& propertyId,
+                                        [[maybe_unused]] const std::string& warning) {};
+
     MetadataUtil::forEachStyleablePropertyAttributeProperty(
         *_pContext,
         model,
@@ -1555,7 +1558,7 @@ void FabricMaterial::setMaterial(
                 noData,
                 defaultValue);
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedCallback);
 
     MetadataUtil::forEachStyleablePropertyTextureProperty(
         *_pContext,
@@ -1594,7 +1597,7 @@ void FabricMaterial::setMaterial(
                 noData,
                 defaultValue);
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedCallback);
 
     uint64_t propertyTablePropertyCounter = 0;
 
@@ -1630,7 +1633,7 @@ void FabricMaterial::setMaterial(
                 noData,
                 defaultValue);
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedCallback);
 
     for (const auto& path : _allPaths) {
         auto& fabricStage = _pContext->getFabricStage();

--- a/src/core/src/FabricMaterialDescriptor.cpp
+++ b/src/core/src/FabricMaterialDescriptor.cpp
@@ -29,10 +29,10 @@ FabricMaterialDescriptor::FabricMaterialDescriptor(
     , _hasBaseColorTexture(materialInfo.baseColorTexture.has_value())
     , _featureIdTypes(FabricFeaturesUtil::getFeatureIdTypes(featuresInfo))
     , _rasterOverlayRenderMethods(rasterOverlaysInfo.overlayRenderMethods)
-    , _tilesetMaterialPath(tilesetMaterialPath)
-    , _styleableProperties(
-          // Only log warnings for unsupported properties if the tileset has a material that could potentially reference properties
-          MetadataUtil::getStyleableProperties(context, model, primitive, !tilesetMaterialPath.IsEmpty())) {}
+    , _tilesetMaterialPath(tilesetMaterialPath) {
+    std::tie(_styleableProperties, _unsupportedPropertyWarnings) =
+        MetadataUtil::getStyleableProperties(context, model, primitive);
+}
 
 bool FabricMaterialDescriptor::hasVertexColors() const {
     return _hasVertexColors;
@@ -62,6 +62,10 @@ const std::vector<FabricPropertyDescriptor>& FabricMaterialDescriptor::getStylea
     return _styleableProperties;
 }
 
+const std::map<std::string, std::string>& FabricMaterialDescriptor::getUnsupportedPropertyWarnings() const {
+    return _unsupportedPropertyWarnings;
+}
+
 // Make sure to update this function when adding new fields to the class
 // In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDescriptor::operator==(const FabricMaterialDescriptor& other) const {
@@ -71,7 +75,8 @@ bool FabricMaterialDescriptor::operator==(const FabricMaterialDescriptor& other)
            _featureIdTypes == other._featureIdTypes &&
            _rasterOverlayRenderMethods == other._rasterOverlayRenderMethods &&
            _tilesetMaterialPath == other._tilesetMaterialPath &&
-           _styleableProperties == other._styleableProperties;
+           _styleableProperties == other._styleableProperties &&
+           _unsupportedPropertyWarnings == other._unsupportedPropertyWarnings;
     // clang-format on
 }
 

--- a/src/core/src/FabricMaterialDescriptor.cpp
+++ b/src/core/src/FabricMaterialDescriptor.cpp
@@ -67,7 +67,6 @@ const std::map<std::string, std::string>& FabricMaterialDescriptor::getUnsupport
 }
 
 // Make sure to update this function when adding new fields to the class
-// In C++ 20 we can use the default equality comparison (= default)
 bool FabricMaterialDescriptor::operator==(const FabricMaterialDescriptor& other) const {
     // clang-format off
     return _hasVertexColors == other._hasVertexColors &&
@@ -75,8 +74,9 @@ bool FabricMaterialDescriptor::operator==(const FabricMaterialDescriptor& other)
            _featureIdTypes == other._featureIdTypes &&
            _rasterOverlayRenderMethods == other._rasterOverlayRenderMethods &&
            _tilesetMaterialPath == other._tilesetMaterialPath &&
-           _styleableProperties == other._styleableProperties &&
-           _unsupportedPropertyWarnings == other._unsupportedPropertyWarnings;
+           _styleableProperties == other._styleableProperties;
+           // _unsupportedPropertyWarnings is intentionally not checked
+
     // clang-format on
 }
 

--- a/src/core/src/FabricMaterialDescriptor.cpp
+++ b/src/core/src/FabricMaterialDescriptor.cpp
@@ -75,7 +75,7 @@ bool FabricMaterialDescriptor::operator==(const FabricMaterialDescriptor& other)
            _rasterOverlayRenderMethods == other._rasterOverlayRenderMethods &&
            _tilesetMaterialPath == other._tilesetMaterialPath &&
            _styleableProperties == other._styleableProperties;
-           // _unsupportedPropertyWarnings is intentionally not checked
+           // _unsupportedPropertyWarnings is intentionally not checked because it adds unecessary overhead
 
     // clang-format on
 }

--- a/src/core/src/FabricPrepareRenderResources.cpp
+++ b/src/core/src/FabricPrepareRenderResources.cpp
@@ -145,15 +145,13 @@ std::vector<FabricMesh> acquireFabricMeshes(
             fabricMesh.featureIdTextures.push_back(fabricResourceManager.acquireTexture());
         }
 
-        const auto propertyTextureCount =
-            MetadataUtil::getPropertyTextureImages(context, model, primitive, false).size();
+        const auto propertyTextureCount = MetadataUtil::getPropertyTextureImages(context, model, primitive).size();
         fabricMesh.propertyTextures.reserve(propertyTextureCount);
         for (uint64_t i = 0; i < propertyTextureCount; ++i) {
             fabricMesh.propertyTextures.push_back(fabricResourceManager.acquireTexture());
         }
 
-        const auto propertyTableTextureCount =
-            MetadataUtil::getPropertyTableTextureCount(context, model, primitive, false);
+        const auto propertyTableTextureCount = MetadataUtil::getPropertyTableTextureCount(context, model, primitive);
         fabricMesh.propertyTableTextures.reserve(propertyTableTextureCount);
         for (uint64_t i = 0; i < propertyTableTextureCount; ++i) {
             fabricMesh.propertyTableTextures.push_back(fabricResourceManager.acquireTexture());
@@ -181,7 +179,7 @@ std::vector<FabricMesh> acquireFabricMeshes(
 
         // Map glTF texture index to property texture (FabricTexture) index
         fabricMesh.propertyTextureIndexMapping =
-            MetadataUtil::getPropertyTextureIndexMapping(context, model, primitive, false);
+            MetadataUtil::getPropertyTextureIndexMapping(context, model, primitive);
     }
 
     return fabricMeshes;
@@ -220,13 +218,13 @@ void setFabricTextures(
             }
         }
 
-        const auto propertyTextureImages = MetadataUtil::getPropertyTextureImages(context, model, primitive, false);
+        const auto propertyTextureImages = MetadataUtil::getPropertyTextureImages(context, model, primitive);
         const auto propertyTextureCount = fabricMesh.propertyTextures.size();
         for (uint64_t j = 0; j < propertyTextureCount; ++j) {
             fabricMesh.propertyTextures[j]->setImage(*propertyTextureImages[j], TransferFunction::LINEAR);
         }
 
-        const auto propertyTableTextures = MetadataUtil::encodePropertyTables(context, model, primitive, false);
+        const auto propertyTableTextures = MetadataUtil::encodePropertyTables(context, model, primitive);
         const auto propertyTableTextureCount = fabricMesh.propertyTableTextures.size();
         for (uint64_t j = 0; j < propertyTableTextureCount; ++j) {
             const auto& texture = propertyTableTextures[j];

--- a/src/core/src/Logger.cpp
+++ b/src/core/src/Logger.cpp
@@ -16,13 +16,4 @@ Logger::Logger()
               std::make_shared<LoggerSink>(omni::log::Level::eFatal),
           }) {}
 
-void Logger::oneTimeWarning(const std::string& warning) {
-    if (CppUtil::contains(_oneTimeWarnings, warning)) {
-        return;
-    }
-
-    _oneTimeWarnings.insert(warning);
-    warn(warning);
-}
-
 } // namespace cesium::omniverse

--- a/src/core/src/MetadataUtil.cpp
+++ b/src/core/src/MetadataUtil.cpp
@@ -14,6 +14,11 @@ std::tuple<std::vector<FabricPropertyDescriptor>, std::map<std::string, std::str
     std::vector<FabricPropertyDescriptor> properties;
     std::map<std::string, std::string> unsupportedPropertyWarnings;
 
+    const auto unsupportedPropertyCallback =
+        [&unsupportedPropertyWarnings](const std::string& propertyId, const std::string& warning) {
+            unsupportedPropertyWarnings.insert({propertyId, warning});
+        };
+
     forEachStyleablePropertyAttributeProperty(
         context,
         model,
@@ -32,9 +37,7 @@ std::tuple<std::vector<FabricPropertyDescriptor>, std::map<std::string, std::str
                 0, // featureIdSetIndex not relevant for property attributes
             });
         },
-        [&unsupportedPropertyWarnings](const std::string& propertyId, const std::string& warning) {
-            unsupportedPropertyWarnings.insert({propertyId, warning});
-        });
+        unsupportedPropertyCallback);
 
     forEachStyleablePropertyTextureProperty(
         context,
@@ -54,9 +57,7 @@ std::tuple<std::vector<FabricPropertyDescriptor>, std::map<std::string, std::str
                 0, // featureIdSetIndex not relevant for property textures
             });
         },
-        [&unsupportedPropertyWarnings](const std::string& propertyId, const std::string& warning) {
-            unsupportedPropertyWarnings.insert({propertyId, warning});
-        });
+        unsupportedPropertyCallback);
 
     forEachStyleablePropertyTableProperty(
         context,
@@ -76,9 +77,7 @@ std::tuple<std::vector<FabricPropertyDescriptor>, std::map<std::string, std::str
                 property.featureIdSetIndex,
             });
         },
-        [&unsupportedPropertyWarnings](const std::string& propertyId, const std::string& warning) {
-            unsupportedPropertyWarnings.insert({propertyId, warning});
-        });
+        unsupportedPropertyCallback);
 
     // Sorting is important for checking FabricMaterialDescriptor equality
     CppUtil::sort(properties, [](const auto& lhs, const auto& rhs) { return lhs.propertyId > rhs.propertyId; });

--- a/src/core/src/MetadataUtil.cpp
+++ b/src/core/src/MetadataUtil.cpp
@@ -7,6 +7,11 @@
 
 namespace cesium::omniverse::MetadataUtil {
 
+namespace {
+const auto unsupportedPropertyCallbackNoop = []([[maybe_unused]] const std::string& propertyId,
+                                                [[maybe_unused]] const std::string& warning) {};
+}
+
 std::tuple<std::vector<FabricPropertyDescriptor>, std::map<std::string, std::string>> getStyleableProperties(
     const Context& context,
     const CesiumGltf::Model& model,
@@ -107,7 +112,7 @@ std::vector<const CesiumGltf::ImageCesium*> getPropertyTextureImages(
                 images.push_back(pImage);
             }
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedPropertyCallbackNoop);
 
     return images;
 }
@@ -138,7 +143,7 @@ std::unordered_map<uint64_t, uint64_t> getPropertyTextureIndexMapping(
             const auto textureIndex = property.textureIndex;
             propertyTextureIndexMapping[textureIndex] = imageIndex;
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedPropertyCallbackNoop);
 
     return propertyTextureIndexMapping;
 }
@@ -204,7 +209,7 @@ std::vector<FabricTextureData> encodePropertyTables(
                 textureFormat,
             });
         },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedPropertyCallbackNoop);
 
     return textures;
 }
@@ -223,7 +228,7 @@ uint64_t getPropertyTableTextureCount(
             [[maybe_unused]] const std::string& propertyId,
             [[maybe_unused]] const auto& propertyTablePropertyView,
             [[maybe_unused]] const auto& property) { ++count; },
-        []([[maybe_unused]] const std::string& propertyId, [[maybe_unused]] const std::string& warning) {});
+        unsupportedPropertyCallbackNoop);
 
     return count;
 }

--- a/src/core/src/OmniGlobeAnchor.cpp
+++ b/src/core/src/OmniGlobeAnchor.cpp
@@ -206,9 +206,9 @@ bool OmniGlobeAnchor::isAnchorValid() const {
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
 
     if (!xformOps) {
-        _pContext->getLogger()->oneTimeWarning(fmt::format(
+        _pContext->getLogger()->oneTimeWarning(
             "Globe anchor xform op order must [translate, rotate, scale] without additional transforms.",
-            _path.GetText()));
+            _path.GetText());
         return false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-omniverse/issues/588

* https://github.com/CesiumGS/cesium-omniverse/commit/d02944fd13be9d8633ae97733770c047b343c91a - cleanup commit so that `oneTimeWarning` can take multiple parameters
* https://github.com/CesiumGS/cesium-omniverse/commit/c5c68dc412801532b789b16efd9f4f7991a050a6 - use `oneTimeWarning` for "Could not find property" and "incompatible type" warnings