### PR TITLE
Allow globe anchors to be assigned to tilesets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v0.18.0 - 2024-03-01
+
+* Added support for globe anchors on non-georeferenced tilesets.
+* Fixed zooming to tileset extents when tileset prims have non identity transformation.
+* Fixed crash when updating tilesets shader inputs.
+
 ### v0.17.0 - 2024-02-01
 
 * **Breaking changes for globe anchors:**

--- a/exts/cesium.omniverse/cesium/omniverse/ui/add_menu_controller.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/add_menu_controller.py
@@ -74,9 +74,7 @@ class CesiumAddMenuController:
 
     @staticmethod
     def _show_add_globe_anchor(objects: dict, context_menu: omni.kit.context_menu, usd_type: Tf.Type) -> bool:
-        return context_menu.prim_is_type(objects, type=usd_type) and not context_menu.prim_is_type(
-            objects, type=CesiumTileset
-        )
+        return context_menu.prim_is_type(objects, type=usd_type)
 
     @staticmethod
     def _show_add_raster_overlay(objects: dict, context_menu: omni.kit.context_menu, usd_type: Tf.Type) -> bool:

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -339,6 +339,14 @@ bool OmniTileset::getShowCreditsOnScreen() const {
 }
 
 pxr::SdfPath OmniTileset::getResolvedGeoreferencePath() const {
+    const auto pGlobeAnchor = _pContext->getAssetRegistry().getGlobeAnchor(_path);
+    if (pGlobeAnchor) {
+        // The georeference math has already happened in OmniGlobeAnchor, so this prevents it from happening again.
+        // By returning an empty path any ecefTo or toEcef conversions are really conversions to and from tile world
+        // space, which for non-georeferenced tilesets is some local coordinate system.
+        return {};
+    }
+
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
 
     pxr::SdfPathVector targets;
@@ -659,8 +667,8 @@ bool OmniTileset::updateExtent() {
     const auto& boundingVolume = pRootTile->getBoundingVolume();
     const auto ecefObb = Cesium3DTilesSelection::getOrientedBoundingBoxFromBoundingVolume(boundingVolume);
     const auto georeferencePath = getResolvedGeoreferencePath();
-    const auto ecefToPrimWorldTransform = UsdUtil::computeEcefToPrimWorldTransform(*_pContext, georeferencePath, _path);
-    const auto primObb = ecefObb.transform(ecefToPrimWorldTransform);
+    const auto ecefToStageTransform = UsdUtil::computeEcefToStageTransform(*_pContext, georeferencePath);
+    const auto primObb = ecefObb.transform(ecefToStageTransform);
     const auto primAabb = primObb.toAxisAligned();
 
     const auto bottomLeft = glm::dvec3(primAabb.minimumX, primAabb.minimumY, primAabb.minimumZ);

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -166,7 +166,8 @@ glm::dmat4 computePrimWorldToLocalTransform(const pxr::UsdStageWeakPtr& pStage, 
 
 glm::dmat4 computeEcefToStageTransform(const Context& context, const pxr::SdfPath& georeferencePath) {
     const auto disableGeoreferencing = getDebugDisableGeoreferencing(context);
-    const auto pGeoreference = context.getAssetRegistry().getGeoreference(georeferencePath);
+    const auto pGeoreference =
+        georeferencePath.IsEmpty() ? nullptr : context.getAssetRegistry().getGeoreference(georeferencePath);
 
     if (disableGeoreferencing || !pGeoreference) {
         const auto zUp = getUsdUpAxis(context.getUsdStage()) == pxr::UsdGeomTokens->z;


### PR DESCRIPTION
This is useful for georeferencing tilesets that are in a local coordinate system.


https://github.com/CesiumGS/cesium-omniverse/assets/915398/0c3c9df6-a559-4306-8e94-232d059d9742


The video shows adding a tileset in a local coordinate system, attaching a globe anchor, modifying the longitude/latitude on both the globe anchor and the georeference, and zooming to the tileset extents.

[agi-local-globe-anchor.zip](https://github.com/CesiumGS/cesium-omniverse/files/14172887/agi-local-globe-anchor.zip)
