### PR TITLE
Fix updating feature id set index

### DIFF
--- a/src/core/src/FabricUtil.cpp
+++ b/src/core/src/FabricUtil.cpp
@@ -744,7 +744,8 @@ std::vector<omni::fabric::Path> copyMaterial(
         if (srcPath == materialSourcePath) {
             dstPath = dstMaterialPath;
         } else {
-            dstPath = FabricUtil::getCopiedShaderPath(dstMaterialPath, srcPath);
+            const auto name = omni::fabric::Token(std::strrchr(srcPath.getText(), '/') + 1);
+            dstPath = FabricUtil::getCopiedShaderPath(dstMaterialPath, srcMaterialPath.appendChild(name));
         }
 
         dstPaths.push_back(dstPath);


### PR DESCRIPTION
Fixes a crash related to https://github.com/CesiumGS/cesium-omniverse/pull/644.

When copying Fabric materials it should use the original material path instead of the `_materialSource` path since changed property notifications come from the original material, not the `_materialSource` (which seems to be removed). Not doing this causes [this assert](https://github.com/CesiumGS/cesium-omniverse/blob/11bb8a806ce594161e09dd5a3389d6cec38830c4/src/core/src/FabricMaterial.cpp#L1806) to be hit.

To reproduce:

* Load [ferry-building-2.zip](https://github.com/CesiumGS/cesium-omniverse/files/14167781/ferry-building-2.zip)
* Navigate to `/World/Looks/Material/cesium_feature_id_int`
* Change `feature_id_set_index` to 1
* Crash

On this branch it won't crash. But you might still see artifacts related to https://github.com/CesiumGS/cesium-omniverse/issues/581.

