### PR TITLE
Fix crash when dependent prims are removed in specific order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Fixed crash when updating tilesets shader inputs.
 * Fixed crash when setting certain `/Cesium` debug options at runtime.
 * Fixed crash when disabling and re-enabling the extension.
+* Fixed crash when removing USD prims in certain order.
 
 ### v0.17.0 - 2024-02-01
 

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -91,6 +91,8 @@ Cesium3DTilesSelection::ViewState computeViewState(
     const Viewport& viewport);
 
 bool primExists(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path);
+bool isSchemaValid(const pxr::UsdSchemaBase& schema);
+
 bool isPrimVisible(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path);
 const std::string& getName(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path);
 

--- a/src/core/src/OmniCartographicPolygon.cpp
+++ b/src/core/src/OmniCartographicPolygon.cpp
@@ -38,6 +38,9 @@ std::vector<CesiumGeospatial::Cartographic> OmniCartographicPolygon::getCartogra
     }
 
     const auto cesiumCartographicPolygon = UsdUtil::getCesiumCartographicPolygon(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumCartographicPolygon)) {
+        return {};
+    }
 
     pxr::VtArray<pxr::GfVec3f> points;
     cesiumCartographicPolygon.GetPointsAttr().Get(&points);

--- a/src/core/src/OmniData.cpp
+++ b/src/core/src/OmniData.cpp
@@ -17,6 +17,9 @@ const pxr::SdfPath& OmniData::getPath() const {
 
 pxr::SdfPath OmniData::getSelectedIonServerPath() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumData.GetSelectedIonServerRel().GetForwardedTargets(&targets);
@@ -30,6 +33,9 @@ pxr::SdfPath OmniData::getSelectedIonServerPath() const {
 
 bool OmniData::getDebugDisableMaterials() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool disableMaterials;
     cesiumData.GetDebugDisableMaterialsAttr().Get(&disableMaterials);
@@ -39,6 +45,9 @@ bool OmniData::getDebugDisableMaterials() const {
 
 bool OmniData::getDebugDisableTextures() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool disableTextures;
     cesiumData.GetDebugDisableTexturesAttr().Get(&disableTextures);
@@ -48,6 +57,9 @@ bool OmniData::getDebugDisableTextures() const {
 
 bool OmniData::getDebugDisableGeometryPool() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool disableGeometryPool;
     cesiumData.GetDebugDisableGeometryPoolAttr().Get(&disableGeometryPool);
@@ -57,6 +69,9 @@ bool OmniData::getDebugDisableGeometryPool() const {
 
 bool OmniData::getDebugDisableMaterialPool() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool disableMaterialPool;
     cesiumData.GetDebugDisableMaterialPoolAttr().Get(&disableMaterialPool);
@@ -66,6 +81,9 @@ bool OmniData::getDebugDisableMaterialPool() const {
 
 bool OmniData::getDebugDisableTexturePool() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool disableTexturePool;
     cesiumData.GetDebugDisableTexturePoolAttr().Get(&disableTexturePool);
@@ -75,6 +93,9 @@ bool OmniData::getDebugDisableTexturePool() const {
 
 uint64_t OmniData::getDebugGeometryPoolInitialCapacity() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return 2048;
+    }
 
     uint64_t geometryPoolInitialCapacity;
     cesiumData.GetDebugGeometryPoolInitialCapacityAttr().Get(&geometryPoolInitialCapacity);
@@ -84,6 +105,9 @@ uint64_t OmniData::getDebugGeometryPoolInitialCapacity() const {
 
 uint64_t OmniData::getDebugMaterialPoolInitialCapacity() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return 2048;
+    }
 
     uint64_t materialPoolInitialCapacity;
     cesiumData.GetDebugMaterialPoolInitialCapacityAttr().Get(&materialPoolInitialCapacity);
@@ -93,6 +117,9 @@ uint64_t OmniData::getDebugMaterialPoolInitialCapacity() const {
 
 uint64_t OmniData::getDebugTexturePoolInitialCapacity() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return 2048;
+    }
 
     uint64_t texturePoolInitialCapacity;
     cesiumData.GetDebugTexturePoolInitialCapacityAttr().Get(&texturePoolInitialCapacity);
@@ -102,6 +129,9 @@ uint64_t OmniData::getDebugTexturePoolInitialCapacity() const {
 
 bool OmniData::getDebugRandomColors() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool debugRandomColors;
     cesiumData.GetDebugRandomColorsAttr().Get(&debugRandomColors);
@@ -111,6 +141,9 @@ bool OmniData::getDebugRandomColors() const {
 
 bool OmniData::getDebugDisableGeoreferencing() const {
     const auto cesiumData = UsdUtil::getCesiumData(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumData)) {
+        return false;
+    }
 
     bool debugDisableGeoreferencing;
     cesiumData.GetDebugDisableGeoreferencingAttr().Get(&debugDisableGeoreferencing);

--- a/src/core/src/OmniGeoreference.cpp
+++ b/src/core/src/OmniGeoreference.cpp
@@ -22,6 +22,9 @@ const pxr::SdfPath& OmniGeoreference::getPath() const {
 
 CesiumGeospatial::Cartographic OmniGeoreference::getOrigin() const {
     const auto cesiumGeoreference = UsdUtil::getCesiumGeoreference(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGeoreference)) {
+        return {0.0, 0.0, 0.0};
+    }
 
     double longitude;
     double latitude;

--- a/src/core/src/OmniGlobeAnchor.cpp
+++ b/src/core/src/OmniGlobeAnchor.cpp
@@ -49,6 +49,9 @@ const pxr::SdfPath& OmniGlobeAnchor::getPath() const {
 
 bool OmniGlobeAnchor::getDetectTransformChanges() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return true;
+    }
 
     bool detectTransformChanges;
     cesiumGlobeAnchor.GetDetectTransformChangesAttr().Get(&detectTransformChanges);
@@ -58,6 +61,9 @@ bool OmniGlobeAnchor::getDetectTransformChanges() const {
 
 bool OmniGlobeAnchor::getAdjustOrientation() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return true;
+    }
 
     bool adjustOrientation;
     cesiumGlobeAnchor.GetAdjustOrientationForGlobeWhenMovingAttr().Get(&adjustOrientation);
@@ -67,6 +73,9 @@ bool OmniGlobeAnchor::getAdjustOrientation() const {
 
 pxr::SdfPath OmniGlobeAnchor::getResolvedGeoreferencePath() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumGlobeAnchor.GetGeoreferenceBindingRel().GetForwardedTargets(&targets);
@@ -158,7 +167,7 @@ void OmniGlobeAnchor::updateByPrimLocalTransform(bool resetOrientation) {
     }
 
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
     const auto eulerAngleOrder = xformOps->eulerAngleOrder;
 
@@ -202,7 +211,11 @@ bool OmniGlobeAnchor::isAnchorValid() const {
     }
 
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return false;
+    }
+
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
 
     if (!xformOps) {
@@ -229,7 +242,10 @@ void OmniGlobeAnchor::initialize() {
     // when using globe anchors.
 
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return;
+    }
 
     bool resetsXformStack;
     const auto originalXformOps = xformable.GetOrderedXformOps(&resetsXformStack);
@@ -268,6 +284,9 @@ void OmniGlobeAnchor::finalize() {
 
 glm::dvec3 OmniGlobeAnchor::getPrimLocalToEcefTranslation() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return {0.0, 0.0, 0.0};
+    }
 
     pxr::GfVec3d primLocalToEcefTranslation;
     cesiumGlobeAnchor.GetPositionAttr().Get(&primLocalToEcefTranslation);
@@ -277,6 +296,9 @@ glm::dvec3 OmniGlobeAnchor::getPrimLocalToEcefTranslation() const {
 
 CesiumGeospatial::Cartographic OmniGlobeAnchor::getGeographicCoordinates() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return {0.0, 0.0, 0.0};
+    }
 
     double longitude;
     double latitude;
@@ -291,36 +313,57 @@ CesiumGeospatial::Cartographic OmniGlobeAnchor::getGeographicCoordinates() const
 
 glm::dvec3 OmniGlobeAnchor::getPrimLocalTranslation() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return {0.0, 0.0, 0.0};
+    }
+
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
     return UsdUtil::getTranslate(xformOps.value().translateOp);
 }
 
 glm::dvec3 OmniGlobeAnchor::getPrimLocalRotation() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return {0.0, 0.0, 0.0};
+    }
+
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
     return glm::radians(UsdUtil::getRotate(xformOps.value().rotateOp));
 }
 
 glm::dvec3 OmniGlobeAnchor::getPrimLocalScale() const {
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return {1.0, 1.0, 1.0};
+    }
+
     const auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
     return UsdUtil::getScale(xformOps.value().scaleOp);
 }
 
 void OmniGlobeAnchor::savePrimLocalToEcefTranslation() {
+    const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return;
+    }
+
     const auto& primLocalToEcefTransform = _pAnchor->getAnchorToFixedTransform();
     const auto primLocalToEcefTranslation = glm::dvec3(primLocalToEcefTransform[3]);
 
     _cachedPrimLocalToEcefTranslation = primLocalToEcefTranslation;
 
-    const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
     cesiumGlobeAnchor.GetPositionAttr().Set(UsdUtil::glmToUsdVector(primLocalToEcefTranslation));
 }
 
 void OmniGlobeAnchor::saveGeographicCoordinates() {
+    const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumGlobeAnchor)) {
+        return;
+    }
+
     const auto pGeoreference = _pContext->getAssetRegistry().getGeoreference(getResolvedGeoreferencePath());
     const auto& primLocalToEcefTransform = _pAnchor->getAnchorToFixedTransform();
     const auto primLocalToEcefTranslation = glm::dvec3(primLocalToEcefTransform[3]);
@@ -332,7 +375,6 @@ void OmniGlobeAnchor::saveGeographicCoordinates() {
 
     _cachedGeographicCoordinates = *cartographic;
 
-    const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
     cesiumGlobeAnchor.GetAnchorLongitudeAttr().Set(glm::degrees(cartographic->longitude));
     cesiumGlobeAnchor.GetAnchorLatitudeAttr().Set(glm::degrees(cartographic->latitude));
     cesiumGlobeAnchor.GetAnchorHeightAttr().Set(cartographic->height);
@@ -343,7 +385,11 @@ void OmniGlobeAnchor::savePrimLocalTransform() {
     // work when rotation and scale properties are double precision, which is common in Omniverse.
 
     const auto cesiumGlobeAnchor = UsdUtil::getCesiumGlobeAnchor(_pContext->getUsdStage(), _path);
-    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor.GetPrim());
+    const auto xformable = pxr::UsdGeomXformable(cesiumGlobeAnchor);
+    if (!UsdUtil::isSchemaValid(xformable)) {
+        return;
+    }
+
     auto xformOps = UsdUtil::getOrCreateTranslateRotateScaleOps(xformable);
 
     auto& [translateOp, rotateOp, scaleOp, eulerAngleOrder] = xformOps.value();

--- a/src/core/src/OmniIonRasterOverlay.cpp
+++ b/src/core/src/OmniIonRasterOverlay.cpp
@@ -25,6 +25,9 @@ OmniIonRasterOverlay::OmniIonRasterOverlay(Context* pContext, const pxr::SdfPath
 
 int64_t OmniIonRasterOverlay::getIonAssetId() const {
     const auto cesiumIonRasterOverlay = UsdUtil::getCesiumIonRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonRasterOverlay)) {
+        return 0;
+    }
 
     int64_t ionAssetId;
     cesiumIonRasterOverlay.GetIonAssetIdAttr().Get(&ionAssetId);
@@ -34,6 +37,9 @@ int64_t OmniIonRasterOverlay::getIonAssetId() const {
 
 CesiumIonClient::Token OmniIonRasterOverlay::getIonAccessToken() const {
     const auto cesiumIonRasterOverlay = UsdUtil::getCesiumIonRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonRasterOverlay)) {
+        return {};
+    }
 
     std::string ionAccessToken;
     cesiumIonRasterOverlay.GetIonAccessTokenAttr().Get(&ionAccessToken);
@@ -77,6 +83,9 @@ std::string OmniIonRasterOverlay::getIonApiUrl() const {
 
 pxr::SdfPath OmniIonRasterOverlay::getResolvedIonServerPath() const {
     const auto cesiumIonRasterOverlay = UsdUtil::getCesiumIonRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonRasterOverlay)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumIonRasterOverlay.GetIonServerBindingRel().GetForwardedTargets(&targets);

--- a/src/core/src/OmniIonServer.cpp
+++ b/src/core/src/OmniIonServer.cpp
@@ -29,6 +29,9 @@ std::shared_ptr<CesiumIonSession> OmniIonServer::getSession() const {
 
 std::string OmniIonServer::getIonServerUrl() const {
     const auto cesiumIonServer = UsdUtil::getCesiumIonServer(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonServer)) {
+        return "";
+    }
 
     std::string ionServerUrl;
     cesiumIonServer.GetIonServerUrlAttr().Get(&ionServerUrl);
@@ -38,6 +41,9 @@ std::string OmniIonServer::getIonServerUrl() const {
 
 std::string OmniIonServer::getIonServerApiUrl() const {
     const auto cesiumIonServer = UsdUtil::getCesiumIonServer(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonServer)) {
+        return "";
+    }
 
     std::string ionServerApiUrl;
     cesiumIonServer.GetIonServerApiUrlAttr().Get(&ionServerApiUrl);
@@ -47,6 +53,9 @@ std::string OmniIonServer::getIonServerApiUrl() const {
 
 int64_t OmniIonServer::getIonServerApplicationId() const {
     const auto cesiumIonServer = UsdUtil::getCesiumIonServer(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonServer)) {
+        return 0;
+    }
 
     int64_t ionServerApplicationId;
     cesiumIonServer.GetIonServerApplicationIdAttr().Get(&ionServerApplicationId);
@@ -56,6 +65,9 @@ int64_t OmniIonServer::getIonServerApplicationId() const {
 
 CesiumIonClient::Token OmniIonServer::getToken() const {
     const auto cesiumIonServer = UsdUtil::getCesiumIonServer(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonServer)) {
+        return {};
+    }
 
     std::string projectDefaultIonAccessToken;
     std::string projectDefaultIonAccessTokenId;
@@ -72,6 +84,9 @@ CesiumIonClient::Token OmniIonServer::getToken() const {
 
 void OmniIonServer::setToken(const CesiumIonClient::Token& token) {
     const auto cesiumIonServer = UsdUtil::getCesiumIonServer(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumIonServer)) {
+        return;
+    }
 
     cesiumIonServer.GetProjectDefaultIonAccessTokenAttr().Set(token.token);
     cesiumIonServer.GetProjectDefaultIonAccessTokenIdAttr().Set(token.id);

--- a/src/core/src/OmniPolygonRasterOverlay.cpp
+++ b/src/core/src/OmniPolygonRasterOverlay.cpp
@@ -20,6 +20,9 @@ OmniPolygonRasterOverlay::OmniPolygonRasterOverlay(Context* pContext, const pxr:
 
 std::vector<pxr::SdfPath> OmniPolygonRasterOverlay::getCartographicPolygonPaths() const {
     const auto cesiumPolygonRasterOverlay = UsdUtil::getCesiumPolygonRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumPolygonRasterOverlay)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumPolygonRasterOverlay.GetCartographicPolygonBindingRel().GetForwardedTargets(&targets);
@@ -32,7 +35,11 @@ CesiumRasterOverlays::RasterOverlay* OmniPolygonRasterOverlay::getRasterOverlay(
 }
 
 bool OmniPolygonRasterOverlay::getInvertSelection() const {
-    auto cesiumPolygonRasterOverlay = UsdUtil::getCesiumPolygonRasterOverlay(_pContext->getUsdStage(), _path);
+    const auto cesiumPolygonRasterOverlay = UsdUtil::getCesiumPolygonRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumPolygonRasterOverlay)) {
+        return false;
+    }
+
     bool invertSelection;
     cesiumPolygonRasterOverlay.GetInvertSelectionAttr().Get(&invertSelection);
     return invertSelection;

--- a/src/core/src/OmniRasterOverlay.cpp
+++ b/src/core/src/OmniRasterOverlay.cpp
@@ -22,6 +22,9 @@ const pxr::SdfPath& OmniRasterOverlay::getPath() const {
 
 bool OmniRasterOverlay::getShowCreditsOnScreen() const {
     const auto cesiumRasterOverlay = UsdUtil::getCesiumRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumRasterOverlay)) {
+        return false;
+    }
 
     bool showCreditsOnScreen;
     cesiumRasterOverlay.GetShowCreditsOnScreenAttr().Get(&showCreditsOnScreen);
@@ -31,6 +34,9 @@ bool OmniRasterOverlay::getShowCreditsOnScreen() const {
 
 double OmniRasterOverlay::getAlpha() const {
     const auto cesiumRasterOverlay = UsdUtil::getCesiumRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumRasterOverlay)) {
+        return 1.0;
+    }
 
     float alpha;
     cesiumRasterOverlay.GetAlphaAttr().Get(&alpha);
@@ -40,6 +46,9 @@ double OmniRasterOverlay::getAlpha() const {
 
 FabricOverlayRenderMethod OmniRasterOverlay::getOverlayRenderMethod() const {
     const auto cesiumRasterOverlay = UsdUtil::getCesiumRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumRasterOverlay)) {
+        return FabricOverlayRenderMethod::OVERLAY;
+    }
 
     pxr::TfToken overlayRenderMethod;
     cesiumRasterOverlay.GetOverlayRenderMethodAttr().Get(&overlayRenderMethod);

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -108,6 +108,9 @@ TilesetStatistics OmniTileset::getStatistics() const {
 
 TilesetSourceType OmniTileset::getSourceType() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return TilesetSourceType::ION;
+    }
 
     pxr::TfToken sourceType;
     cesiumTileset.GetSourceTypeAttr().Get(&sourceType);
@@ -121,6 +124,9 @@ TilesetSourceType OmniTileset::getSourceType() const {
 
 std::string OmniTileset::getUrl() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return "";
+    }
 
     std::string url;
     cesiumTileset.GetUrlAttr().Get(&url);
@@ -130,6 +136,9 @@ std::string OmniTileset::getUrl() const {
 
 int64_t OmniTileset::getIonAssetId() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 0;
+    }
 
     int64_t ionAssetId;
     cesiumTileset.GetIonAssetIdAttr().Get(&ionAssetId);
@@ -139,6 +148,9 @@ int64_t OmniTileset::getIonAssetId() const {
 
 CesiumIonClient::Token OmniTileset::getIonAccessToken() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return {};
+    }
 
     std::string ionAccessToken;
     cesiumTileset.GetIonAccessTokenAttr().Get(&ionAccessToken);
@@ -182,6 +194,9 @@ std::string OmniTileset::getIonApiUrl() const {
 
 pxr::SdfPath OmniTileset::getResolvedIonServerPath() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumTileset.GetIonServerBindingRel().GetForwardedTargets(&targets);
@@ -201,6 +216,9 @@ pxr::SdfPath OmniTileset::getResolvedIonServerPath() const {
 
 double OmniTileset::getMaximumScreenSpaceError() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 16.0;
+    }
 
     float maximumScreenSpaceError;
     cesiumTileset.GetMaximumScreenSpaceErrorAttr().Get(&maximumScreenSpaceError);
@@ -210,6 +228,9 @@ double OmniTileset::getMaximumScreenSpaceError() const {
 
 bool OmniTileset::getPreloadAncestors() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return true;
+    }
 
     bool preloadAncestors;
     cesiumTileset.GetPreloadAncestorsAttr().Get(&preloadAncestors);
@@ -219,6 +240,9 @@ bool OmniTileset::getPreloadAncestors() const {
 
 bool OmniTileset::getPreloadSiblings() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return true;
+    }
 
     bool preloadSiblings;
     cesiumTileset.GetPreloadSiblingsAttr().Get(&preloadSiblings);
@@ -228,6 +252,9 @@ bool OmniTileset::getPreloadSiblings() const {
 
 bool OmniTileset::getForbidHoles() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return false;
+    }
 
     bool forbidHoles;
     cesiumTileset.GetForbidHolesAttr().Get(&forbidHoles);
@@ -237,6 +264,9 @@ bool OmniTileset::getForbidHoles() const {
 
 uint32_t OmniTileset::getMaximumSimultaneousTileLoads() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 20;
+    }
 
     uint32_t maximumSimultaneousTileLoads;
     cesiumTileset.GetMaximumSimultaneousTileLoadsAttr().Get(&maximumSimultaneousTileLoads);
@@ -246,6 +276,9 @@ uint32_t OmniTileset::getMaximumSimultaneousTileLoads() const {
 
 uint64_t OmniTileset::getMaximumCachedBytes() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 536870912;
+    }
 
     uint64_t maximumCachedBytes;
     cesiumTileset.GetMaximumCachedBytesAttr().Get(&maximumCachedBytes);
@@ -255,6 +288,9 @@ uint64_t OmniTileset::getMaximumCachedBytes() const {
 
 uint32_t OmniTileset::getLoadingDescendantLimit() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 20;
+    }
 
     uint32_t loadingDescendantLimit;
     cesiumTileset.GetLoadingDescendantLimitAttr().Get(&loadingDescendantLimit);
@@ -264,6 +300,9 @@ uint32_t OmniTileset::getLoadingDescendantLimit() const {
 
 bool OmniTileset::getEnableFrustumCulling() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return true;
+    }
 
     bool enableFrustumCulling;
     cesiumTileset.GetEnableFrustumCullingAttr().Get(&enableFrustumCulling);
@@ -273,6 +312,9 @@ bool OmniTileset::getEnableFrustumCulling() const {
 
 bool OmniTileset::getEnableFogCulling() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return true;
+    }
 
     bool enableFogCulling;
     cesiumTileset.GetEnableFogCullingAttr().Get(&enableFogCulling);
@@ -282,6 +324,9 @@ bool OmniTileset::getEnableFogCulling() const {
 
 bool OmniTileset::getEnforceCulledScreenSpaceError() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return true;
+    }
 
     bool enforceCulledScreenSpaceError;
     cesiumTileset.GetEnforceCulledScreenSpaceErrorAttr().Get(&enforceCulledScreenSpaceError);
@@ -291,6 +336,9 @@ bool OmniTileset::getEnforceCulledScreenSpaceError() const {
 
 double OmniTileset::getMainThreadLoadingTimeLimit() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 0.0;
+    }
 
     float mainThreadLoadingTimeLimit;
     cesiumTileset.GetMainThreadLoadingTimeLimitAttr().Get(&mainThreadLoadingTimeLimit);
@@ -300,6 +348,9 @@ double OmniTileset::getMainThreadLoadingTimeLimit() const {
 
 double OmniTileset::getCulledScreenSpaceError() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 64.0;
+    }
 
     float culledScreenSpaceError;
     cesiumTileset.GetCulledScreenSpaceErrorAttr().Get(&culledScreenSpaceError);
@@ -309,6 +360,9 @@ double OmniTileset::getCulledScreenSpaceError() const {
 
 bool OmniTileset::getSuspendUpdate() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return false;
+    }
 
     bool suspendUpdate;
     cesiumTileset.GetSuspendUpdateAttr().Get(&suspendUpdate);
@@ -318,6 +372,9 @@ bool OmniTileset::getSuspendUpdate() const {
 
 bool OmniTileset::getSmoothNormals() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return false;
+    }
 
     bool smoothNormals;
     cesiumTileset.GetSmoothNormalsAttr().Get(&smoothNormals);
@@ -327,6 +384,9 @@ bool OmniTileset::getSmoothNormals() const {
 
 bool OmniTileset::getShowCreditsOnScreen() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return false;
+    }
 
     bool showCreditsOnScreen;
     cesiumTileset.GetShowCreditsOnScreenAttr().Get(&showCreditsOnScreen);
@@ -344,6 +404,9 @@ pxr::SdfPath OmniTileset::getResolvedGeoreferencePath() const {
     }
 
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumTileset.GetGeoreferenceBindingRel().GetForwardedTargets(&targets);
@@ -363,8 +426,11 @@ pxr::SdfPath OmniTileset::getResolvedGeoreferencePath() const {
 
 pxr::SdfPath OmniTileset::getMaterialPath() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
-
     const auto materialBindingApi = pxr::UsdShadeMaterialBindingAPI(cesiumTileset);
+    if (!UsdUtil::isSchemaValid(materialBindingApi)) {
+        return {};
+    }
+
     const auto materialBinding = materialBindingApi.GetDirectBinding();
     const auto& materialPath = materialBinding.GetMaterialPath();
 
@@ -373,6 +439,9 @@ pxr::SdfPath OmniTileset::getMaterialPath() const {
 
 glm::dvec3 OmniTileset::getDisplayColor() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return {1.0, 1.0, 1.0};
+    }
 
     pxr::VtVec3fArray displayColorArray;
     cesiumTileset.GetDisplayColorAttr().Get(&displayColorArray);
@@ -391,6 +460,9 @@ glm::dvec3 OmniTileset::getDisplayColor() const {
 
 double OmniTileset::getDisplayOpacity() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return 1.0;
+    }
 
     pxr::VtFloatArray displayOpacityArray;
     cesiumTileset.GetDisplayOpacityAttr().Get(&displayOpacityArray);
@@ -404,6 +476,9 @@ double OmniTileset::getDisplayOpacity() const {
 
 std::vector<pxr::SdfPath> OmniTileset::getRasterOverlayPaths() const {
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumTileset)) {
+        return {};
+    }
 
     pxr::SdfPathVector targets;
     cesiumTileset.GetRasterOverlayBindingRel().GetForwardedTargets(&targets);
@@ -496,7 +571,6 @@ void OmniTileset::reload() {
             break;
     }
 
-    const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
     const auto boundRasterOverlayPaths = getRasterOverlayPaths();
 
     for (const auto& boundRasterOverlayPath : boundRasterOverlayPaths) {
@@ -661,6 +735,11 @@ bool OmniTileset::updateExtent() {
     }
 
     const auto cesiumTileset = UsdUtil::getCesiumTileset(_pContext->getUsdStage(), _path);
+    const auto boundable = pxr::UsdGeomBoundable(cesiumTileset);
+    if (!UsdUtil::isSchemaValid(boundable)) {
+        return false;
+    }
+
     const auto& boundingVolume = pRootTile->getBoundingVolume();
     const auto ecefObb = Cesium3DTilesSelection::getOrientedBoundingBoxFromBoundingVolume(boundingVolume);
     const auto georeferencePath = getResolvedGeoreferencePath();
@@ -676,7 +755,6 @@ bool OmniTileset::updateExtent() {
         UsdUtil::glmToUsdVector(glm::fvec3(topRight)),
     };
 
-    const auto boundable = pxr::UsdGeomBoundable(cesiumTileset);
     boundable.GetExtentAttr().Set(extent);
     return true;
 }

--- a/src/core/src/OmniWebMapServiceRasterOverlay.cpp
+++ b/src/core/src/OmniWebMapServiceRasterOverlay.cpp
@@ -22,51 +22,75 @@ CesiumRasterOverlays::RasterOverlay* OmniWebMapServiceRasterOverlay::getRasterOv
 }
 
 std::string OmniWebMapServiceRasterOverlay::getBaseUrl() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return "";
+    }
+
     std::string baseUrl;
     cesiumWebMapServiceRasterOverlay.GetBaseUrlAttr().Get(&baseUrl);
     return baseUrl;
 }
 
 int OmniWebMapServiceRasterOverlay::getMinimumLevel() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
-    int val;
-    cesiumWebMapServiceRasterOverlay.GetMinimumLevelAttr().Get(&val);
-    return val;
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return 0;
+    }
+
+    int minimumLevel;
+    cesiumWebMapServiceRasterOverlay.GetMinimumLevelAttr().Get(&minimumLevel);
+    return minimumLevel;
 }
 
 int OmniWebMapServiceRasterOverlay::getMaximumLevel() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
-    int val;
-    cesiumWebMapServiceRasterOverlay.GetMaximumLevelAttr().Get(&val);
-    return val;
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return 14;
+    }
+
+    int maximumLevel;
+    cesiumWebMapServiceRasterOverlay.GetMaximumLevelAttr().Get(&maximumLevel);
+    return maximumLevel;
 }
 
 int OmniWebMapServiceRasterOverlay::getTileWidth() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
-    int val;
-    cesiumWebMapServiceRasterOverlay.GetTileWidthAttr().Get(&val);
-    return val;
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return 256;
+    }
+
+    int tileWidth;
+    cesiumWebMapServiceRasterOverlay.GetTileWidthAttr().Get(&tileWidth);
+    return tileWidth;
 }
 
 int OmniWebMapServiceRasterOverlay::getTileHeight() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
-    int val;
-    cesiumWebMapServiceRasterOverlay.GetTileHeightAttr().Get(&val);
-    return val;
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return 256;
+    }
+
+    int tileHeight;
+    cesiumWebMapServiceRasterOverlay.GetTileHeightAttr().Get(&tileHeight);
+    return tileHeight;
 }
 
 std::string OmniWebMapServiceRasterOverlay::getLayers() const {
-    auto cesiumWebMapServiceRasterOverlay =
+    const auto cesiumWebMapServiceRasterOverlay =
         UsdUtil::getCesiumWebMapServiceRasterOverlay(_pContext->getUsdStage(), _path);
-    std::string val;
-    cesiumWebMapServiceRasterOverlay.GetLayersAttr().Get(&val);
-    return val;
+    if (!UsdUtil::isSchemaValid(cesiumWebMapServiceRasterOverlay)) {
+        return "1";
+    }
+
+    std::string layers;
+    cesiumWebMapServiceRasterOverlay.GetLayersAttr().Get(&layers);
+    return layers;
 }
 
 void OmniWebMapServiceRasterOverlay::reload() {

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -178,10 +178,6 @@ void processCesiumGlobeAnchorChanged(
         return;
     }
 
-    if (!UsdUtil::primExists(context.getUsdStage(), pGlobeAnchor->getPath())) {
-        return;
-    }
-
     // No change tracking needed for
     // * adjustOrientation
 
@@ -256,10 +252,6 @@ void processCesiumTilesetChanged(
         return;
     }
 
-    if (!UsdUtil::primExists(context.getUsdStage(), pTileset->getPath())) {
-        return;
-    }
-
     // Process globe anchor API schema first
     processCesiumGlobeAnchorChanged(context, tilesetPath, properties);
 
@@ -328,10 +320,6 @@ void processCesiumRasterOverlayChanged(
         return;
     }
 
-    if (!UsdUtil::primExists(context.getUsdStage(), pRasterOverlay->getPath())) {
-        return;
-    }
-
     auto reload = false;
     auto updateBindings = false;
     auto updateRasterOverlayAlpha = false;
@@ -369,10 +357,6 @@ void processCesiumIonRasterOverlayChanged(
         return;
     }
 
-    if (!UsdUtil::primExists(context.getUsdStage(), pIonRasterOverlay->getPath())) {
-        return;
-    }
-
     // Process base class first
     processCesiumRasterOverlayChanged(context, ionRasterOverlayPath, properties);
 
@@ -402,10 +386,6 @@ void processCesiumPolygonRasterOverlayChanged(
     const std::vector<pxr::TfToken>& properties) {
     const auto pPolygonRasterOverlay = context.getAssetRegistry().getPolygonRasterOverlay(polygonRasterOverlayPath);
     if (!pPolygonRasterOverlay) {
-        return;
-    }
-
-    if (!UsdUtil::primExists(context.getUsdStage(), pPolygonRasterOverlay->getPath())) {
         return;
     }
 
@@ -443,10 +423,6 @@ void processCesiumWebMapServiceRasterOverlayChanged(
         return;
     }
 
-    if (!UsdUtil::primExists(context.getUsdStage(), pWebMapServiceRasterOverlay->getPath())) {
-        return;
-    }
-
     // Process base class first
     processCesiumRasterOverlayChanged(context, webMapServiceRasterOverlayPath, properties);
 
@@ -472,7 +448,6 @@ void processCesiumWebMapServiceRasterOverlayChanged(
 }
 
 void processCesiumGeoreferenceChanged(const Context& context, const std::vector<pxr::TfToken>& properties) {
-
     auto updateBindings = false;
 
     // clang-format off
@@ -787,6 +762,12 @@ bool UsdNotificationHandler::processChangedPrims() {
     ChangedPrim* pPrevious = nullptr;
 
     for (const auto& changedPrim : _changedPrims) {
+        if (changedPrim.changedType == ChangedType::PROPERTY_CHANGED &&
+            !UsdUtil::primExists(_pContext->getUsdStage(), changedPrim.primPath)) {
+            // Don't process property changes if the prim is no longer on the stage
+            continue;
+        }
+
         if (pPrevious && changedPrim.primPath == pPrevious->primPath) {
             if (pPrevious->changedType == ChangedType::PRIM_ADDED &&
                 changedPrim.changedType == ChangedType::PROPERTY_CHANGED) {

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -44,10 +44,8 @@ void updateRasterOverlayBindings(const Context& context, const pxr::SdfPath& ras
 
     // Update tilesets that reference this raster overlay
     for (const auto& pTileset : tilesets) {
-        if (UsdUtil::primExists(context.getUsdStage(), pTileset->getPath())) {
-            if (CppUtil::contains(pTileset->getRasterOverlayPaths(), rasterOverlayPath)) {
-                pTileset->reload();
-            }
+        if (CppUtil::contains(pTileset->getRasterOverlayPaths(), rasterOverlayPath)) {
+            pTileset->reload();
         }
     }
 }
@@ -57,10 +55,8 @@ void updateRasterOverlayBindingsAlpha(const Context& context, const pxr::SdfPath
 
     // Update tilesets that reference this raster overlay
     for (const auto& pTileset : tilesets) {
-        if (UsdUtil::primExists(context.getUsdStage(), pTileset->getPath())) {
-            if (CppUtil::contains(pTileset->getRasterOverlayPaths(), rasterOverlayPath)) {
-                pTileset->updateRasterOverlayAlpha(rasterOverlayPath);
-            }
+        if (CppUtil::contains(pTileset->getRasterOverlayPaths(), rasterOverlayPath)) {
+            pTileset->updateRasterOverlayAlpha(rasterOverlayPath);
         }
     }
 }
@@ -69,18 +65,14 @@ void updateIonServerBindings(const Context& context) {
     // Update all tilesets. Some tilesets may have referenced this ion server implicitly.
     const auto& tilesets = context.getAssetRegistry().getTilesets();
     for (const auto& pTileset : tilesets) {
-        if (UsdUtil::primExists(context.getUsdStage(), pTileset->getPath())) {
-            pTileset->reload();
-        }
+        pTileset->reload();
     }
 
     // Update all raster overlays. Some raster overlays may have referenced this ion server implicitly.
     const auto& ionRasterOverlays = context.getAssetRegistry().getIonRasterOverlays();
     for (const auto& pIonRasterOverlay : ionRasterOverlays) {
-        if (UsdUtil::primExists(context.getUsdStage(), pIonRasterOverlay->getPath())) {
-            pIonRasterOverlay->reload();
-            updateRasterOverlayBindings(context, pIonRasterOverlay->getPath());
-        }
+        pIonRasterOverlay->reload();
+        updateRasterOverlayBindings(context, pIonRasterOverlay->getPath());
     }
 }
 
@@ -88,12 +80,10 @@ void updateCartographicPolygonBindings(const Context& context, const pxr::SdfPat
     // Update polygon raster overlays that reference this cartographic polygon
     const auto& polygonRasterOverlays = context.getAssetRegistry().getPolygonRasterOverlays();
     for (const auto& pPolygonRasterOverlay : polygonRasterOverlays) {
-        if (UsdUtil::primExists(context.getUsdStage(), pPolygonRasterOverlay->getPath())) {
-            const auto paths = pPolygonRasterOverlay->getCartographicPolygonPaths();
-            if (CppUtil::contains(paths, cartographicPolygonPath)) {
-                pPolygonRasterOverlay->reload();
-                updateRasterOverlayBindings(context, pPolygonRasterOverlay->getPath());
-            }
+        const auto paths = pPolygonRasterOverlay->getCartographicPolygonPaths();
+        if (CppUtil::contains(paths, cartographicPolygonPath)) {
+            pPolygonRasterOverlay->reload();
+            updateRasterOverlayBindings(context, pPolygonRasterOverlay->getPath());
         }
     }
 }
@@ -102,10 +92,8 @@ void updateGlobeAnchorBindings(const Context& context, const pxr::SdfPath& globe
     // Don't need to update tilesets. Globe anchor changes are handled automatically in the update loop.
 
     if (context.getAssetRegistry().getCartographicPolygon(globeAnchorPath)) {
-        if (UsdUtil::primExists(context.getUsdStage(), globeAnchorPath)) {
-            // Update cartographic polygon that this globe anchor is attached to
-            updateCartographicPolygonBindings(context, globeAnchorPath);
-        }
+        // Update cartographic polygon that this globe anchor is attached to
+        updateCartographicPolygonBindings(context, globeAnchorPath);
     }
 }
 
@@ -115,10 +103,8 @@ void updateGeoreferenceBindings(const Context& context) {
     // Update all globe anchors. Some globe anchors may have referenced this georeference implicitly.
     const auto& globeAnchors = context.getAssetRegistry().getGlobeAnchors();
     for (const auto& pGlobeAnchor : globeAnchors) {
-        if (UsdUtil::primExists(context.getUsdStage(), pGlobeAnchor->getPath())) {
-            pGlobeAnchor->updateByGeoreference();
-            updateGlobeAnchorBindings(context, pGlobeAnchor->getPath());
-        }
+        pGlobeAnchor->updateByGeoreference();
+        updateGlobeAnchorBindings(context, pGlobeAnchor->getPath());
     }
 }
 
@@ -448,6 +434,7 @@ void processCesiumWebMapServiceRasterOverlayChanged(
 }
 
 void processCesiumGeoreferenceChanged(const Context& context, const std::vector<pxr::TfToken>& properties) {
+
     auto updateBindings = false;
 
     // clang-format off
@@ -527,10 +514,6 @@ void processUsdShaderChanged(
     const pxr::SdfPath& shaderPath,
     const std::vector<pxr::TfToken>& properties) {
     const auto usdShader = UsdUtil::getUsdShader(context.getUsdStage(), shaderPath);
-    if (!UsdUtil::isSchemaValid(usdShader)) {
-        return;
-    }
-
     const auto shaderPathFabric = FabricUtil::toFabricPath(shaderPath);
     const auto materialPath = shaderPath.GetParentPath();
     const auto materialPathFabric = FabricUtil::toFabricPath(materialPath);
@@ -575,10 +558,8 @@ void processUsdShaderChanged(
 
         const auto& tilesets = context.getAssetRegistry().getTilesets();
         for (const auto& pTileset : tilesets) {
-            if (UsdUtil::primExists(context.getUsdStage(), pTileset->getPath())) {
-                if (pTileset->getMaterialPath() == materialPath) {
-                    pTileset->updateShaderInput(shaderPath, property);
-                }
+            if (pTileset->getMaterialPath() == materialPath) {
+                pTileset->updateShaderInput(shaderPath, property);
             }
         }
 
@@ -766,12 +747,6 @@ bool UsdNotificationHandler::processChangedPrims() {
     ChangedPrim* pPrevious = nullptr;
 
     for (const auto& changedPrim : _changedPrims) {
-        if (changedPrim.changedType == ChangedType::PROPERTY_CHANGED &&
-            !UsdUtil::primExists(_pContext->getUsdStage(), changedPrim.primPath)) {
-            // Don't process property changes if the prim is no longer on the stage
-            continue;
-        }
-
         if (pPrevious && changedPrim.primPath == pPrevious->primPath) {
             if (pPrevious->changedType == ChangedType::PRIM_ADDED &&
                 changedPrim.changedType == ChangedType::PROPERTY_CHANGED) {

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -527,6 +527,10 @@ void processUsdShaderChanged(
     const pxr::SdfPath& shaderPath,
     const std::vector<pxr::TfToken>& properties) {
     const auto usdShader = UsdUtil::getUsdShader(context.getUsdStage(), shaderPath);
+    if (!UsdUtil::isSchemaValid(usdShader)) {
+        return;
+    }
+
     const auto shaderPathFabric = FabricUtil::toFabricPath(shaderPath);
     const auto materialPath = shaderPath.GetParentPath();
     const auto materialPathFabric = FabricUtil::toFabricPath(materialPath);

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -152,12 +152,12 @@ pxr::GfMatrix4d glmToUsdMatrix(const glm::dmat4& matrix) {
 
 glm::dmat4 computePrimLocalToWorldTransform(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path) {
     const auto prim = pStage->GetPrimAtPath(path);
+    const auto xform = pxr::UsdGeomXformable(prim);
 
-    if (!prim.IsA<pxr::UsdGeomXformable>()) {
+    if (!isSchemaValid(xform)) {
         return glm::dmat4(1.0);
     }
 
-    const auto xform = pxr::UsdGeomXformable(prim);
     const auto time = pxr::UsdTimeCode::Default();
     const auto transform = xform.ComputeLocalToWorldTransform(time);
     return usdToGlmMatrix(transform);
@@ -245,15 +245,19 @@ bool primExists(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path) {
     return pStage->GetPrimAtPath(path).IsValid();
 }
 
+bool isSchemaValid(const pxr::UsdSchemaBase& schema) {
+    return schema.GetSchemaKind() != pxr::UsdSchemaKind::Invalid;
+}
+
 bool isPrimVisible(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path) {
     // This is similar to isPrimVisible in kit-sdk/dev/include/omni/usd/UsdUtils.h
     const auto prim = pStage->GetPrimAtPath(path);
+    const auto imageable = pxr::UsdGeomImageable(prim);
 
-    if (!prim.IsA<pxr::UsdGeomImageable>()) {
+    if (!isSchemaValid(imageable)) {
         return false;
     }
 
-    const auto imageable = pxr::UsdGeomImageable(prim);
     const auto time = pxr::UsdTimeCode::Default();
     const auto visibility = imageable.ComputeVisibility(time);
     return visibility != pxr::UsdGeomTokens->invisible;

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -246,7 +246,7 @@ bool primExists(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path) {
 }
 
 bool isSchemaValid(const pxr::UsdSchemaBase& schema) {
-    return schema.GetSchemaKind() != pxr::UsdSchemaKind::Invalid;
+    return schema.GetPrim().IsValid() && schema.GetSchemaKind() != pxr::UsdSchemaKind::Invalid;
 }
 
 bool isPrimVisible(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path) {


### PR DESCRIPTION
The following scenario would cause a crash:

* Receive notification that CesiumIonServer was removed
* Receive notification that CesiumIonRasterOverlay was removed

When prims are removed they update any assets that have a relationship to them. If the other assets had also been removed from the stage, during their update they may try to access properties on a USD prim that no longer exists.

I ended up making the fix in UsdNotificationHandler so that it checks whether prims exist before updating them.

I was able to trigger this by loading [imagery-single-2.zip](https://github.com/CesiumGS/cesium-omniverse/files/14251881/imagery-single-2.zip), hand deleting the raster overlay and rel from the .usda, and clicking the fetch changes button. This USD is a bit older and doesn't have an ion server in it, so the default ion server gets removed and the raster overlay gets removed.

