### PR TITLE
Fixed rendering base color textures that contain an alpha channel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### v0.23.0 - 2024-10-01
 
 * Fixed bug where tilesets and raster overlays were not being passed the correct custom ellipsoid.
+* Fixed rendering base color textures that contain an alpha channel.
 
 ### v0.22.0 - 2024-09-03
 

--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -53,6 +53,7 @@ float4 alpha_blend(float4 src, float4 dst) {
 float4 compute_base_color(
     color base_color_factor,
     float base_alpha,
+    bool has_base_color_texture,
     float4 base_color_texture,
     float4 raster_overlay,
     float4 tile_color,
@@ -61,10 +62,17 @@ float4 compute_base_color(
     if (alpha_clip > 0.5) return float4(0.0);
 
     auto base_color_factor_float3 = float3(base_color_factor);
+    auto base_color_factor_float4 = float4(base_color_factor_float3.x, base_color_factor_float3.y, base_color_factor_float3.z, base_alpha);
 
-    auto base_color = float4(1.0);
-    base_color = alpha_blend(base_color_texture, base_color);
-    base_color *= float4(base_color_factor_float3.x, base_color_factor_float3.y, base_color_factor_float3.z, base_alpha);
+    float4 base_color;
+
+    if (has_base_color_texture) {
+        base_color = base_color_texture;
+        base_color *= base_color_factor_float4;
+    } else {
+        base_color = base_color_factor_float4;
+    }
+
     base_color *= scene::data_lookup_float4("COLOR_0", float4(1.0));
     base_color = alpha_blend(raster_overlay, base_color);
     base_color *= tile_color;
@@ -1536,7 +1544,8 @@ export material cesium_internal_material(
     auto base_color = compute_base_color(
         base_color_factor,
         base_alpha,
-        base_color_texture.valid ? base_color_texture.value : float4(0.0),
+        base_color_texture.valid,
+        base_color_texture.value,
         raster_overlay.valid ? raster_overlay.value : float4(0.0),
         tile_color,
         alpha_clip.valid ? alpha_clip.value.x : 0.0


### PR DESCRIPTION
Removed the underlying white color in cesium.mdl.

Before | After
--|--
<img width="716" alt="before" src="https://github.com/user-attachments/assets/c182ef26-0e19-4523-9d9b-fe1c50b42a98">|<img width="711" alt="after" src="https://github.com/user-attachments/assets/7ae221da-ea98-41b1-9a45-db32fc480b77">
