### PR TITLE
Fix polygon clipping rendering black when host ignores glTF mask cutout

### DIFF
--- a/exts/cesium.omniverse/mdl/cesium.mdl
+++ b/exts/cesium.omniverse/mdl/cesium.mdl
@@ -1541,6 +1541,7 @@ export material cesium_internal_material(
     gltf_texture_lookup_value raster_overlay = gltf_texture_lookup_value(),
     gltf_texture_lookup_value alpha_clip = gltf_texture_lookup_value()
 ) [[ anno::hidden() ]] = let {
+    float alpha_clip_value = alpha_clip.valid ? alpha_clip.value.x : 0.0;
     auto base_color = compute_base_color(
         base_color_factor,
         base_alpha,
@@ -1548,7 +1549,7 @@ export material cesium_internal_material(
         base_color_texture.value,
         raster_overlay.valid ? raster_overlay.value : float4(0.0),
         tile_color,
-        alpha_clip.valid ? alpha_clip.value.x : 0.0
+        alpha_clip_value
     );
     material base = gltf_material(
         base_color_texture: gltf_texture_lookup_value(true, base_color),
@@ -1564,7 +1565,14 @@ export material cesium_internal_material(
     surface: base.surface,
     volume: base.volume,
     ior: base.ior,
-    geometry: base.geometry
+    // Kit 110 / Isaac Sim RTX does not honor the gltf mask cutout for clipped
+    // tiles (clipped fragments render opaque black instead of being discarded).
+    // Force a hard geometry cutout so clipped fragments are reliably removed.
+    geometry: material_geometry(
+        displacement: base.geometry.displacement,
+        cutout_opacity: alpha_clip_value > 0.5 ? 0.0 : base.geometry.cutout_opacity,
+        normal: base.geometry.normal
+    )
 );
 
 export gltf_texture_lookup_value cesium_internal_raster_overlay_resolver(


### PR DESCRIPTION
Fixes #777.

### Problem
Polygon clipping (`CesiumPolygonRasterOverlay` with `overlayRenderMethod = "clip"`) renders the clipped tile geometry as **opaque black** instead of discarding it, on RTX setups where the host's `gltf_material` does not honor the glTF `mask` cutout. Observed on **Cesium for Omniverse v0.28.0 / Isaac Sim 5.1** (Windows). Full triage in #777.

### Why
`compute_base_color()` returns `float4(0.0)` for clipped texels and `FabricMaterial` sets the material to glTF `MASK` mode, delegating the discard to the host's `::gltf::pbr::gltf_material` (`alpha_mode = mask` → `geometry.cutout_opacity`). When the host doesn't translate `mask` into a working cutout under RTX, the transparent-black fragment is shaded as opaque → black tile (and it keeps depth, so it z-fights).

### Fix
Drive `geometry.cutout_opacity` **directly** for clipped fragments in `cesium_internal_material`, instead of relying on the host's `gltf_material` mask wiring:

```mdl
} in material(
    ...
    geometry: material_geometry(
        displacement:   base.geometry.displacement,
        cutout_opacity: alpha_clip_value > 0.5 ? 0.0 : base.geometry.cutout_opacity,
        normal:         base.geometry.normal
    )
);
```

`cutout_opacity` is a geometry-level (pre-BSDF) property honored independently of `alpha_mode`, so clipped fragments are reliably discarded (no color, no depth, no z-fight). It's a no-op where the gltf `mask` path already works, and keeps tiles fully opaque elsewhere.

### Testing
The bug was reproduced on the released **v0.28.0** (Isaac Sim 5.1, Windows, RTX). The fix was verified in a **local build of Cesium for Omniverse with this change applied** — clipped tiles now form a clean transparent cutout. Before/after captures in #777.
