### PR TITLE
Revert to using our own SSL certificate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,12 +122,13 @@ jobs:
       # hardcoding their locations instead. Followed these instructions for adding to the PATH on PowerShell:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
       # Note that this is only a problem on CI, not with local builds
+      # Also requests is not installed by default on windows, but is expected by scripts/update_certs.py
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
         run: |
           choco install -y conan --version 1.60.0
           choco install -y llvm --version=15.0.7 --allow-downgrade
-          pip3 install black==23.1.0 flake8==6.0.0
+          pip3 install black==23.1.0 flake8==6.0.0 requests
           echo "C:/Program Files/conan/conan" >> $env:GITHUB_PATH
 
       # Note: CMAKE_BUILD_TYPE is only used by Linux. It is ignored for Windows.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,7 @@ configure_file("${PROJECT_SOURCE_DIR}/src/plugins/CesiumUsdSchemas/generatedSche
                "${PROJECT_BINARY_DIR}/CesiumUsdSchemas.generatedSchema.usda.kit")
 
 set(KIT_EXTENSION_BIN_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.omniverse/bin")
+set(KIT_EXTENSION_CERTS_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.omniverse/certs/cacert.pem")
 set(KIT_PLUGIN_EXTENSION_BIN_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.usd.plugins/bin")
 set(KIT_EXTENSION_BINDINGS_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.omniverse/cesium/omniverse/bindings")
 set(KIT_PLUGIN_EXTENSION_BINDINGS_PATH "${PROJECT_SOURCE_DIR}/exts/cesium.usd.plugins/cesium/usd/plugins")
@@ -532,6 +533,9 @@ set(KIT_EXTENSION_TESTS_BINDINGS_PATH
 # This path doesn't exist, so in order to find python we need to explicility add it
 # to the search path. Unfortunately CMake will print a warning when python .so is
 # found this way.
+
+# Automatically fetch certificates used for any requests from the core Context class
+execute_process(COMMAND "${Python3_EXECUTABLE}" "${SCRIPTS_DIRECTORY}/update_certs.py" "${KIT_EXTENSION_CERTS_PATH}")
 
 get_property(INSTALL_SEARCH_PATHS GLOBAL PROPERTY NVIDIA_ADDITIONAL_SEARCH_PATHS_PROPERTY)
 

--- a/docs/developer-setup/README.md
+++ b/docs/developer-setup/README.md
@@ -117,6 +117,10 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
     cd <first_path_in_list>
     mklink python3.exe python.exe
     ```
+- Install `requests` module for Python
+  ```sh
+  pip3 install requests
+  ```
 - Install `cmake-format`
   ```sh
   pip3 install cmake-format
@@ -166,6 +170,10 @@ There are two ways to install prerequisites for Windows, [manually](#install-man
   where python
   cd <first_path_in_list>
   mklink python3.exe python.exe
+  ```
+- Install `requests`
+  ```sh
+  pip3 install requests
   ```
 - Install `cmake-format`
   ```sh

--- a/scripts/update_certs.py
+++ b/scripts/update_certs.py
@@ -1,0 +1,44 @@
+#! /usr/bin/python3
+
+"""
+Intended to be called in the
+This script updates the certificates used for any requests that use the core
+Context class. While some certs are available on the system, they may not be
+consistent or updated. This ensures all certs are uniform and up to date
+see: https://github.com/CesiumGS/cesium-omniverse/issues/306
+"""
+
+import requests
+import sys
+import os
+
+
+def main():
+    # --- establish source/destination for certs ---
+    if len(sys.argv) < 2:
+        print("must provide a filepath for the updated certs")
+        return -1
+
+    CERT_URL = "https://curl.se/ca/cacert.pem"
+    CERT_FILE_PATH = sys.argv[1]
+
+    # --- ensure directory structure exists ----
+    os.makedirs(os.path.dirname(CERT_FILE_PATH), exist_ok=True)
+
+    # --- fetch and write the cert file ----
+
+    req = requests.get(CERT_URL)
+
+    if req.status_code != 200:
+        print(f"failed to fetch certificates from {CERT_URL}")
+        return -1
+
+    # explicit encoding is required for windows
+    with open(CERT_FILE_PATH, "w", encoding="utf-8") as f:
+        f.write(req.text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/include/cesium/omniverse/Context.h
+++ b/src/core/include/cesium/omniverse/Context.h
@@ -43,6 +43,7 @@ class Context {
     Context& operator=(Context&&) noexcept = delete;
 
     [[nodiscard]] const std::filesystem::path& getCesiumExtensionLocation() const;
+    [[nodiscard]] const std::filesystem::path& getCertificatePath() const;
     [[nodiscard]] const pxr::TfToken& getCesiumMdlPathToken() const;
 
     [[nodiscard]] std::shared_ptr<TaskProcessor> getTaskProcessor() const;
@@ -76,6 +77,7 @@ class Context {
 
   private:
     std::filesystem::path _cesiumExtensionLocation;
+    std::filesystem::path _certificatePath;
     pxr::TfToken _cesiumMdlPathToken;
 
     std::shared_ptr<TaskProcessor> _pTaskProcessor;

--- a/src/core/src/Context.cpp
+++ b/src/core/src/Context.cpp
@@ -69,6 +69,7 @@ uint64_t getSecondsSinceEpoch() {
 
 Context::Context(const std::filesystem::path& cesiumExtensionLocation)
     : _cesiumExtensionLocation(cesiumExtensionLocation.lexically_normal())
+    , _certificatePath(_cesiumExtensionLocation / "certs" / "cacert.pem")
     , _cesiumMdlPathToken(pxr::TfToken((_cesiumExtensionLocation / "mdl" / "cesium.mdl").generic_string()))
     , _pTaskProcessor(std::make_shared<TaskProcessor>())
     , _pAsyncSystem(std::make_unique<CesiumAsync::AsyncSystem>(_pTaskProcessor))
@@ -82,10 +83,10 @@ Context::Context(const std::filesystem::path& cesiumExtensionLocation)
     , _contextId(static_cast<int64_t>(getSecondsSinceEpoch())) {
     if (_pCacheDatabase) {
         _pAssetAccessor = std::make_shared<CesiumAsync::CachingAssetAccessor>(
-            _pLogger, std::make_shared<UrlAssetAccessor>(), _pCacheDatabase);
+            _pLogger, std::make_shared<UrlAssetAccessor>(_certificatePath), _pCacheDatabase);
 
     } else {
-        _pAssetAccessor = std::make_shared<UrlAssetAccessor>();
+        _pAssetAccessor = std::make_shared<UrlAssetAccessor>(_certificatePath);
     }
     Cesium3DTilesContent::registerAllTileContentTypes();
 
@@ -105,6 +106,10 @@ Context::~Context() {
 
 const std::filesystem::path& Context::getCesiumExtensionLocation() const {
     return _cesiumExtensionLocation;
+}
+
+const std::filesystem::path& Context::getCertificatePath() const {
+    return _certificatePath;
 }
 
 const pxr::TfToken& Context::getCesiumMdlPathToken() const {

--- a/src/core/src/UrlAssetAccessor.cpp
+++ b/src/core/src/UrlAssetAccessor.cpp
@@ -185,8 +185,9 @@ UrlAssetAccessor::setCommonOptions(CURL* curl, const std::string& url, const Ces
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     if (!_certificatePath.empty()) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, _certificatePath.c_str());
+    } else {
+        curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
     }
-    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
     curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
     curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, CURL_BUFFERSIZE);
     curl_easy_setopt(curl, CURLOPT_MAXCONNECTS, 20L);


### PR DESCRIPTION
The certificates do not live in the same directory in different Linux distributions, one of the many reasons why it's not portable to rely on the system's installed certificates. Addresses #695 .