### PR TITLE
Allow token-less tilesets to load

### DIFF
--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -570,7 +570,7 @@ void OmniTileset::reload() {
 
     switch (sourceType) {
         case TilesetSourceType::ION:
-            if (ionAssetId <= 0 || ionAccessToken.token.empty() || ionApiUrl.empty()) {
+            if (ionAssetId <= 0 || ionApiUrl.empty()) {
                 _pTileset = std::make_unique<Cesium3DTilesSelection::Tileset>(externals, 0, "", options);
             } else {
                 _pTileset = std::make_unique<Cesium3DTilesSelection::Tileset>(


### PR DESCRIPTION
This PR removes the check for an empty token when configuring a tileset.

This check was preventing some tilesets from loading in scenarios such as using Cesium ion Self-Hosted in developer mode, which does not use Oauth, and a token is not provided.  #702 

I'm not 100% sure if there was anything more to the original if statement other than being a sanity check that all values were valid, but @lilleyse please let me know if there is something more to it and we'll work out another approach if needed.

I've tested this with both Self-Hosted and ion content and it appears to be working fine.