### PR TITLE
Fix missing button for adding imagery from Asset UI

### DIFF
--- a/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
+++ b/exts/cesium.omniverse/cesium/omniverse/ui/asset_details_widget.py
@@ -76,7 +76,7 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
         selection = context.get_selection().get_selected_prim_paths()
         tileset_path: Optional[str] = None
 
-        if len(selection) > 0 and is_tileset(context.get_stage().GetPrimAtPath(selection[0])):
+        if len(selection) > 0 and is_tileset(selection[0]):
             tileset_path = selection[0]
 
         if tileset_path is None:
@@ -122,7 +122,7 @@ class CesiumAssetDetailsWidget(ui.ScrollingFrame):
                                 style=CesiumOmniverseUiStyles.blue_button_style,
                                 clicked_fn=self._add_tileset_button_clicked,
                             )
-                        elif self._asset_type == "RASTER_OVERLAY":
+                        elif self._asset_type == "IMAGERY":
                             ui.Button(
                                 "Use as Terrain Tileset Base Layer",
                                 width=0,


### PR DESCRIPTION
Closes #701

The Use as Terrain Tileset Base Layer button was missing from the assets UI when selecting an imagery asset to add

Two issues were present

Firstly, the `self._asset_type` needed to be checking for `IMAGERY` when checking if the button should be created in `asset_details_widget.py`

Secondly, `is_tileset `was being passed a prim instead of a prim path, which caused the function to fail

The button is now visible, and successfully adds to either the first tileset found in the selection, the first tileset in the stage if no selection is present, or creates a new Cesium World Terrain tileset if no tilesets are found.

![image](https://github.com/CesiumGS/cesium-omniverse/assets/123468416/ad715553-ae61-49b8-9170-cd23e51f9c6c)
