### PR TITLE
Fix point cloud styling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### v0.21.0 - 2024-06-03
 
+* Fixed point cloud styling.
 * Added read-only attribute `ecefToUsdTransform` to `CesiumGeoreferencePrim`. Previously this was stored in `/CesiumSession` which has since been removed.
 * Fixed crash when updating globe anchor when georeferencing is disabled.
 

--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -395,8 +395,9 @@ float4 finalize_float4(float4 raw_value, bool has_no_data, float4 no_data, float
 
 int2 get_property_table_pixel_index(int feature_id, uniform texture_2d property_table_texture) {
     auto width = tex::width(property_table_texture);
+    auto height = tex::height(property_table_texture);
     auto pixel_x = feature_id % width;
-    auto pixel_y = feature_id / width;
+    auto pixel_y = height - 1 - feature_id / width;
     return int2(pixel_x, pixel_y);
 }
 


### PR DESCRIPTION
Property table values were being read incorrectly in `cesium.mdl`. The code was treating (0, 0) as the bottom left pixel instead of the top left pixel. This affected property tables with more than 4096 elements; anything less than would would fit in a single row of the texture and not hit this bug. That's why most datasets worked except point clouds.

Before:

<img width="1120" alt="image" src="https://github.com/CesiumGS/cesium-omniverse/assets/915398/39d6bb5e-d66c-40dd-b738-3a8eaa8239bf">

After:

<img width="1122" alt="image" src="https://github.com/CesiumGS/cesium-omniverse/assets/915398/a4a7f331-71f6-4321-83e9-898afcf34c6e">

Test data: [montreal.zip](https://github.com/CesiumGS/cesium-omniverse/files/15300354/montreal.zip)