### PR TITLE
Fix crash on extension reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Fixed zooming to tileset extents when tileset prims have non identity transformation.
 * Fixed crash when updating tilesets shader inputs.
 * Fixed crash when setting certain `/Cesium` debug options at runtime.
+* Fixed crash when disabling and re-enabling the extension.
 
 ### v0.17.0 - 2024-02-01
 

--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -71,6 +71,8 @@ class Context {
 
     [[nodiscard]] RenderStatistics getRenderStatistics() const;
 
+    [[nodiscard]] int64_t getContextId() const;
+
   private:
     std::filesystem::path _cesiumExtensionLocation;
     std::filesystem::path _certificatePath;
@@ -85,6 +87,8 @@ class Context {
     std::unique_ptr<FabricResourceManager> _pFabricResourceManager;
     std::unique_ptr<CesiumIonServerManager> _pCesiumIonServerManager;
     std::unique_ptr<UsdNotificationHandler> _pUsdNotificationHandler;
+
+    int64_t _contextId;
 
     pxr::UsdStageWeakPtr _pUsdStage;
     std::unique_ptr<omni::fabric::StageReaderWriter> _pFabricStage;

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -23,6 +23,7 @@
 
 #include <Cesium3DTilesContent/registerAllTileContentTypes.h>
 #include <CesiumUtility/CreditSystem.h>
+#include <glm/gtc/random.hpp>
 #include <omni/fabric/SimStageWithHistory.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usdUtils/stageCache.h>
@@ -45,7 +46,8 @@ Context::Context(const std::filesystem::path& cesiumExtensionLocation)
     , _pAssetRegistry(std::make_unique<AssetRegistry>(this))
     , _pFabricResourceManager(std::make_unique<FabricResourceManager>(this))
     , _pCesiumIonServerManager(std::make_unique<CesiumIonServerManager>(this))
-    , _pUsdNotificationHandler(std::make_unique<UsdNotificationHandler>(this)) {
+    , _pUsdNotificationHandler(std::make_unique<UsdNotificationHandler>(this))
+    , _contextId(glm::linearRand<int64_t>(0, 100000)) {
 
     Cesium3DTilesContent::registerAllTileContentTypes();
 
@@ -234,6 +236,12 @@ RenderStatistics Context::getRenderStatistics() const {
     }
 
     return renderStatistics;
+}
+
+int64_t Context::getContextId() const {
+    // Creating a Fabric prim with the same path as a previously destroyed prim causes a crash.
+    // The contextId is randomly generated and ensures that Fabric prim paths are unique even across extension reloads.
+    return _contextId;
 }
 
 } // namespace cesium::omniverse

--- a/src/core/src/FabricGeometryPool.cpp
+++ b/src/core/src/FabricGeometryPool.cpp
@@ -1,5 +1,6 @@
 #include "cesium/omniverse/FabricGeometryPool.h"
 
+#include "cesium/omniverse/Context.h"
 #include "cesium/omniverse/FabricVertexAttributeDescriptor.h"
 #include "cesium/omniverse/GltfUtil.h"
 
@@ -28,7 +29,8 @@ int64_t FabricGeometryPool::getPoolId() const {
 }
 
 std::shared_ptr<FabricGeometry> FabricGeometryPool::createObject(uint64_t objectId) const {
-    const auto pathStr = fmt::format("/cesium_geometry_pool_{}_object_{}", _poolId, objectId);
+    const auto contextId = _pContext->getContextId();
+    const auto pathStr = fmt::format("/cesium_geometry_pool_{}_object_{}_context_{}", _poolId, objectId, contextId);
     const auto path = omni::fabric::Path(pathStr.c_str());
     return std::make_shared<FabricGeometry>(_pContext, path, _geometryDescriptor, _poolId);
 }

--- a/src/core/src/FabricMaterialPool.cpp
+++ b/src/core/src/FabricMaterialPool.cpp
@@ -42,7 +42,8 @@ void FabricMaterialPool::updateShaderInput(const pxr::SdfPath& shaderPath, const
 }
 
 std::shared_ptr<FabricMaterial> FabricMaterialPool::createObject(uint64_t objectId) const {
-    const auto pathStr = fmt::format("/cesium_material_pool_{}_object_{}", _poolId, objectId);
+    const auto contextId = _pContext->getContextId();
+    const auto pathStr = fmt::format("/cesium_material_pool_{}_object_{}_context_{}", _poolId, objectId, contextId);
     const auto path = omni::fabric::Path(pathStr.c_str());
     return std::make_shared<FabricMaterial>(
         _pContext,

--- a/src/core/src/FabricResourceManager.cpp
+++ b/src/core/src/FabricResourceManager.cpp
@@ -23,8 +23,8 @@ namespace cesium::omniverse {
 
 namespace {
 
-const std::string_view DEFAULT_WHITE_TEXTURE_NAME = "fabric_default_white_texture";
-const std::string_view DEFAULT_TRANSPARENT_TEXTURE_NAME = "fabric_default_transparent_texture";
+const std::string_view DEFAULT_WHITE_TEXTURE_NAME = "cesium_default_white_texture";
+const std::string_view DEFAULT_TRANSPARENT_TEXTURE_NAME = "cesium_default_transparent_texture";
 
 std::unique_ptr<omni::ui::DynamicTextureProvider>
 createSinglePixelTexture(const std::string_view& name, const std::array<uint8_t, 4>& bytes) {
@@ -86,7 +86,8 @@ std::shared_ptr<FabricGeometry> FabricResourceManager::acquireGeometry(
     FabricGeometryDescriptor geometryDescriptor(model, primitive, featuresInfo, smoothNormals);
 
     if (_disableGeometryPool) {
-        const auto pathStr = fmt::format("/cesium_geometry_{}", getNextGeometryId());
+        const auto contextId = _pContext->getContextId();
+        const auto pathStr = fmt::format("/cesium_geometry_{}_context_{}", getNextGeometryId(), contextId);
         const auto path = omni::fabric::Path(pathStr.c_str());
         return std::make_shared<FabricGeometry>(_pContext, path, geometryDescriptor, -1);
     }
@@ -122,7 +123,8 @@ std::shared_ptr<FabricMaterial> FabricResourceManager::acquireMaterial(
 
 std::shared_ptr<FabricTexture> FabricResourceManager::acquireTexture() {
     if (_disableTexturePool) {
-        const auto name = fmt::format("/cesium_texture_{}", getNextTextureId());
+        const auto contextId = _pContext->getContextId();
+        const auto name = fmt::format("/cesium_texture_{}_context_{}", getNextTextureId(), contextId);
         return std::make_shared<FabricTexture>(_pContext, name, -1);
     }
 
@@ -241,7 +243,8 @@ void FabricResourceManager::clear() {
 
 std::shared_ptr<FabricMaterial>
 FabricResourceManager::createMaterial(const FabricMaterialDescriptor& materialDescriptor) {
-    const auto pathStr = fmt::format("/cesium_material_{}", getNextMaterialId());
+    const auto contextId = _pContext->getContextId();
+    const auto pathStr = fmt::format("/cesium_material_{}_context_{}", getNextMaterialId(), contextId);
     const auto path = omni::fabric::Path(pathStr.c_str());
     return std::make_shared<FabricMaterial>(
         _pContext,

--- a/src/core/src/FabricTexturePool.cpp
+++ b/src/core/src/FabricTexturePool.cpp
@@ -1,5 +1,7 @@
 #include "cesium/omniverse/FabricTexturePool.h"
 
+#include "cesium/omniverse/Context.h"
+
 #include <spdlog/fmt/fmt.h>
 
 namespace cesium::omniverse {
@@ -16,7 +18,8 @@ int64_t FabricTexturePool::getPoolId() const {
 }
 
 std::shared_ptr<FabricTexture> FabricTexturePool::createObject(uint64_t objectId) const {
-    const auto name = fmt::format("/cesium_texture_pool_{}_object_{}", _poolId, objectId);
+    const auto contextId = _pContext->getContextId();
+    const auto name = fmt::format("/cesium_texture_pool_{}_object_{}_context_{}", _poolId, objectId, contextId);
     return std::make_shared<FabricTexture>(_pContext, name, _poolId);
 }
 


### PR DESCRIPTION
Creating a Fabric prim with the same path as a previously destroyed prim causes a crash. Previously this was avoided by included the object id and pool id in the name, but on extension reload the pool id is initialized to 0 and new paths may conflict with old paths.

Now a contextId is randomly generated and ensures that Fabric prim paths are unique even across extension reloads.

There are probably more robust and safer ways to do this than `glm::linearRand<int64_t>(0, 100000)`, like using a timestamp, but since extension reloads are uncommon and I didn't want to overcomplicate this.