### PR TITLE
Pass custom ellipsoid to tileset and raster overlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### v0.23.0 - 2024-10-01
+
+* Fixed bug where tilesets and raster overlays were not being passed the correct custom ellipsoid.
+
 ### v0.22.0 - 2024-09-03
 
 * Cesium for Omniverse now supports using non-WGS84 ellipsoids.

--- a/src/core/include/cesium/omniverse/OmniRasterOverlay.h
+++ b/src/core/include/cesium/omniverse/OmniRasterOverlay.h
@@ -48,6 +48,7 @@ class OmniRasterOverlay {
     pxr::SdfPath _path;
 
   private:
+    [[nodiscard]] const CesiumGeospatial::Ellipsoid* getEllipsoid() const;
     void setRasterOverlayOptionsFromUsd(CesiumRasterOverlays::RasterOverlayOptions& options) const;
 };
 } // namespace cesium::omniverse

--- a/src/core/include/cesium/omniverse/OmniTileset.h
+++ b/src/core/include/cesium/omniverse/OmniTileset.h
@@ -17,6 +17,10 @@ namespace CesiumRasterOverlays {
 class RasterOverlay;
 }
 
+namespace CesiumGeospatial {
+class Ellipsoid;
+}
+
 namespace CesiumGltf {
 struct Model;
 }
@@ -50,6 +54,7 @@ class OmniTileset {
     [[nodiscard]] const pxr::SdfPath& getPath() const;
     [[nodiscard]] int64_t getTilesetId() const;
     [[nodiscard]] TilesetStatistics getStatistics() const;
+    [[nodiscard]] const CesiumGeospatial::Ellipsoid* getEllipsoid() const;
 
     [[nodiscard]] TilesetSourceType getSourceType() const;
     [[nodiscard]] std::string getUrl() const;

--- a/src/core/src/OmniTileset.cpp
+++ b/src/core/src/OmniTileset.cpp
@@ -31,6 +31,7 @@
 #include <Cesium3DTilesSelection/Tileset.h>
 #include <Cesium3DTilesSelection/ViewState.h>
 #include <Cesium3DTilesSelection/ViewUpdateResult.h>
+#include <CesiumGeospatial/Ellipsoid.h>
 #include <CesiumUsdSchemas/rasterOverlay.h>
 #include <CesiumUsdSchemas/tileset.h>
 #include <pxr/usd/usd/prim.h>
@@ -104,6 +105,20 @@ TilesetStatistics OmniTileset::getStatistics() const {
     }
 
     return statistics;
+}
+
+const CesiumGeospatial::Ellipsoid* OmniTileset::getEllipsoid() const {
+    const auto georeferencePath = getResolvedGeoreferencePath();
+    if (georeferencePath.IsEmpty()) {
+        return nullptr;
+    }
+
+    const auto pGeoreference = _pContext->getAssetRegistry().getGeoreference(georeferencePath);
+    if (!pGeoreference) {
+        return nullptr;
+    }
+
+    return &pGeoreference->getEllipsoid();
 }
 
 TilesetSourceType OmniTileset::getSourceType() const {
@@ -549,6 +564,12 @@ void OmniTileset::reload() {
     options.culledScreenSpaceError = getCulledScreenSpaceError();
     options.mainThreadLoadingTimeLimit = getMainThreadLoadingTimeLimit();
     options.showCreditsOnScreen = getShowCreditsOnScreen();
+
+    const auto pEllipsoid = getEllipsoid();
+
+    if (pEllipsoid) {
+        options.ellipsoid = *pEllipsoid;
+    }
 
     options.loadErrorCallback =
         [this, tilesetPath, ionAssetId, name](const Cesium3DTilesSelection::TilesetLoadFailureDetails& error) {


### PR DESCRIPTION
Follow up to #722.

Passes the custom ellipsoid to `TilesetOptions` and `RasterOverlayOptions`. This fixes tilesets with `region` bounding volumes that use custom ellipsoids. I don't think this has any affect on Cesium Moon Terrain since it uses `box`, but it's a good fix nonetheless.