### PR TITLE
Fix smooth normals crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### v0.24.0 - 2024-11-01
+
+* Fixed bug where smooth normals setting would crash.
+
 ### v0.23.0 - 2024-10-01
 
 * Fixed bug where tilesets and raster overlays were not being passed the correct custom ellipsoid.

--- a/src/core/src/FabricVertexAttributeAccessors.cpp
+++ b/src/core/src/FabricVertexAttributeAccessors.cpp
@@ -163,8 +163,8 @@ NormalsAccessor NormalsAccessor::GenerateSmooth(const PositionsAccessor& positio
     }
 
     auto accessor = NormalsAccessor();
+    accessor._size = normals.size();
     accessor._computed = std::move(normals);
-    accessor._size = indices.size();
     return accessor;
 }
 


### PR DESCRIPTION
The latest `moon.usda` from https://github.com/CesiumGS/cesium-omniverse-samples/pull/18 was crashing on windows because of out-of-bounds reads.

Ended up being a pretty clear cut bug in `NormalsAccessor::GenerateSmooth`.