### PR TITLE
Reload tileset if georeference binding changes

### DIFF
--- a/src/core/src/UsdNotificationHandler.cpp
+++ b/src/core/src/UsdNotificationHandler.cpp
@@ -295,7 +295,6 @@ void processCesiumTilesetChanged(
 
     // No change tracking needed for
     // * suspendUpdate
-    // * georeferenceBinding
     // * Transform changes (handled automatically in update loop)
 
     // clang-format off
@@ -309,6 +308,7 @@ void processCesiumTilesetChanged(
             property == pxr::CesiumTokens->cesiumShowCreditsOnScreen ||
             property == pxr::CesiumTokens->cesiumRasterOverlayBinding ||
             property == pxr::CesiumTokens->cesiumPointSize ||
+            property == pxr::CesiumTokens->cesiumGeoreferenceBinding ||
             property == pxr::UsdTokens->material_binding) {
             reload = true;
         } else if (


### PR DESCRIPTION
One thing I missed in https://github.com/CesiumGS/cesium-omniverse/pull/732 is to reload the tileset if its georeference binding changes (which implies the ellipsoid may have changed, which requires a tileset reload)

No need to update `CHANGES.md`, falls under the existing mention of ellipsoid fixes.