### PR TITLE
Increase width of basis curves

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
+++ b/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
@@ -109,6 +109,10 @@ def add_cartographic_polygon() -> str:
     basis_curves.GetPointsAttr().Set([(-1000, 0, -1000), (-1000, 0, 1000), (1000, 0, 1000), (1000, 0, -1000)])
     basis_curves.GetCurveVertexCountsAttr().Set([4])
 
+    # Set curve to a 0.5m width
+    curve_width = 0.5 / UsdGeom.GetStageMetersPerUnit(stage)
+    basis_curves.GetWidthsAttr().Set([curve_width, curve_width, curve_width, curve_width])
+
     add_globe_anchor_to_prim(cartographic_polygon_path)
 
     return cartographic_polygon_path

--- a/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
+++ b/exts/cesium.omniverse/cesium/omniverse/usdUtils/usdUtils.py
@@ -106,7 +106,18 @@ def add_cartographic_polygon() -> str:
     basis_curves = UsdGeom.BasisCurves.Define(stage, cartographic_polygon_path)
     basis_curves.GetTypeAttr().Set("linear")
     basis_curves.GetWrapAttr().Set("periodic")
-    basis_curves.GetPointsAttr().Set([(-1000, 0, -1000), (-1000, 0, 1000), (1000, 0, 1000), (1000, 0, -1000)])
+
+    # Set curve to have 10m edge lengths
+    curve_size = 10 / UsdGeom.GetStageMetersPerUnit(stage)
+    basis_curves.GetPointsAttr().Set(
+        [
+            (-curve_size, 0, -curve_size),
+            (-curve_size, 0, curve_size),
+            (curve_size, 0, curve_size),
+            (curve_size, 0, -curve_size),
+        ]
+    )
+
     basis_curves.GetCurveVertexCountsAttr().Set([4])
 
     # Set curve to a 0.5m width


### PR DESCRIPTION
This PR increases the width of basis curves created by the Cesium Cartographic Polygon Quick Add option to 0.5m.  This size makes the curve easier to manipulate for **typical** use cases such as removing city blocks, buildings, etc.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/1a4dc0ca-6687-434d-8b2d-4c6a37fcb448)

Both the width and the default 10m x 10m dimension have been configured to be consistent based on the stage units being used (previously a 1000m x 1000m curve would be created if a user was using stage units = 1 meter.

