### PR TITLE
Allow globe anchors to work with `xformOp:orient`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 * Added support for Web Map Tile Service (WMTS) raster overlays.
 * Added raster overlay options: `maximumScreenSpaceError`, `maximumTextureSize`, `maximumSimultaneousTileLoads`, `subTileCacheBytes`.
 * Changed to use UrlAssetAccessor from vsgCs, which does a better job of managing libcurl handles than the existing HttpAssetAccessor.
+* Fixed a bug where globe anchors didn't work with `xformOp:orient`
 
 ### v0.17.0 - 2024-02-01
 

--- a/src/core/include/cesium/omniverse/MathUtil.h
+++ b/src/core/include/cesium/omniverse/MathUtil.h
@@ -41,10 +41,14 @@ glm::dmat4 composeEuler(
     const glm::dvec3& rotation,
     const glm::dvec3& scale,
     EulerAngleOrder eulerAngleOrder);
+
+glm::dmat4 compose(const glm::dvec3& translation, const glm::dquat& rotation, const glm::dvec3& scale);
+
 bool equal(const CesiumGeospatial::Cartographic& a, const CesiumGeospatial::Cartographic& b);
 bool epsilonEqual(const CesiumGeospatial::Cartographic& a, const CesiumGeospatial::Cartographic& b, double epsilon);
 bool epsilonEqual(const glm::dmat4& a, const glm::dmat4& b, double epsilon);
 bool epsilonEqual(const glm::dvec3& a, const glm::dvec3& b, double epsilon);
+bool epsilonEqual(const glm::dquat& a, const glm::dquat& b, double epsilon);
 
 glm::dvec3 getCorner(const std::array<glm::dvec3, 2>& extent, uint64_t index);
 

