### PR TITLE
Add scrollbar to Main UI and Powertools UI

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -234,7 +234,9 @@ class CesiumOmniverseMainWindow(ui.Window):
             with ui.ScrollingFrame():
                 with ui.VStack(spacing=0):
                     self._quick_add_widget = CesiumOmniverseQuickAddWidget(self._cesium_omniverse_interface)
-                    self._sign_in_widget = CesiumOmniverseSignInWidget(self._cesium_omniverse_interface, visible=False)
+                    self._sign_in_widget = CesiumOmniverseSignInWidget(
+                        self._cesium_omniverse_interface, visible=False
+                    )
 
     def _add_button_clicked(self) -> None:
         if not self._add_button or not self._add_button.enabled:

--- a/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/main_window.py
@@ -231,8 +231,10 @@ class CesiumOmniverseMainWindow(ui.Window):
                     clicked_fn=self._sign_out_button_clicked,
                     enabled=False,
                 )
-            self._quick_add_widget = CesiumOmniverseQuickAddWidget(self._cesium_omniverse_interface)
-            self._sign_in_widget = CesiumOmniverseSignInWidget(self._cesium_omniverse_interface, visible=False)
+            with ui.ScrollingFrame():
+                with ui.VStack(spacing=0):
+                    self._quick_add_widget = CesiumOmniverseQuickAddWidget(self._cesium_omniverse_interface)
+                    self._sign_in_widget = CesiumOmniverseSignInWidget(self._cesium_omniverse_interface, visible=False)
 
     def _add_button_clicked(self) -> None:
         if not self._add_button or not self._add_button.enabled:

--- a/exts/cesium.powertools/cesium/powertools/powertools_window.py
+++ b/exts/cesium.powertools/cesium/powertools/powertools_window.py
@@ -65,6 +65,7 @@ class CesiumPowertoolsWindow(ui.Window):
         super().destroy()
 
     def _build_fn(self):
-        with ui.VStack(spacing=4):
-            for action in self._actions:
-                action.button()
+        with ui.ScrollingFrame():
+            with ui.VStack(spacing=4):
+                for action in self._actions:
+                    action.button()


### PR DESCRIPTION
This resolves #705 by adding a vertical scrollbar to the main window and also powertools window.

Similar to Cesium for Unreal, I've made only the UI below the main button scrollable

![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/eb7d1ae2-9c9c-421e-b82f-5248b512e396)

Due to the way `ui.ScrollingFrame()` works by default, there will be a small gap present when the scrollbar isn't visible, as opposed to the contents responsively resizing to fill the whole window.  

![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/844b2a3f-f46e-4b14-ba54-fefe7e825ed1)

This appears to be common behaviour across Omniverse UI, so I'm not too concerned about this.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/3e448b03-54c8-410d-aa99-a1ea34503eb0)