### PR TITLE
Update dev app dependencies

### DIFF
--- a/apps/cesium.omniverse.dev.kit
+++ b/apps/cesium.omniverse.dev.kit
@@ -9,8 +9,9 @@ app = true
 "omni.kit.window.material_graph" = {optional = true}
 "cesium.omniverse" = {}
 "cesium.powertools" = {}
-#"omni.example.ui" = {}
-#"omni.kit.documentation.ui.style" = {}
+"omni.curve.manipulator" = {}
+# "omni.example.ui" = {}
+# "omni.kit.documentation.ui.style" = {}
 
 [settings]
 app.window.title = "Cesium for Omniverse Testing App"


### PR DESCRIPTION
We wanted to have these extensions available in the dev app:

- Script Editor
- Material Graph
- Basic Curves manipulator and creator

The Script Editor is a dependency of omni.app.dev, so is already included. 

Basis Curves was added. 

Material Graph is left optional. "Optional dependencies are not enabled unless they are a non-optional dependency of some other extension which is enabled, or if they are enabled explicitly (using API, settings, CLI etc)." ([source](https://docs.omniverse.nvidia.com/kit/docs/kit-manual/latest/guide/extensions_advanced.html)). `--enable omni.kit.window.material_graph` could be added as an arg to `launch.*.json` if wanted.