--- a/src/core/include/cesium/omniverse/OmniGlobeAnchor.h
+++ b/src/core/include/cesium/omniverse/OmniGlobeAnchor.h
@@ -2,6 +2,7 @@
 
 #include <CesiumGeospatial/Cartographic.h>
 #include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
 #include <pxr/usd/sdf/path.h>
 
 namespace CesiumGeospatial {
@@ -41,6 +42,7 @@ class OmniGlobeAnchor {
     [[nodiscard]] CesiumGeospatial::Cartographic getGeographicCoordinates() const;
     [[nodiscard]] glm::dvec3 getPrimLocalTranslation() const;
     [[nodiscard]] glm::dvec3 getPrimLocalRotation() const;
+    [[nodiscard]] glm::dquat getPrimLocalOrientation() const;
     [[nodiscard]] glm::dvec3 getPrimLocalScale() const;
 
     void savePrimLocalToEcefTranslation();
@@ -58,6 +60,7 @@ class OmniGlobeAnchor {
     CesiumGeospatial::Cartographic _cachedGeographicCoordinates{0.0, 0.0, 0.0};
     glm::dvec3 _cachedPrimLocalTranslation{0.0};
     glm::dvec3 _cachedPrimLocalRotation{0.0, 0.0, 0.0};
+    glm::dquat _cachedPrimLocalOrientation{1.0, 0.0, 0.0, 0.0};
     glm::dvec3 _cachedPrimLocalScale{1.0};
 };
 

--- a/src/core/include/cesium/omniverse/UsdTokens.h
+++ b/src/core/include/cesium/omniverse/UsdTokens.h
@@ -143,6 +143,7 @@ __pragma(warning(push)) __pragma(warning(disable : 4003))
     ((primvars_displayOpacity, "primvars:displayOpacity")) \
     ((primvars_normals, "primvars:normals")) \
     ((primvars_vertexId, "primvars:vertexId")) \
+    ((xformOp_orient, "xformOp:orient")) \
     ((xformOp_rotateXYZ, "xformOp:rotateXYZ")) \
     ((xformOp_rotateXZY, "xformOp:rotateXZY")) \
     ((xformOp_rotateYXZ, "xformOp:rotateYXZ")) \

--- a/src/core/include/cesium/omniverse/UsdUtil.h
+++ b/src/core/include/cesium/omniverse/UsdUtil.h
@@ -51,6 +51,8 @@ namespace cesium::omniverse::UsdUtil {
 glm::dvec3 usdToGlmVector(const pxr::GfVec3d& vector);
 glm::fvec3 usdToGlmVector(const pxr::GfVec3f& vector);
 glm::dmat4 usdToGlmMatrix(const pxr::GfMatrix4d& matrix);
+glm::dquat usdToGlmQuat(const pxr::GfQuatd& quat);
+glm::fquat usdToGlmQuat(const pxr::GfQuatf& quat);
 std::array<glm::dvec3, 2> usdToGlmExtent(const pxr::GfRange3d& extent);
 
 pxr::GfVec3d glmToUsdVector(const glm::dvec3& vector);
@@ -155,14 +157,16 @@ bool isUsdMaterial(const pxr::UsdStageWeakPtr& pStage, const pxr::SdfPath& path)
 
 glm::dvec3 getTranslate(const pxr::UsdGeomXformOp& translateOp);
 glm::dvec3 getRotate(const pxr::UsdGeomXformOp& rotateOp);
+glm::dquat getOrient(const pxr::UsdGeomXformOp& orientOp);
 glm::dvec3 getScale(const pxr::UsdGeomXformOp& scaleOp);
 void setTranslate(pxr::UsdGeomXformOp& translateOp, const glm::dvec3& translate);
 void setRotate(pxr::UsdGeomXformOp& rotateOp, const glm::dvec3& rotate);
+void setOrient(pxr::UsdGeomXformOp& orientOp, const glm::dquat& orient);
 void setScale(pxr::UsdGeomXformOp& scaleOp, const glm::dvec3& scale);
 
 struct TranslateRotateScaleOps {
     pxr::UsdGeomXformOp translateOp;
-    pxr::UsdGeomXformOp rotateOp;
+    pxr::UsdGeomXformOp rotateOrOrientOp;
     pxr::UsdGeomXformOp scaleOp;
     MathUtil::EulerAngleOrder eulerAngleOrder;
 };

--- a/src/core/src/FabricGeometry.cpp
+++ b/src/core/src/FabricGeometry.cpp
@@ -31,8 +31,8 @@ namespace {
 const auto DEFAULT_DOUBLE_SIDED = false;
 const auto DEFAULT_EXTENT = std::array<glm::dvec3, 2>{{glm::dvec3(0.0, 0.0, 0.0), glm::dvec3(0.0, 0.0, 0.0)}};
 const auto DEFAULT_POSITION = glm::dvec3(0.0, 0.0, 0.0);
-const auto DEFAULT_ORIENTATION = glm::dquat(1.0f, 0.0, 0.0, 0.0);
-const auto DEFAULT_SCALE = glm::dvec3(1.0f, 1.0f, 1.0f);
+const auto DEFAULT_ORIENTATION = glm::dquat(1.0, 0.0, 0.0, 0.0);
+const auto DEFAULT_SCALE = glm::dvec3(1.0, 1.0, 1.0);
 const auto DEFAULT_MATRIX = glm::dmat4(1.0);
 const auto DEFAULT_VISIBILITY = false;
 

--- a/src/core/src/MathUtil.cpp
+++ b/src/core/src/MathUtil.cpp
@@ -108,6 +108,14 @@ glm::dmat4 composeEuler(
     return translationMatrix * rotationMatrix * scaleMatrix;
 }
 
+glm::dmat4 compose(const glm::dvec3& translation, const glm::dquat& rotation, const glm::dvec3& scale) {
+    const auto translationMatrix = glm::translate(glm::dmat4(1.0), translation);
+    const auto rotationMatrix = glm::mat4_cast(rotation);
+    const auto scaleMatrix = glm::scale(glm::dmat4(1.0), scale);
+
+    return translationMatrix * rotationMatrix * scaleMatrix;
+}
+
 bool equal(const CesiumGeospatial::Cartographic& a, const CesiumGeospatial::Cartographic& b) {
     const auto& aVec = *reinterpret_cast<const glm::dvec3*>(&a);
     const auto& bVec = *reinterpret_cast<const glm::dvec3*>(&b);
@@ -126,6 +134,10 @@ bool epsilonEqual(const glm::dmat4& a, const glm::dmat4& b, double epsilon) {
 }
 
 bool epsilonEqual(const glm::dvec3& a, const glm::dvec3& b, double epsilon) {
+    return glm::all(glm::epsilonEqual(a, b, epsilon));
+}
+
+bool epsilonEqual(const glm::dquat& a, const glm::dquat& b, double epsilon) {
     return glm::all(glm::epsilonEqual(a, b, epsilon));
 }
 

--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -188,6 +188,7 @@ void processCesiumGlobeAnchorChanged(
              property == pxr::UsdTokens->xformOp_rotateYZX ||
              property == pxr::UsdTokens->xformOp_rotateZXY ||
              property == pxr::UsdTokens->xformOp_rotateZYX ||
+             property == pxr::UsdTokens->xformOp_orient ||
              property == pxr::UsdTokens->xformOp_scale)) {
             updateByPrimLocalTransform = true;
             updateBindings = true;

--- a/src/core/src/UsdUtil.cpp
+++ b/src/core/src/UsdUtil.cpp
@@ -96,6 +96,18 @@ glm::dmat4 usdToGlmMatrix(const pxr::GfMatrix4d& matrix) {
     };
 }
 
+glm::dquat usdToGlmQuat(const pxr::GfQuatd& quat) {
+    const auto real = quat.GetReal();
+    const auto imaginary = usdToGlmVector(quat.GetImaginary());
+    return {real, imaginary.x, imaginary.y, imaginary.z};
+}
+
+glm::fquat usdToGlmQuat(const pxr::GfQuatf& quat) {
+    const auto real = quat.GetReal();
+    const auto imaginary = usdToGlmVector(quat.GetImaginary());
+    return {real, imaginary.x, imaginary.y, imaginary.z};
+}
+
 std::array<glm::dvec3, 2> usdToGlmExtent(const pxr::GfRange3d& extent) {
     return {{usdToGlmVector(extent.GetMin()), usdToGlmVector(extent.GetMax())}};
 }
@@ -594,6 +606,20 @@ glm::dvec3 getRotate(const pxr::UsdGeomXformOp& rotateOp) {
     return glm::dvec3(0.0);
 }
 
+glm::dquat getOrient(const pxr::UsdGeomXformOp& orientOp) {
+    if (orientOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionDouble) {
+        pxr::GfQuatd orient;
+        orientOp.Get(&orient);
+        return UsdUtil::usdToGlmQuat(orient);
+    } else if (orientOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionFloat) {
+        pxr::GfQuatf orient;
+        orientOp.Get(&orient);
+        return glm::dquat(UsdUtil::usdToGlmQuat(orient));
+    }
+
+    return {1.0, 0.0, 0.0, 0.0};
+}
+
 glm::dvec3 getScale(const pxr::UsdGeomXformOp& scaleOp) {
     if (scaleOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionDouble) {
         pxr::GfVec3d scale;
@@ -624,6 +650,14 @@ void setRotate(pxr::UsdGeomXformOp& rotateOp, const glm::dvec3& rotate) {
     }
 }
 
+void setOrient(pxr::UsdGeomXformOp& orientOp, const glm::dquat& orient) {
+    if (orientOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionDouble) {
+        orientOp.Set(UsdUtil::glmToUsdQuat(orient));
+    } else if (orientOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionFloat) {
+        orientOp.Set(UsdUtil::glmToUsdQuat(glm::fquat(orient)));
+    }
+}
+
 void setScale(pxr::UsdGeomXformOp& scaleOp, const glm::dvec3& scale) {
     if (scaleOp.GetPrecision() == pxr::UsdGeomXformOp::PrecisionDouble) {
         scaleOp.Set(UsdUtil::glmToUsdVector(scale));
@@ -635,10 +669,12 @@ void setScale(pxr::UsdGeomXformOp& scaleOp, const glm::dvec3& scale) {
 std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const pxr::UsdGeomXformable& xformable) {
     pxr::UsdGeomXformOp translateOp;
     pxr::UsdGeomXformOp rotateOp;
+    pxr::UsdGeomXformOp orientOp;
     pxr::UsdGeomXformOp scaleOp;
 
     int64_t translateOpIndex = -1;
     int64_t rotateOpIndex = -1;
+    int64_t orientOpIndex = -1;
     int64_t scaleOpIndex = -1;
 
     int64_t opCount = 0;
@@ -698,6 +734,12 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
                     rotateOpIndex = opCount;
                 }
                 break;
+            case pxr::UsdGeomXformOp::TypeOrient:
+                if (orientOpIndex == -1) {
+                    orientOp = xformOp;
+                    orientOpIndex = opCount;
+                }
+                break;
             case pxr::UsdGeomXformOp::TypeScale:
                 if (scaleOpIndex == -1) {
                     scaleOp = xformOp;
@@ -713,7 +755,12 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
 
     const auto translateOpDefined = translateOp.IsDefined();
     const auto rotateOpDefined = rotateOp.IsDefined();
+    const auto orientOpDefined = orientOp.IsDefined();
     const auto scaleOpDefined = scaleOp.IsDefined();
+
+    if (rotateOpDefined && orientOpDefined) {
+        return std::nullopt;
+    }
 
     opCount = 0;
 
@@ -722,6 +769,10 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
     }
 
     if (rotateOpDefined && rotateOpIndex != opCount++) {
+        return std::nullopt;
+    }
+
+    if (orientOpDefined && orientOpIndex != opCount++) {
         return std::nullopt;
     }
 
@@ -741,6 +792,10 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
         return std::nullopt;
     }
 
+    if (orientOpDefined && !isPrecisionSupported(orientOp.GetPrecision())) {
+        return std::nullopt;
+    }
+
     if (scaleOpDefined && !isPrecisionSupported(scaleOp.GetPrecision())) {
         return std::nullopt;
     }
@@ -750,7 +805,7 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
         translateOp.Set(UsdUtil::glmToUsdVector(glm::dvec3(0.0)));
     }
 
-    if (!rotateOpDefined) {
+    if (!rotateOpDefined && !orientOpDefined) {
         rotateOp = xformable.AddRotateXYZOp(pxr::UsdGeomXformOp::PrecisionDouble);
         rotateOp.Set(UsdUtil::glmToUsdVector(glm::dvec3(0.0)));
     }
@@ -760,11 +815,22 @@ std::optional<TranslateRotateScaleOps> getOrCreateTranslateRotateScaleOps(const 
         scaleOp.Set(UsdUtil::glmToUsdVector(glm::dvec3(1.0)));
     }
 
-    if (!translateOpDefined || !rotateOpDefined || !scaleOpDefined) {
-        std::vector<pxr::UsdGeomXformOp> reorderedXformOps = {translateOp, rotateOp, scaleOp};
+    if (!translateOpDefined || (!rotateOpDefined && !orientOpDefined) || !scaleOpDefined) {
+        std::vector<pxr::UsdGeomXformOp> reorderedXformOps;
+
+        if (orientOpDefined) {
+            reorderedXformOps = {translateOp, orientOp, scaleOp};
+        } else {
+            reorderedXformOps = {translateOp, rotateOp, scaleOp};
+        }
+
         // Add back additional xform ops like xformOp:rotateX:unitsResolve
         reorderedXformOps.insert(reorderedXformOps.end(), xformOps.begin() + opCount, xformOps.end());
         xformable.SetXformOpOrder(reorderedXformOps);
+    }
+
+    if (orientOpDefined) {
+        return TranslateRotateScaleOps{translateOp, orientOp, scaleOp, eulerAngleOrder};
     }
 
     return TranslateRotateScaleOps{translateOp, rotateOp, scaleOp, eulerAngleOrder};


### PR DESCRIPTION
This issue was brought up in a [community forum post](https://community.cesium.com/t/globe-anchor-doesnt-detect-transform-changes-if-prim-has-xformop-orient-instead-of-xformop-rotation/30086).

Globe anchors are now compatible `xformOp:orient`. Previously it only worked for `xformOp:rotate` variants.

https://github.com/CesiumGS/cesium-omniverse/assets/915398/0ded9c1b-59df-4384-aca7-8508757c82db

[orientation.zip](https://github.com/CesiumGS/cesium-omniverse/files/14376874/orientation.zip)