### PR TITLE
Add missing folders to premake5.lua

### DIFF
--- a/exts/cesium.omniverse/premake5.lua
+++ b/exts/cesium.omniverse/premake5.lua
@@ -8,3 +8,5 @@ repo_build.prebuild_link { "certs", ext.target_dir.."/certs" }
 repo_build.prebuild_link { "cesium", ext.target_dir.."/cesium" }
 repo_build.prebuild_link { "doc", ext.target_dir.."/doc" }
 repo_build.prebuild_link { "images", ext.target_dir.."/images" }
+repo_build.prebuild_link { "mdl", ext.target_dir.."/mdl" }
+repo_build.prebuild_link { "vendor", ext.target_dir.."/vendor" }


### PR DESCRIPTION
Both `mdl` and `vendor` folders were missing from `premake5.lua`, resulting in those folders being excluded from symlinking during OV app build process such as those found in [kit-app-template](https://github.com/NVIDIA-Omniverse/kit-app-template/tree/main).